### PR TITLE
Record product valuation history

### DIFF
--- a/stock_valuation_history/__init__.py
+++ b/stock_valuation_history/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2013 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import stock_valuation_history
+from . import product
+from . import wizard

--- a/stock_valuation_history/__openerp__.py
+++ b/stock_valuation_history/__openerp__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2013 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Stock valuation history",
+    "version": "2.0",
+    "depends": ["stock"],
+    "author": u"Numérigraphe",
+    "category": "Pricing",
+    "description": """
+Record Stock Valuation
+======================
+* Adds a wizard to record the current Stock Valuation of a location (with
+  sub-locations)
+* Adds an API to record the Stock Valuation by Product ID or by search domain.
+  The location, warehouse or shop can be set in the context.
+* Proposes a scheduled task to record the valuation once a week.
+
+This module was previously named 'stock_valuation_history' in OpenERP v6.0.
+""",
+    "init_xml": [
+        "stock_valuation_history_data.xml",
+    ],
+    "data": [
+        "stock_valuation_history_view.xml",
+        "wizard/compute_stock_valuation_wizard_view.xml",
+        "security/ir.model.access.csv",
+    ],
+    "test": [
+        "stock_valuation_history_test.yml",
+    ],
+    "demo": [
+        "stock_valuation_history_demo.xml"
+    ]
+}

--- a/stock_valuation_history/i18n/fr.po
+++ b/stock_valuation_history/i18n/fr.po
@@ -1,0 +1,177 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* stock_valuation_history
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 6.0.4\n"
+"Report-Msgid-Bugs-To: support@openerp.com\n"
+"POT-Creation-Date: 2014-01-17 10:16+0000\n"
+"PO-Revision-Date: 2014-01-17 10:16+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_valuation_history
+#: field:stock.valuation.history,date:0
+msgid "Date"
+msgstr "Date"
+
+#. module: stock_valuation_history
+#: view:stock.valuation.history:0
+msgid "Group By..."
+msgstr "Grouper par..."
+
+#. module: stock_valuation_history
+#: view:stock.valuation.history:0
+msgid "Labels"
+msgstr "Labels"
+
+#. module: stock_valuation_history
+#: field:stock.valuation.history.wizard,location_id:0
+msgid "Location"
+msgstr "Emplacement"
+
+#. module: stock_valuation_history
+#: view:stock.valuation.history.wizard:0
+msgid "Ok"
+msgstr "Ok"
+
+#. module: stock_valuation_history
+#: field:stock.valuation.history,product_id:0
+msgid "Product"
+msgstr "Produit"
+
+#. module: stock_valuation_history
+#: view:stock.valuation.history:0
+#: field:stock.valuation.history,category_id:0
+msgid "Product Category"
+msgstr "Catégorie de produit"
+
+#. module: stock_valuation_history
+#: field:stock.valuation.history,label_ids:0
+msgid "Product Labels"
+msgstr "Labels produit"
+
+#. module: stock_valuation_history
+#: model:ir.model,name:stock_valuation_history.model_product_product
+msgid "Produit"
+msgstr "Produit"
+
+#. module: stock_valuation_history
+#: field:stock.valuation.history,product_qty:0
+msgid "Quantity"
+msgstr "Quantité"
+
+#. module: stock_valuation_history
+#: model:ir.actions.act_window,name:stock_valuation_history.action_compute_stock_valuation
+#: model:ir.ui.menu,name:stock_valuation_history.menu_compute_stock_valuation
+msgid "Record current Stock Valuation"
+msgstr "Enregistrer la valorisation actuelle"
+
+#. module: stock_valuation_history
+#: view:stock.valuation.history.wizard:0
+msgid "Record stock valuation"
+msgstr "Enregistrer la valorisation"
+
+#. module: stock_valuation_history
+#: code:addons/stock_valuation_history/wizard/compute_stock_valuation_wizard.py:64
+#: view:stock.valuation.history:0
+#, python-format
+msgid "Stock Valuation"
+msgstr "Valorisation de stock"
+
+#. module: stock_valuation_history
+#: model:ir.model,name:stock_valuation_history.model_stock_valuation_history_wizard
+msgid "Stock Valuation wizard"
+msgstr "Stock Valuation wizard"
+
+#. module: stock_valuation_history
+#: model:ir.actions.act_window,name:stock_valuation_history.action_inventory_valuation_all
+#: model:ir.ui.menu,name:stock_valuation_history.menu_inventory_valuation_all
+#: view:stock.valuation.history:0
+msgid "Stock Valuations"
+msgstr "Valorisations de stock"
+
+#. module: stock_valuation_history
+#: model:ir.model,name:stock_valuation_history.model_stock_valuation_history
+msgid "Stock inventory valuation"
+msgstr "Valorisation du stock"
+
+#. module: stock_valuation_history
+#: help:stock.valuation.history,product_qty:0
+msgid "The Quantity of Product of this Stock Valuation."
+msgstr "La quantité de produit de cette valorisation de stock."
+
+#. module: stock_valuation_history
+#: help:stock.valuation.history,product_uom:0
+msgid "The Unit of Measure of this Stock Valuation."
+msgstr "L'unité de mesure de cette valorisation de stock."
+
+#. module: stock_valuation_history
+#: help:stock.valuation.history,date:0
+msgid "The date on which this Stock Valuation was recorded."
+msgstr "La date à laquelle cette valorisation de stock a été enregistrée."
+
+#. module: stock_valuation_history
+#: help:stock.valuation.history,name:0
+msgid "The title of the Stock Valuations. Use the same title for all Stock Valuations that form a logical set: for example if you record the Valuation of all products after a Physical Inventory, you should set the title of all those Stock Valuations to the name of the Physical Inventory."
+msgstr "Le titre de cette valorisation de stock. Utilisez le même titre pour toutes les valorisations qui forment un ensemble logique : par exemple si vous enregistrez la valorisation après un inventaire physique, choisissez le nom de l'inventaire comme titre des valorisations."
+
+#. module: stock_valuation_history
+#: help:stock.valuation.history,label_ids:0
+msgid "These are the labels currently attached to this Product."
+msgstr "Ce sont les labels actuellement attachés à ce produit."
+
+#. module: stock_valuation_history
+#: help:stock.valuation.history,category_id:0
+msgid "This is the current Category of the Product."
+msgstr "C'est la catégorie dans laquelle se trouve actuellement le produit."
+
+#. module: stock_valuation_history
+#: view:stock.valuation.history.wizard:0
+msgid "This wizard will record the stock valuation for all products at a location"
+msgstr "Cet assistant enregistrera la valorisation du stock de tous les produits dans un emplacement."
+
+#. module: stock_valuation_history
+#: view:stock.valuation.history:0
+#: field:stock.valuation.history,name:0
+#: field:stock.valuation.history.wizard,name:0
+msgid "Title"
+msgstr "Titre"
+
+#. module: stock_valuation_history
+#: field:stock.valuation.history,total_valuation:0
+msgid "Total Valuation"
+msgstr "Valorisation totale"
+
+#. module: stock_valuation_history
+#: help:stock.valuation.history,standard_price:0
+msgid "Unit Valuation Price of the Product at the date the Stock Valuation was recorded. You can change this price after it was recorded if you need to."
+msgstr "Prix de valorisation unitaire du produit à la date à laquelle la valorisation a été enregistrée. Vous pouvez corriger ce prix après son enregistrement si nécessaire."
+
+#. module: stock_valuation_history
+#: view:stock.valuation.history:0
+#: field:stock.valuation.history,product_uom:0
+msgid "Unit of Measure"
+msgstr "Unité de mesure"
+
+#. module: stock_valuation_history
+#: field:stock.valuation.history,standard_price:0
+msgid "Valuation Price"
+msgstr "Prix de valorisation"
+
+#. module: stock_valuation_history
+#: code:addons/stock_valuation_history/product.py:52
+#, python-format
+msgid "Valuation as of %s"
+msgstr "Valorisation du %s"
+
+#. module: stock_valuation_history
+#: view:stock.valuation.history.wizard:0
+msgid "_Cancel"
+msgstr "_Annuler"
+

--- a/stock_valuation_history/product.py
+++ b/stock_valuation_history/product.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import time
+
+from openerp.osv import orm
+from openerp.tools.translate import _
+from openerp import tools
+
+
+class ProductProduct(orm.Model):
+    """Add methods to record the valuation"""
+    _inherit = 'product.product'
+
+    def create_valuation(self, cr, uid, ids, context=None):
+        """Record the valuation of the products
+
+        @param ids: list of product IDs
+        @param context: 'product_uom': UoM conversion will be attempted.
+                        'date': the quantity will be queried at that date-time
+                                and the valuation will be recorded at that
+                                date-time.
+                                WARNING! the price CANNOT be queried at that
+                                date, so it may be inconsistent.
+                        'name': all created records will have that name instead
+                                of the name of the product
+                        Other keys may be added to tweak the way quantities are
+                        queried (shop, warehouse...)
+        @return IDs of the created valuation records"""
+        if context is None:
+            context = {}
+
+        # Remove duplicates
+        ids = list(set(ids))
+
+        valuation_ids = []
+        val_obj = self.pool['stock.valuation.history']
+        # Default name
+        name = context.get(
+            "name", _("Valuation as of %s") % time.strftime(
+                tools.DEFAULT_SERVER_DATE_FORMAT))
+
+        for product in self.browse(cr, uid, ids, context=context):
+            default = {
+                'product_id': product.id,
+                'name': name,
+                'standard_price': product.standard_price,
+                'product_uom': context.get("uom", product.uom_id.id),
+                'product_qty': product.qty_available,
+            }
+            if 'date' in context:
+                default['date'] = context['date']
+            valuation_ids.append(val_obj.create(
+                cr, uid, default, context=context))
+        return valuation_ids
+
+    def search_create_valuation(self, cr, uid, args, context=None):
+        """Search for products and record the valuation of the products
+
+        @param values: values values of the valuation records
+        @return IDs of the created valuation records"""
+        return self.create_valuation(
+            cr, uid, self.search(cr, uid, args, context=context),
+            context=context)

--- a/stock_valuation_history/security/ir.model.access.csv
+++ b/stock_valuation_history/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_stock_valuation_history_manager","stock.inventory_valuation manager","model_stock_valuation_history","stock.group_stock_manager",1,1,1,1

--- a/stock_valuation_history/stock_valuation_history.py
+++ b/stock_valuation_history/stock_valuation_history.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+import decimal_precision as dp
+
+
+class stock_valuation_history(orm.Model):
+    """Record Products quantity & standard price for future reference.
+
+    The unit price can be manually adjusted by users, and the total value is
+    recomputed and cached.
+    """
+    _name = 'stock.valuation.history'
+    _description = 'Stock inventory valuation'
+
+    def _get_total_valuation(self, cr, uid, ids, fields, arg,
+                             context=None):
+        """Method for the function field 'total_valuation'"""
+        valuations = self.browse(cr, uid, ids, context=context)
+        return {v.id: v.standard_price * v.product_qty for v in valuations}
+
+    _columns = {
+        'name': fields.char(
+            'Title', size=64, required=True, select=True,
+            help="The title of the Stock Valuations. "
+                 "Use the same title for all Stock Valuations "
+                 "that form a logical set: for example if you "
+                 "record the Valuation of all products after a "
+                 "Physical Inventory, you should set the title "
+                 "of all those Stock Valuations to the name of "
+                 "the Physical Inventory."),
+        'date': fields.datetime(
+            'Date', readonly=True, required=True,
+            help="The date on which this Stock Valuation was recorded."),
+        'product_id': fields.many2one(
+            'product.product', 'Product', ondelete='restrict', readonly=True),
+        'category_id':  fields.related(
+            'product_id', 'categ_id',
+            relation='product.category', type='many2one', readonly=True,
+            store=True, string='Product Category',
+            help='This is the current Category of the Product.'),
+        'label_ids':  fields.related(
+            'product_id', 'label_ids', relation='product.label',
+            type='many2many', readonly=True, string="Product Labels",
+            help='These are the labels currently attached to this Product.'),
+        'product_qty': fields.float(
+            'Quantity',
+            digits_compute=dp.get_precision('Product Unit of Measure'),
+            readonly=True,
+            help="The Quantity of Product of this Stock Valuation."),
+        'product_uom': fields.many2one(
+            'product.uom', 'Unit of Measure', readonly=True,
+            help="The Unit of Measure of this Stock Valuation."),
+        # XXX avg is pretty lame since it's not weighted by quantity
+        'standard_price': fields.float(
+            'Valuation Price',
+            digits_compute=dp.get_precision('Product Price'), required=True,
+            group_operator='min',
+            help="Unit Valuation Price of the Product at the date the "
+                 "Stock Valuation was recorded. You can change this price "
+                 "after it was recorded if you need to."),
+        'total_valuation': fields.function(
+            _get_total_valuation, method=True, type="float",
+            string='Total Valuation',
+            digits_compute=dp.get_precision('Account'),
+            store={'stock.valuation.history': (
+                lambda self, cr, uid, ids, context=None: ids,
+                ['standard_price'], 10), },
+            readonly=True),
+    }
+
+    _defaults = {
+        'date': fields.date.context_today,
+    }

--- a/stock_valuation_history/stock_valuation_history_data.xml
+++ b/stock_valuation_history/stock_valuation_history_data.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+        <!-- Pre-record an inactive scheduled task to record the product valuation once a week -->
+        <record id="ir_cron_record_valuation" model="ir.cron">
+            <field name="name">Record the product valuation</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">weeks</field>
+            <field name="numbercall">-1</field>
+            <field eval="False" name="doall"/>
+            <field eval="False" name="active"/>
+            <field name="model">product.product</field>
+            <field name="function">search_create_valuation</field>
+            <field name="args">([('active', '=', True)], {'location': 1})</field>
+        </record>
+
+
+        <!-- Export template to make it easy to export the valuations to Excel -->
+        <record id="export_template" model="ir.exports">
+            <field name="name">Valuation template</field>
+            <field name="resource">stock.valuation.history</field>
+        </record>
+        <record id="export_template_product_id_default_code" model="ir.exports.line">
+            <field name="name">product_id/default_code</field>
+            <field name="export_id" ref="export_template"/>
+        </record>
+        <record id="export_template_product_id_name" model="ir.exports.line">
+            <field name="name">product_id/name</field>
+            <field name="export_id" ref="export_template"/>
+        </record>
+        <record id="export_template_standard_price" model="ir.exports.line">
+            <field name="name">standard_price</field>
+            <field name="export_id" ref="export_template"/>
+        </record>
+        <record id="export_template_product_qty" model="ir.exports.line">
+            <field name="name">product_qty</field>
+            <field name="export_id" ref="export_template"/>
+        </record>
+        <record id="export_template_product_uom_name" model="ir.exports.line">
+            <field name="name">product_uom/name</field>
+            <field name="export_id" ref="export_template"/>
+        </record>
+    </data>
+</openerp>

--- a/stock_valuation_history/stock_valuation_history_demo.xml
+++ b/stock_valuation_history/stock_valuation_history_demo.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+
+        <!-- Record a production lot we can use in the tests. -->
+        <record id="lot_test0" model="stock.production.lot">
+            <field name="product_id" ref="product.product_product_10" />
+        </record>
+
+        <!-- Record inventories we can use in the tests. -->
+        <!-- We need them in the demo data because test data is rolled back 
+            whenever an exception is raised. -->
+        
+        <!-- Record an inventory to make sure the next one will have stock moves posted. -->
+        <record id="stock_valuation_history0" model="stock.inventory">
+            <field name="name">Valuation test inventory</field>
+            <field name="state">draft</field>
+            <field name="date">2020-06-01 00:00:00</field>
+        </record>        
+        <record id="stock_inventory_line" model="stock.inventory.line">
+            <field name="inventory_id" ref="stock_valuation_history0" />
+            <field name="product_id" ref="product.product_product_10" />
+            <field name="prod_lot_id" ref="lot_test0"/>
+            <field name="product_uom" ref="product.product_uom_unit" />
+            <!-- Current stock quantity is 14.000 -->
+            <field name="product_qty">25.0</field>
+            <field name="location_id" ref="stock.stock_location_components" />
+        </record>
+    </data>
+</openerp>

--- a/stock_valuation_history/stock_valuation_history_view.xml
+++ b/stock_valuation_history/stock_valuation_history_view.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+    <!-- Inventory Valuation views -->
+    <record model="ir.ui.view" id="view_inventory_valuation_filter">
+        <field name="name">inventory.valuation.filter</field>
+        <field name="model">stock.valuation.history</field>
+        <field name="type">search</field>
+        <field name="arch" type="xml">
+            <search string="Stock Valuation">
+                <group col="6" colspan="4">
+                    <field name="name"/>
+                    <field name="date"/>
+                    <separator/>
+                    <field name="product_id"/>
+                    <field name="category_id"/>
+                    <field name="label_ids"/>
+                </group>
+                <newline/>
+                <group expand="0" string="Group By...">
+                    <filter name="group_by_name" string="Title" icon="terp-go-month" domain="[]" context="{'group_by' : 'name'}"/>
+                    <filter name="group_by_category" string="Product Category" icon="terp-stock_symbol-selection" domain="[]" context="{'group_by' : 'category_id'}"/>
+                    <filter name="group_by_uom" string="Unit of Measure" icon="terp-mrp" domain="[]" context="{'group_by':'product_uom'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+    <record model="ir.ui.view" id="stock_valuation_history_tree_view">
+        <field name="name">stock.valuation.history.tree</field>
+        <field name="model">stock.valuation.history</field>
+        <field name="type">tree</field>
+        <field name="arch" type="xml">
+            <tree string="Stock Valuations">
+                <field name="name"/>
+                <field name="date"/>
+                <field name="category_id"/>
+                <field name="product_id"/>
+                <field name="product_qty"/>
+                <field name="product_uom"/>
+                <field name="standard_price"/>
+                <field name="total_valuation"/>
+            </tree>
+        </field>
+    </record>
+    <record model="ir.ui.view" id="stock_valuation_history_line_form_view">
+        <field name="name">stock.valuation.history.detail.form</field>
+        <field name="model">stock.valuation.history</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <form string="Details" version="7.0">
+                <group col="6" colspan="4">
+                    <field name="name"/>
+                    <field name="date"/>
+                </group>
+                <separator colspan="4"/>
+                <group col="4" colspan="4">
+                    <field name="product_id"/>
+                    <field name="category_id"/>
+                    <label string="Labels" colspan="4"/>
+                    <field name="label_ids" nolabel="1" colspan="4"/>
+                </group>
+                <separator colspan="4"/>
+                <group col="4" colspan="4">
+                    <field name="product_qty"/>
+                    <field name="product_uom"/>
+                    <field name="standard_price"/>
+                    <field name="total_valuation"/>
+                </group>
+            </form>
+        </field>
+    </record>
+    
+    <!-- Action to open the valuation from the menu -->
+    <act_window id="action_inventory_valuation_all"
+        name="Stock Valuations"
+        res_model="stock.valuation.history"
+        view_mode="tree,form"
+        view_type="form"
+        context="{'search_default_group_by_name':1}" />
+    
+    <menuitem id="menu_inventory_valuation_all" name="Stock Valuations"
+        parent="stock.menu_stock_inventory_control" action="action_inventory_valuation_all" sequence="50"/>
+    </data>
+</openerp>

--- a/stock_valuation_history/test/stock_valuation_history_test.yml
+++ b/stock_valuation_history/test/stock_valuation_history_test.yml
@@ -1,0 +1,28 @@
+-
+  Test recording of the valuation
+-
+  Confirm the inventory
+-
+  !python {model: stock.inventory}: |
+    self.action_confirm(cr, uid, [ref('stock_valuation_history0')])    
+    state = self.read(cr, uid, [ref('stock_valuation_history0')], ['state'])[0]['state']
+    assert state=='confirm', "The Inventory is '%s'. It should be confirmed" % state
+-
+  Record the valuation
+-
+  !python {model: product.product}: |
+    self.search_create_valuation(cr, uid, [('qty_available', '>', '0')],
+      context={
+        'date': '2020-06-01',
+        'location_id': ref('stock.stock_location_components')
+      }
+-
+  Check the valuation is correct
+-
+  !python {model: stock.valuation.history}: |
+    valuation_ids = self.search(cr, uid, [('date', '=', '2020-06-01 00:00:00'])
+    valuation_infos = self.read(cr, uid, valuation_ids, ['name', 'product_qty', 'product_id', 'total_valuation'])
+    
+    assert valuation_infos != False, "Valuation is not done !"
+    assert valuation_infos[0]['product_qty'] == 25.0, "Product quantity is '%s', should be '25.0'" % valuation_infos[0]['product_qty']
+    assert valuation_infos[0]['total_valuation'] == 7500.0, "Product valuation is '%s', should be '7500.0'"

--- a/stock_valuation_history/wizard/__init__.py
+++ b/stock_valuation_history/wizard/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import compute_stock_valuation_wizard

--- a/stock_valuation_history/wizard/compute_stock_valuation_wizard.py
+++ b/stock_valuation_history/wizard/compute_stock_valuation_wizard.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import osv, fields
+from openerp.tools.translate import _
+
+
+class compute_stock_valuation(osv.TransientModel):
+    _name = "stock.valuation.history.wizard"
+    _description = "Stock Valuation wizard"
+
+    _columns = {
+        'name': fields.char('Title', size=64),
+        'location_id': fields.many2one(
+            'stock.location', 'Location', required=True),
+    }
+
+    def action_ok(self, cr, uid, ids, context=None):
+        """Call the computation module and open the result screen.
+
+        A default name will be generated if none is given."""
+        if context is None:
+            context = {}
+
+        wizard = self.browse(cr, uid, ids[0], context=context)
+
+        context = context.copy()
+        context['location'] = wizard.location_id.id
+        if wizard.name:
+            context['name'] = wizard.name
+
+        valuation_ids = self.pool['product.product'].search_create_valuation(
+            cr, uid, [('qty_available', '>', 0)], context=context)
+
+        view_ids = self.pool['ir.model.data'].get_object_reference(
+            cr, uid,
+            'stock_valuation_history',
+            'stock_valuation_history_tree_view')
+        view_id = view_ids and view_ids[1] or False
+
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Stock Valuation'),
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'view_ids': [view_id],
+            'res_model': 'stock.valuation.history',
+            'context': {'search_default_group_by_name': 1,
+                        'search_default_group_by_category': 1,
+                        'search_default_group_by_uom': 1},
+            'domain': [('id', 'in', valuation_ids)],
+        } or True

--- a/stock_valuation_history/wizard/compute_stock_valuation_wizard_view.xml
+++ b/stock_valuation_history/wizard/compute_stock_valuation_wizard_view.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="compute_stock_valuation_wizard_form" model="ir.ui.view">
+            <field name="name">stock.valuation.history.wizard.wizard.form</field>
+            <field name="model">stock.valuation.history.wizard</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Record stock valuation" col="2">
+                    <label
+                        string="This wizard will record the stock valuation for all products at a location" colspan="2" />
+                    <separator string="" colspan="2" />
+                    <field name="name"/>
+                    <field name="location_id" />
+                    <button special="cancel" string="_Cancel" icon='gtk-cancel'/>
+                    <button name="action_ok" type="object" icon="gtk-ok" string="Ok" />
+                </form>
+            </field>
+        </record>        
+    
+    <!-- Action to open the valuation from the menu -->
+    <record id="action_compute_stock_valuation" model="ir.actions.act_window">
+        <field name="name">Record current Stock Valuation</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.valuation.history.wizard</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <!-- Add menu entry -->
+    <menuitem name="Record current Stock Valuation" id="menu_compute_stock_valuation"
+        parent="stock.menu_stock_inventory_control" action="action_compute_stock_valuation" sequence="55"/>
+       
+    </data>
+</openerp>


### PR DESCRIPTION
In v7 the product cost prices are not kept in a history, so this module simply proposes a wizard to let users record them at key moments (ie. at annual inventory), or on regular basis using a "cron" job.
