### PR TITLE
fix #42: reserve location should be outside WH

### DIFF
--- a/stock_reserve/__openerp__.py
+++ b/stock_reserve/__openerp__.py
@@ -21,7 +21,7 @@
 
 {'name': 'Stock Reservation',
  'summary': 'Stock reservations on products',
- 'version': '0.1',
+ 'version': '0.2',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'category': 'Warehouse',
  'license': 'AGPL-3',

--- a/stock_reserve/data/stock_data.xml
+++ b/stock_reserve/data/stock_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <record id="stock_location_reservation" model="stock.location">
             <field name="name">Reservation Stock</field>
-            <field name="location_id" ref="stock.stock_location_company"/>
+            <field name="location_id" ref="stock.stock_location_locations"/>
         </record>
 
 

--- a/stock_reserve/migrations/0.2/post-migration.py
+++ b/stock_reserve/migrations/0.2/post-migration.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#    Author: Leonardo Pistone
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+def migrate(cr, installed_version):
+    """Update a wrong location that is no_update in XML."""
+    if installed_version == '8.0.0.1':
+        cr.execute('''
+            UPDATE stock_location
+            SET location_id = (
+                SELECT res_id
+                FROM ir_model_data
+                WHERE name = 'stock_location_locations'
+                AND model = 'stock.location'
+            )
+            WHERE id = (
+                SELECT res_id
+                FROM ir_model_data
+                WHERE name = 'stock_location_reservation'
+                AND model = 'stock.location'
+            )
+            AND location_id = (
+                SELECT res_id
+                FROM ir_model_data
+                WHERE name = 'stock_location_company'
+                AND model = 'stock.location'
+            );
+        ''')

--- a/stock_reserve/migrations/0.2/post-migration.py
+++ b/stock_reserve/migrations/0.2/post-migration.py
@@ -25,18 +25,18 @@ def migrate(cr, installed_version):
                 SELECT res_id
                 FROM ir_model_data
                 WHERE name = 'stock_location_locations'
-                AND model = 'stock.location'
+                AND module = 'stock'
             )
             WHERE id = (
                 SELECT res_id
                 FROM ir_model_data
                 WHERE name = 'stock_location_reservation'
-                AND model = 'stock.location'
+                AND module = 'stock_reserve'
             )
             AND location_id = (
                 SELECT res_id
                 FROM ir_model_data
                 WHERE name = 'stock_location_company'
-                AND model = 'stock.location'
+                AND module = 'stock'
             );
         ''')


### PR DESCRIPTION
This has always been wrong on v8, but because of the very obscure
odoo/odoo#5797, this seemed to work every time we had single-step
reception.

Please note that this block of XML is noupdate, so for existing
installations you need to change the parent of the reservation location
to something outside your warehouses manually.

Incidentally, this makes the branch green independently of odoo/odoo#5797.
