### PR TITLE
[FIX] stock_available : use extend instead of append

### DIFF
--- a/stock_available/product.py
+++ b/stock_available/product.py
@@ -36,16 +36,16 @@ class ProductTemplate(models.Model):
         stock_location_obj = self.env['stock.location']
         internal_locations = stock_location_obj.search([
             ('usage', '=', 'internal')])
-        sublocation_ids = []
+        sublocations = self.env['stock.location']
         for location in internal_locations:
-            sublocation_ids.append(self.env['stock.location'].search(
-                [('id', 'child_of', location.id)]).ids)
+            sublocations += stock_location_obj.search(
+                [('id', 'child_of', location.id)])
         for product_template in self:
             products = self.env['product.product'].search([
                 ('product_tmpl_id', '=', product_template.id)])
             quant_obj = self.env['stock.quant']
             quants = quant_obj.search([
-                ('location_id', 'in', sublocation_ids),
+                ('location_id', 'in', sublocations.ids),
                 ('product_id', 'in', products.ids),
                 ('reservation_id', '=', False)])
             availability = 0


### PR DESCRIPTION
**Display of list of product get error**

Impacted versions:
- 8.0

Steps to reproduce:
1. install stock_available on demo database
2. display list of product

Current behavior:
- get the following error :

Traceback (most recent call last):
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 537, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 574, in dispatch
    result = self._call_function(*_self.params)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 310, in _call_function
    return checked_call(self.db, *args, *_kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/service/model.py", line 113, in wrapper
    return f(dbname, _args, *_kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 307, in checked_call
    return self.endpoint(_a, *_kw)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 803, in __call__
    return self.method(_args, *_kw)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 403, in response_wrap
    response = f(_args, *_kw)
  File "/home/lga/project/openerp/parts/odoo/addons/web/controllers/main.py", line 884, in search_read
    return self.do_search_read(model, fields, offset, limit, domain, sort)
  File "/home/lga/project/openerp/parts/odoo/addons/web/controllers/main.py", line 905, in do_search_read
    request.context)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 908, in proxy
    result = meth(cr, request.uid, _args, *_kw)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 241, in wrapper
    return old_api(self, _args, *_kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/models.py", line 5146, in search_read
    result = self.read(cr, uid, record_ids, fields, context=read_ctx)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 241, in wrapper
    return old_api(self, _args, *_kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/models.py", line 3141, in read
    result = BaseModel.read(records, fields, load=load)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 239, in wrapper
    return new_api(self, _args, *_kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/models.py", line 3187, in read
    values[name] = field.convert_to_read(record[name], use_name_get)
  File "/home/lga/project/openerp/parts/odoo/openerp/models.py", line 5573, in **getitem**
    return self._fields[key].__get__(self, type(self))
  File "/home/lga/project/openerp/parts/odoo/openerp/fields.py", line 817, in **get**
    self.determine_value(record)
  File "/home/lga/project/openerp/parts/odoo/openerp/fields.py", line 919, in determine_value
    self.compute_value(recs)
  File "/home/lga/project/openerp/parts/odoo/openerp/fields.py", line 875, in compute_value
    self._compute_value(records)
  File "/home/lga/project/openerp/parts/odoo/openerp/fields.py", line 867, in _compute_value
    self.compute(records)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 239, in wrapper
    return new_api(self, _args, *_kwargs)
  File "/home/lga/project/openerp/addons-stock-logistics-warehouse/stock_available/product.py", line 50, in _immediately_usable_qty
    ('reservation_id', '=', False)])
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 239, in wrapper
    return new_api(self, _args, *_kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 463, in new_api
    result = method(self._model, cr, uid, _args, *_kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/models.py", line 1644, in search
    return self._search(cr, user, args, offset=offset, limit=limit, order=order, context=context, count=count)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 241, in wrapper
    return old_api(self, _args, *_kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/models.py", line 4658, in _search
    cr.execute(query_str, where_clause_params)
  File "/home/lga/project/openerp/parts/odoo/openerp/sql_db.py", line 158, in wrapper
    return f(self, _args, *_kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/sql_db.py", line 234, in execute
    res = self._obj.execute(query, params)
TypeError: not all arguments converted during string formatting

Expected behavior:
- get the list of product
