### PR TITLE
fix stock_mts_mto procurement check method

### DIFF
--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -19,11 +19,20 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ###############################################################################
-from openerp import models, api
+from openerp import models, api, fields
 
 
 class ProcurementOrder(models.Model):
     _inherit = 'procurement.order'
+
+    mts_mto_procurement_id = fields.Many2one(
+        'procurement.order',
+        string="Mto+Mts Procurement",
+        copy=False)
+    mts_mto_procurement_ids = fields.One2many(
+        'procurement.order',
+        'mts_mto_procurement_id',
+        string="Procurements")
 
     @api.multi
     def get_mto_qty_to_order(self):
@@ -52,23 +61,31 @@ class ProcurementOrder(models.Model):
             'product_qty': qty,
             'product_uos_qty': uos_qty,
             'rule_id': rule.id,
+            'mts_mto_procurement_id': proc.id,
         }
 
     @api.model
     def _check(self, procurement):
         if procurement.rule_id and \
                 procurement.rule_id.action == 'split_procurement':
-            if procurement.state == 'running':
+            cancel_proc_list = [x.state == 'cancel'
+                                for x in procurement.mts_mto_procurement_ids]
+            done_cancel_test_list = [
+                x.state in ('done', 'cancel')
+                for x in procurement.mts_mto_procurement_ids]
+            if all(cancel_proc_list):
+                procurement.write({'state': 'cancel'})
+            elif all(done_cancel_test_list):
                 return True
         return super(ProcurementOrder, self)._check(procurement)
 
     @api.multi
-    def run(self, autocommit=False):
-        res = super(ProcurementOrder, self).run(autocommit=autocommit)
-        for proc in self:
-            if proc.rule_id and \
-                    proc.rule_id.action == 'split_procurement':
-                proc.check()
+    def check(self, autocommit=False):
+        res = super(ProcurementOrder, self).check(autocommit=autocommit)
+        for procurement in self:
+            if procurement.mts_mto_procurement_id:
+                procurement.mts_mto_procurement_id.check(
+                    autocommit=autocommit)
         return res
 
     @api.model


### PR DESCRIPTION
Hello,

In stock_mts_mto module, we have a new type of procurement rule action : 'split procurement'.
This rule is used to create one or 2 procurements.

I had define the def _check method in a way that the procurement having this type of rule would be 'done' once it had created the other procurements.

But I am not sure it is a good idea. For example it is not compatible with the module sale_order_back2draft, because when you cancel your order and put it to draft state again, Odoo try to delete the procurements. But it won't be able to delete a done procurement.
That is why, I think it may be better to change the procurement's state to done, only when its 'children procurements' are done or cancel.

What do you think?
Maybe there is a better solution...
