### PR TITLE
[FIX] Added a type check to product_id_change of sale.order.line in stock_r…

### DIFF
--- a/stock_reserve_sale/model/sale.py
+++ b/stock_reserve_sale/model/sale.py
@@ -180,7 +180,8 @@ class SaleOrderLine(models.Model):
                     "the quantity of the stock reservation will "
                     "be automatically adjusted to %.2f.") % qty
             msg += "\n\n"
-            result.setdefault('warning', {})
+            if 'warning' not in result or type(result['warning']) is not dict:
+                result['warning'] = {}
             if result['warning'].get('message'):
                 result['warning']['message'] += msg
             else:

--- a/stock_reserve_sale/test/sale_line_reserve.yml
+++ b/stock_reserve_sale/test/sale_line_reserve.yml
@@ -109,6 +109,27 @@
     product = self.browse(cr, uid, ref('product_yogurt'), context=context)
     assert product.virtual_available == 5, "Stock is not updated."
 -
+  I try to change the product quantity on the sale order line
+-
+  !python {model: sale.order.line}: |
+    line = self.browse(cr, uid, ref('sale_line_reserve_02_01'), context=context)
+    self.product_id_change(cr, uid, [line.id],
+      line.order_id.pricelist_id.id,
+      line.product_id.id,
+      qty=22,
+      uom=False,
+      qty_uos=0,
+      uos=False,
+      name='',
+      partner_id=ref('base.res_partner_2'),
+      lang=False,
+      update_tax=True,
+      date_order=False,
+      packaging=False,
+      fiscal_position=False,
+      flag=False,
+      context=None)
+-
   I release the sales order's reservations for the first line
 -
   !python {model: sale.order.line}: |


### PR DESCRIPTION
…eserve_sale. Sometimes result['warning'] can be present, but False and the old code fails to deal with it and raises an error.

If you go through the original [product_id_change](https://github.com/odoo/odoo/blob/8.0/addons/sale/sale.py#L1088) of `sale.order.line`, you'll notice that `result['warning']` can very well be `False`. There's already `result.setdefault('warning', {})` that sets `result['warning']` to `{}`, but it will not touch the value if `warning` exists in `result`. Despite having `False` as the value.
