### PR TITLE
[FIX] stock_reserve_sale: Cancel related stock.move of a stock.reserv…

### DIFF
--- a/stock_reserve_sale/__openerp__.py
+++ b/stock_reserve_sale/__openerp__.py
@@ -37,6 +37,7 @@
           ],
  'test': ['test/sale_reserve.yml',
           'test/sale_line_reserve.yml',
+          'test/sale_line_reserve_delete.yml',
           ],
  'installable': True,
  'auto_install': False,

--- a/stock_reserve_sale/model/sale.py
+++ b/stock_reserve_sale/model/sale.py
@@ -75,6 +75,15 @@ class SaleOrder(models.Model):
         self.release_all_stock_reservation()
         return super(SaleOrder, self).action_cancel()
 
+    @api.multi
+    def unlink(self):
+        """
+        Force unlink of order lines to make sure that
+        all reservations are removed as well.
+        """
+        self.mapped('order_line').unlink()
+        return super(SaleOrder, self).unlink()
+
 
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
@@ -232,3 +241,13 @@ class SaleOrderLine(models.Model):
                      }
                 )
         return res
+
+    @api.multi
+    def unlink(self):
+        """
+        Force remove the reservations. This is necessary because even though
+        sale_line_id of stock.reservation has ondelete=cascade, the unlink
+        method of the reservations is never called.
+        """
+        self.mapped('reservation_ids').unlink()
+        return super(SaleOrderLine, self).unlink()

--- a/stock_reserve_sale/test/sale_line_reserve_delete.yml
+++ b/stock_reserve_sale/test/sale_line_reserve_delete.yml
@@ -1,0 +1,34 @@
+-
+  I create a sales order line for sales order defined in sale_line_reserve.yml
+-
+  !record {model: sale.order.line, id: sale_line_reserve_02_03, view: sale.view_order_line_tree}:
+    name: Yogurt
+    product_id: product_yogurt
+    product_uom_qty: 4
+    product_uom: product.product_uom_kgm
+    order_id: sale_reserve_02
+-
+  And I create a stock reserve for this line
+-
+  !record {model: sale.stock.reserve, id: wizard_reserve_02_03, context: "{'active_model': 'sale.order.line', 'active_ids': ref('sale_line_reserve_02_03')}"}:
+    note: 'A unique note to be used in a search'
+-
+  I call the wizard to reserve the products of the sales order
+-
+  !python {model: sale.stock.reserve}: |
+    active_id = ref('sale_line_reserve_02_03')
+    context['active_id'] = active_id
+    context['active_ids'] = [active_id]
+    context['active_model'] = 'sale.order.line'
+    self.button_reserve(cr, uid, [ref('wizard_reserve_02_03')], context=context)
+-
+  I remove the order line from the order
+-
+  !python {model: sale.order}: |
+    self.write(cr, uid, ref('sale_reserve_02'), {'order_line': [(2, ref('sale_line_reserve_02_03'))]})
+-
+  I make sure that the moves related to the reservation were cancelled
+-
+  !python {model: stock.move}: |
+    move_ids = self.search(cr, uid, [('note', '=', 'A unique note to be used in a search'), ('state', '!=', 'cancel')])
+    assert len(move_ids) == 0, 'The move related to the stock reservation should have been cancelled'


### PR DESCRIPTION
…ation when an sale.order.line is unlinked.

**Impacted versions:**
8.0

**Steps to reproduce:**
1. Create a sales order with one order line
2. Create a reservation for the order line
3. Remove the order line
4. Find the orphaned `stock.move`s

**Current behavior:**
The `stock.move` related to a `stock.reservation` is not being cancelled when a `sale.order.line` related to the same `stock.reservation` is removed. This leaves us with "zombie moves" that are not linked to anything. This happens because the `ondelete=cascade` of `stock.reservation sale_line_id` works at the database level and never calls the `unlink` method of `stock.reservation` which is used to cancel the moves.

**Expected behavior:**
The `stock.move`'s are cancelled _always_ when the related `stock.reservation` is removed.
