### PR TITLE
[8.0] fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 # Config file .travis.yml
 
+language: python
+python:
+    - "2.7"
+
 sudo: false
 cache: pip
 
@@ -9,15 +13,16 @@ addons:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
 
-language: python
-
-python:
-    - "2.7"
-
 env:
-  - VERSION="8.0" LINT_CHECK="1"
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
-  - VERSION="8.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
+  global:
+  - VERSION="8.0" TESTS="0" LINT_CHECK="0"
+  - TRANSIFEX_USER='transbot@odoo-community.org'
+  - secure: tDsvZaY3JqmnjgyRuKkgQRtlRILkkjnHtZPWWaGg+KBD+BBH4AqX5ACTyu5U/J6Kr/Yb5NIoM3+NYRuASdGXnJb9siZvh/9B58B1wKUbC2umH4Yrpw66CEvG9JY4XMOCZni9kQBwQ7iMk5GfusDWuVuydZjd6dAqkCxz6JdkIco=
+  matrix:
+  - LINT_CHECK="1"
+  - TRANSIFEX="1"
+  - TESTS=1 ODOO_REPO="odoo/odoo" LINT_CHECK="0"
+  - TESTS=1 ODOO_REPO="OCA/OCB" LINT_CHECK="0"
 
 virtualenv:
   system_site_packages: true
@@ -33,4 +38,4 @@ script:
     - travis_run_tests
 
 after_success:
-  coveralls
+  - travis_after_tests_success

--- a/stock_reserve/test/stock_reserve.yml
+++ b/stock_reserve/test/stock_reserve.yml
@@ -1,4 +1,13 @@
 -
+  I force recomputation of stock.location parent left/right
+-
+  !python {model: stock.location}:
+    # we need this because when running the tests at install time as is done on
+    # Travis, the hook performing this operation for the new stock reservation
+    # location is run after the test execution. This causes the stock level
+    # computation to be wrong at the time the tests are run.
+    self._parent_store_compute(cr)
+-
   I create a product to test the stock reservation
 -
   !record {model: product.product, id: product_sorbet}:
@@ -33,9 +42,8 @@
 -
   I check Virtual stock of Sorbet after update stock.
 -
-  !python {model: product.product}: |
-    product = self.browse(cr, uid, ref('stock_reserve.product_sorbet'), context=context)
-    assert product.virtual_available == 10, "Stock is not updated."
+  !python {model: product.product, id: product_sorbet}: |
+    assert self.virtual_available == 10, "Stock is not updated."
 -
   I create a stock reservation for 6 kgm
 -

--- a/stock_reserve/test/stock_reserve.yml
+++ b/stock_reserve/test/stock_reserve.yml
@@ -92,7 +92,7 @@
   The procurement linked to the orderpoint must be in exception (no routes configured)
 -
   !python {model: stock.warehouse.orderpoint}: |
-    orderpoint = self.browse(cr, uid, ref('sorbet_orderpoint'))
+    orderpoint = self.browse(cr, uid, ref('stock_reserve.sorbet_orderpoint'))
     assert orderpoint.procurement_ids[0].state == 'exception', 'procurement must be in exception as there is no rule for procurement'
     import math
     assert orderpoint.procurement_ids[0].product_qty == math.ceil(15 - 3.5), 'wrong product qty ordered'

--- a/stock_reserve_sale/test/sale_reserve.yml
+++ b/stock_reserve_sale/test/sale_reserve.yml
@@ -1,4 +1,13 @@
 -
+  I force recomputation of stock.location parent left/right
+-
+  !python {model: stock.location}:
+    # we need this because when running the tests at install time as is done on
+    # Travis, the hook performing this operation for the new stock reservation
+    # location is run after the test execution. This causes the stock level
+    # computation to be wrong at the time the tests are run.
+    self._parent_store_compute(cr)
+-
   I create a product to test the stock reservation
 -
  !record {model: product.product, id: product_gelato}:


### PR DESCRIPTION
- update travis config, add transifex support
- fix stock_reserve test, which would fail when run at module install time, 
  because the test would run before the parent left/right of stock.location was 
  updated, which killed the reserved stock computation. 

closes #9 #67
