### PR TITLE
product_available improvements

### DIFF
--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -29,7 +29,7 @@ class ProductProduct(models.Model):
     """
     _inherit = 'product.product'
 
-    @api.one
+    @api.multi
     @api.depends('virtual_available')
     def _immediately_usable_qty(self):
         """No-op implementation of the stock available to promise.
@@ -38,7 +38,8 @@ class ProductProduct(models.Model):
 
         Must be overridden by another module that actually implement
         computations."""
-        self.immediately_usable_qty = self.virtual_available
+        for prod in self:
+            prod.immediately_usable_qty = prod.virtual_available
 
     immediately_usable_qty = fields.Float(
         digits=dp.get_precision('Product Unit of Measure'),

--- a/stock_available/models/product_template.py
+++ b/stock_available/models/product_template.py
@@ -25,12 +25,15 @@ from openerp.addons import decimal_precision as dp
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
-    @api.one
-    @api.depends('virtual_available')
+    @api.multi
+    @api.depends('product_variant_ids.immediately_usable_qty')
     def _immediately_usable_qty(self):
         """Compute the quantity using all the variants"""
-        self.immediately_usable_qty = sum(
-            [v.immediately_usable_qty for v in self.product_variant_ids])
+        for tmpl in self:
+            tmpl.immediately_usable_qty = sum(
+                v.immediately_usable_qty
+                for v in tmpl.product_variant_ids
+            )
 
     immediately_usable_qty = fields.Float(
         digits=dp.get_precision('Product Unit of Measure'),

--- a/stock_available_immediately/models/product_product.py
+++ b/stock_available_immediately/models/product_product.py
@@ -25,8 +25,10 @@ from openerp import models, api
 class ProductProduct(models.Model):
     _inherit = 'product.product'
 
-    @api.one
+    @api.multi
+    @api.depends('virtual_available', 'incoming_qty')
     def _immediately_usable_qty(self):
         """Ignore the incoming goods in the quantity available to promise"""
         super(ProductProduct, self)._immediately_usable_qty()
-        self.immediately_usable_qty -= self.incoming_qty
+        for prod in self:
+            prod.immediately_usable_qty -= prod.incoming_qty


### PR DESCRIPTION
- fix the dependencies for the computed field
- use api.multi instead of api.one to avoid calling `super()._immediately_usable_qty` in a loop (this improves perfs on a tree view  display)
