### PR TITLE
[IMP] Decouple the quantity for templates and variants

### DIFF
--- a/stock_available/__init__.py
+++ b/stock_available/__init__.py
@@ -1,21 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/stock_available/__openerp__.py
+++ b/stock_available/__openerp__.py
@@ -1,23 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
+# © 2014 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Stock available to promise',
     'version': '8.0.3.0.0',

--- a/stock_available/models/__init__.py
+++ b/stock_available/models/__init__.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import product_template
 from . import product_product

--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -36,8 +36,11 @@ class ProductProduct(models.Model):
 
         By default, available to promise = forecasted quantity.
 
-        Must be overridden by another module that actually implement
-        computations."""
+        **Each** sub-module **must** override this method in **both**
+            `product.product` **and** `product.template`, because we can't
+            decide in advance how to compute the template's quantity from the
+            variants.
+        """
         for prod in self:
             prod.immediately_usable_qty = prod.virtual_available
 

--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields, api
 from openerp.addons import decimal_precision as dp

--- a/stock_available/models/product_template.py
+++ b/stock_available/models/product_template.py
@@ -28,12 +28,17 @@ class ProductTemplate(models.Model):
     @api.multi
     @api.depends('product_variant_ids.immediately_usable_qty')
     def _immediately_usable_qty(self):
-        """Compute the quantity using all the variants"""
+        """No-op implementation of the stock available to promise.
+
+        By default, available to promise = forecasted quantity.
+
+        **Each** sub-module **must** override this method in **both**
+            `product.product` **and** `product.template`, because we can't
+            decide in advance how to compute the template's quantity from the
+            variants.
+        """
         for tmpl in self:
-            tmpl.immediately_usable_qty = sum(
-                v.immediately_usable_qty
-                for v in tmpl.product_variant_ids
-            )
+            tmpl.immediately_usable_qty = tmpl.virtual_available
 
     immediately_usable_qty = fields.Float(
         digits=dp.get_precision('Product Unit of Measure'),

--- a/stock_available/models/product_template.py
+++ b/stock_available/models/product_template.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields, api
 from openerp.addons import decimal_precision as dp

--- a/stock_available/models/res_config.py
+++ b/stock_available/models/res_config.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields
 

--- a/stock_available_immediately/__init__.py
+++ b/stock_available_immediately/__init__.py
@@ -1,21 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Author Guewen Baconnier. Copyright Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/stock_available_immediately/__openerp__.py
+++ b/stock_available_immediately/__openerp__.py
@@ -22,7 +22,7 @@
 
 {
     "name": "Ignore planned receptions in quantity available to promise",
-    "version": "8.0.2.0.0",
+    "version": "8.0.2.0.1",
     "depends": ["stock_available"],
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/stock_available_immediately/__openerp__.py
+++ b/stock_available_immediately/__openerp__.py
@@ -1,24 +1,7 @@
 # -*- coding: utf-8 -*-
-#
-#
-#    Author: Guewen Baconnier
-#    Copyright 2010-2012 Camptocamp SA
-#    Copyright (C) 2011 Akretion Sébastien BEAU <sebastien.beau@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
+# © 2010-2012 Camptocamp SA
+# © 2011 Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Ignore planned receptions in quantity available to promise",

--- a/stock_available_immediately/models/__init__.py
+++ b/stock_available_immediately/models/__init__.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Author Guewen Baconnier. Copyright Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import product_product
 from . import product_template

--- a/stock_available_immediately/models/__init__.py
+++ b/stock_available_immediately/models/__init__.py
@@ -19,3 +19,4 @@
 ##############################################################################
 
 from . import product_product
+from . import product_template

--- a/stock_available_immediately/models/product_product.py
+++ b/stock_available_immediately/models/product_product.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright 2010-2012 Camptocamp SA
-#    Copyright (C) 2011 Akretion Sébastien BEAU <sebastien.beau@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2010-2012 Camptocamp SA
+# © 2011 Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, api
 

--- a/stock_available_immediately/models/product_product.py
+++ b/stock_available_immediately/models/product_product.py
@@ -28,7 +28,9 @@ class ProductProduct(models.Model):
     @api.multi
     @api.depends('virtual_available', 'incoming_qty')
     def _immediately_usable_qty(self):
-        """Ignore the incoming goods in the quantity available to promise"""
+        """Ignore the incoming goods in the quantity available to promise
+
+        This is the same implementation as for templates."""
         super(ProductProduct, self)._immediately_usable_qty()
         for prod in self:
             prod.immediately_usable_qty -= prod.incoming_qty

--- a/stock_available_immediately/models/product_template.py
+++ b/stock_available_immediately/models/product_template.py
@@ -18,16 +18,18 @@
 #
 ##############################################################################
 
-{
-    'name': 'Stock available to promise',
-    'version': '8.0.3.0.0',
-    "author": u"Numérigraphe,Odoo Community Association (OCA)",
-    'category': 'Warehouse',
-    'depends': ['stock'],
-    'license': 'AGPL-3',
-    'data': [
-        'views/product_template_view.xml',
-        'views/product_product_view.xml',
-        'views/res_config_view.xml',
-    ]
-}
+from openerp import models, api
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    @api.multi
+    @api.depends('virtual_available', 'incoming_qty')
+    def _immediately_usable_qty(self):
+        """Ignore the incoming goods in the quantity available to promise
+
+        This is the same implementation as for variants."""
+        super(ProductTemplate, self)._immediately_usable_qty()
+        for tmpl in self:
+            tmpl.immediately_usable_qty -= tmpl.incoming_qty

--- a/stock_available_immediately/models/product_template.py
+++ b/stock_available_immediately/models/product_template.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2015 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, api
 

--- a/stock_available_immediately/tests/__init__.py
+++ b/stock_available_immediately/tests/__init__.py
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
+# © 2015 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_stock_available_immediately

--- a/stock_available_immediately/tests/test_stock_available_immediately.py
+++ b/stock_available_immediately/tests/test_stock_available_immediately.py
@@ -1,22 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2015 Therp BV <http://therp.nl>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2015 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp.tests.common import TransactionCase
 
 


### PR DESCRIPTION
There are cases where we dot NOT want to simply sum the quantities of all the variants. For example when dealing with manufacturing capacities, we may have to chose between variants because we can't make ALL of them with the same components.
So instead of a simple non-modular implementation, we'll let each module define his own implementation of how to compute the product template's quantity available for sale.
