### PR TITLE
[8.0] stock_available_mrp : configure compute potential

### DIFF
--- a/stock_available/README.rst
+++ b/stock_available/README.rst
@@ -11,6 +11,8 @@ promise for each product.
 This quantity is based on the projected stock and, depending on the
 configuration, it can account for various data such as sales quotations or
 immediate production capacity.
+In case of immediate production capacity, it is possible to configure on which
+field the potential is computed, by default Quantity On Hand is used.
 This can be configured in the menu Settings > Configuration > Warehouse.
 
 Configuration
@@ -21,6 +23,8 @@ stock.
 To take davantage of the additional features, you must which information you
 want to base the computation, by checking one or more boxes in the settings:
 `Configuration` > `Warehouse` > `Stock available to promise`.
+In case of "Include the production potential", it is also possible to configure
+which field of product to use to compute the production potential.
 
 Usage
 =====

--- a/stock_available/__openerp__.py
+++ b/stock_available/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Stock available to promise',
-    'version': '8.0.3.0.0',
+    'version': '8.0.3.1.0',
     "author": u"Numérigraphe,Odoo Community Association (OCA)",
     'category': 'Warehouse',
     'depends': ['stock'],

--- a/stock_available/models/res_config.py
+++ b/stock_available/models/res_config.py
@@ -2,12 +2,21 @@
 # © 2014 Numérigraphe SARL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, fields
+from openerp import api, models, fields
+from openerp.tools.safe_eval import safe_eval
 
 
 class StockConfig(models.TransientModel):
     """Add options to easily install the submodules"""
     _inherit = 'stock.config.settings'
+
+    @api.model
+    def _get_stock_available_mrp_based_on(self):
+        """Gets the available languages for the selection."""
+        fields = self.env['ir.model.fields'].search(
+            [('model', '=', 'product.product'),
+             ('ttype', '=', 'float')])
+        return [(field.name, field.field_description) for field in fields]
 
     module_stock_available_immediately = fields.Boolean(
         string='Exclude incoming goods',
@@ -31,3 +40,27 @@ class StockConfig(models.TransientModel):
              "This installs the module stock_available_mrp.\n"
              "If the module mrp is not installed, this will install it "
              "too")
+
+    stock_available_mrp_based_on = fields.Selection(
+        _get_stock_available_mrp_based_on,
+        string='based on',
+        help="Choose the field of the product which will be used to compute "
+             "potential.\nIf empty, Quantity On Hand is used.",
+    )
+
+    @api.model
+    def get_default_stock_available_mrp_based_on(self, fields):
+        res = {}
+        icp = self.env['ir.config_parameter']
+        res['stock_available_mrp_based_on'] = safe_eval(
+            icp.get_param('stock_available_mrp_based_on', 'False'))
+        if not res['stock_available_mrp_based_on']:
+            res['stock_available_mrp_based_on'] = 'qty_available'
+        return res
+
+    @api.multi
+    def set_stock_available_mrp_based_on(self):
+        if self.stock_available_mrp_based_on:
+            icp = self.env['ir.config_parameter']
+            icp.set_param('stock_available_mrp_based_on',
+                          repr(self.stock_available_mrp_based_on))

--- a/stock_available/views/res_config_view.xml
+++ b/stock_available/views/res_config_view.xml
@@ -22,6 +22,8 @@
                                 <div>
                                     <field name="module_stock_available_mrp" class="oe_inline" />
                                     <label for="module_stock_available_mrp" />
+                                    <label for="stock_available_mrp_based_on" />
+                                    <field name="stock_available_mrp_based_on" class="oe_inline" attrs="{'required':[('module_stock_available_mrp','=',True)]}"/>
                                 </div>
                             </div>
                         </group>

--- a/stock_available_mrp/README.rst
+++ b/stock_available_mrp/README.rst
@@ -9,6 +9,9 @@ Consider the production potential is available to promise
 This module takes the potential quantities available for Products into account in
 the quantity available to promise, where the "Potential quantity" is the
 quantity that can be manufactured with the components immediately at hand.
+By configuration, the "Potential quantity" can be computed based on other product field.
+For example, "Potential quantity" can be the quantity that can be manufactured
+with the components available to promise.
 
 Usage
 =====

--- a/stock_available_mrp/__openerp__.py
+++ b/stock_available_mrp/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Consider the production potential is available to promise',
-    'version': '8.0.3.0.0',
+    'version': '8.0.3.1.0',
     "author": u"Numérigraphe,"
               u"Odoo Community Association (OCA)",
     'category': 'Hidden',


### PR DESCRIPTION
On configuration add new field : stock_available_mrp_based_on to configure which field to use when compute potential.

For example, in my case, I want potential quantity based on available to promise and not on quantity on hand.
