### PR TITLE
Mts mto name fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
-  - git clone https://github.com/OCA/stock-logistics-tracking -b ${VERSION} $HOME/stock-logistics-tracking
-  - git clone https://github.com/OCA/stock-logistics-barcode -b ${VERSION} $HOME/stock-logistics-barcode
 
 script:
     - travis_run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 
 env:
   global:
-  - VERSION="8.0" TESTS="0" LINT_CHECK="0"
+  - VERSION="9.0" TESTS="0" LINT_CHECK="0"
   - TRANSIFEX_USER='transbot@odoo-community.org'
   - secure: tDsvZaY3JqmnjgyRuKkgQRtlRILkkjnHtZPWWaGg+KBD+BBH4AqX5ACTyu5U/J6Kr/Yb5NIoM3+NYRuASdGXnJb9siZvh/9B58B1wKUbC2umH4Yrpw66CEvG9JY4XMOCZni9kQBwQ7iMk5GfusDWuVuydZjd6dAqkCxz6JdkIco=
   matrix:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/OCA/stock-logistics-warehouse.svg?branch=8.0)](https://travis-ci.org/OCA/stock-logistics-warehouse)
-[![Coverage Status](https://img.shields.io/coveralls/OCA/stock-logistics-warehouse/badge.png?branch=8.0)](https://coveralls.io/r/OCA/stock-logistics-warehouse?branch=8.0)
+[![Build Status](https://travis-ci.org/OCA/stock-logistics-warehouse.svg?branch=9.0)](https://travis-ci.org/OCA/stock-logistics-warehouse)
+[![Coverage Status](https://img.shields.io/coveralls/OCA/stock-logistics-warehouse/badge.png?branch=9.0)](https://coveralls.io/r/OCA/stock-logistics-warehouse?branch=9.0)
 
 Odoo Stock Logistic Warehouse
 =============================
@@ -18,35 +18,4 @@ Please don't hesitate to suggest one of your module to this project. Also, you m
  - https://github.com/OCA/stock-logistics-workflow
 
 [//]: # (addons)
-Available addons
-----------------
-addon | version | summary
---- | --- | ---
-[stock_available](stock_available/) | 8.0.2.0.0 | Stock available to promise
-[stock_available_immediately](stock_available_immediately/) | 8.0.2.0.0 | Ignore planned receptions in quantity available to promise
-[stock_inventory_preparation_filter](stock_inventory_preparation_filter/) | 8.0.1.0.0 | More filters for inventory adjustments
-[stock_location_area_data](stock_location_area_data/) | 8.0.0.1.0 | Add surface units of measure
-[stock_location_area_management](stock_location_area_management/) | 8.0.0.1.0 | Enter a location's area based on different units of measure
-[stock_location_ownership](stock_location_ownership/) | 8.0.0.1.0 | Stock Location Ownership
-[stock_mts_mto_rule](stock_mts_mto_rule/) | 8.0.1.0.0 | Add a MTS+MTO route
-[stock_reserve](stock_reserve/) | 8.0.0.2.0 | Stock reservations on products
-[stock_reserve_sale](stock_reserve_sale/) | 8.0.1.0.0 | Stock Reserve Sales
-
-Unported addons
----------------
-addon | version | summary
---- | --- | ---
-[base_product_merge](base_product_merge/) | 1.0 (unported) | Base Products Merge
-[configurable_stock_level](configurable_stock_level/) | 0.1 (unported) | name
-[stock_available_mrp](stock_available_mrp/) | 2.0 (unported) | Consider the production potential is available to promise
-[stock_available_sale](stock_available_sale/) | 2.0 (unported) | Quotations in quantity available to promise
-[stock_inventory_existing_lines](stock_inventory_existing_lines/) | 1.0 (unported) | Inventory Extended
-[stock_inventory_extended](stock_inventory_extended/) | 1.0 (unported) | Move Inventory Extended
-[stock_inventory_with_location](stock_inventory_with_location/) | 1.0 (unported) | Move Inventory Extended
-[stock_lot_valuation](stock_lot_valuation/) | 0.1 (unported) | Lot Valuation
-[stock_move_location](stock_move_location/) | 1.0 (unported) | Move Stock Location
-[stock_optional_valuation](stock_optional_valuation/) | 0.1 (unported) | Stock optional valuation
-[stock_orderpoint_creator](stock_orderpoint_creator/) | 1.0 (unported) | Configuration of order point in mass
-[stock_reord_rule](stock_reord_rule/) | 0.2 (unported) | Improved reordering rules
-
 [//]: # (end addons)

--- a/README.md
+++ b/README.md
@@ -18,14 +18,19 @@ Please don't hesitate to suggest one of your module to this project. Also, you m
  - https://github.com/OCA/stock-logistics-workflow
 
 [//]: # (addons)
+Available addons
+----------------
+addon | version | summary
+--- | --- | ---
+[stock_available](stock_available/) | 9.0.1.0.0 | Stock available to promise
+[stock_available_immediately](stock_available_immediately/) | 9.0.1.0.0 | Ignore planned receptions in quantity available to promise
+
 Unported addons
 ---------------
 addon | version | summary
 --- | --- | ---
 [base_product_merge](base_product_merge/) | 1.0 (unported) | Base Products Merge
 [configurable_stock_level](configurable_stock_level/) | 0.1 (unported) | name
-[stock_available](stock_available/) | 8.0.2.0.0 (unported) | Stock available to promise
-[stock_available_immediately](stock_available_immediately/) | 8.0.2.0.0 (unported) | Ignore planned receptions in quantity available to promise
 [stock_available_mrp](stock_available_mrp/) | 2.0 (unported) | Consider the production potential is available to promise
 [stock_available_sale](stock_available_sale/) | 2.0 (unported) | Quotations in quantity available to promise
 [stock_inventory_existing_lines](stock_inventory_existing_lines/) | 1.0 (unported) | Inventory Extended

--- a/README.md
+++ b/README.md
@@ -18,4 +18,30 @@ Please don't hesitate to suggest one of your module to this project. Also, you m
  - https://github.com/OCA/stock-logistics-workflow
 
 [//]: # (addons)
+Unported addons
+---------------
+addon | version | summary
+--- | --- | ---
+[base_product_merge](base_product_merge/) | 1.0 (unported) | Base Products Merge
+[configurable_stock_level](configurable_stock_level/) | 0.1 (unported) | name
+[stock_available](stock_available/) | 8.0.2.0.0 (unported) | Stock available to promise
+[stock_available_immediately](stock_available_immediately/) | 8.0.2.0.0 (unported) | Ignore planned receptions in quantity available to promise
+[stock_available_mrp](stock_available_mrp/) | 2.0 (unported) | Consider the production potential is available to promise
+[stock_available_sale](stock_available_sale/) | 2.0 (unported) | Quotations in quantity available to promise
+[stock_inventory_existing_lines](stock_inventory_existing_lines/) | 1.0 (unported) | Inventory Extended
+[stock_inventory_extended](stock_inventory_extended/) | 1.0 (unported) | Move Inventory Extended
+[stock_inventory_preparation_filter](stock_inventory_preparation_filter/) | 8.0.1.0.0 (unported) | More filters for inventory adjustments
+[stock_inventory_with_location](stock_inventory_with_location/) | 1.0 (unported) | Move Inventory Extended
+[stock_location_area_data](stock_location_area_data/) | 8.0.0.1.0 (unported) | Add surface units of measure
+[stock_location_area_management](stock_location_area_management/) | 8.0.0.1.0 (unported) | Enter a location's area based on different units of measure
+[stock_location_ownership](stock_location_ownership/) | 8.0.0.1.0 (unported) | Stock Location Ownership
+[stock_lot_valuation](stock_lot_valuation/) | 0.1 (unported) | Lot Valuation
+[stock_move_location](stock_move_location/) | 1.0 (unported) | Move Stock Location
+[stock_mts_mto_rule](stock_mts_mto_rule/) | 8.0.1.0.0 (unported) | Add a MTS+MTO route
+[stock_optional_valuation](stock_optional_valuation/) | 0.1 (unported) | Stock optional valuation
+[stock_orderpoint_creator](stock_orderpoint_creator/) | 1.0 (unported) | Configuration of order point in mass
+[stock_reord_rule](stock_reord_rule/) | 0.2 (unported) | Improved reordering rules
+[stock_reserve](stock_reserve/) | 8.0.0.2.0 (unported) | Stock reservations on products
+[stock_reserve_sale](stock_reserve_sale/) | 8.0.1.0.0 (unported) | Stock Reserve Sales
+
 [//]: # (end addons)

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,2 @@
+stock-logistics-tracking
+stock-logistics-barcode

--- a/stock_available/README.rst
+++ b/stock_available/README.rst
@@ -31,6 +31,7 @@ Contributors
 ------------
 
 * Lionel Sausin (Numérigraphe) <ls@numerigraphe.com>
+* Sodexis <sodexis@sodexis.com>
 * many others contributed to sub-modules, please refer to each sub-module's credits
 
 Maintainer

--- a/stock_available/__init__.py
+++ b/stock_available/__init__.py
@@ -1,21 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe, Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/stock_available/__openerp__.py
+++ b/stock_available/__openerp__.py
@@ -30,4 +30,5 @@
         'views/product_product_view.xml',
         'views/res_config_view.xml',
     ]
+    'installable': False,
 }

--- a/stock_available/__openerp__.py
+++ b/stock_available/__openerp__.py
@@ -1,27 +1,11 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe, Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Stock available to promise',
-    'version': '8.0.2.0.0',
-    "author": u"Numérigraphe,Odoo Community Association (OCA)",
+    'version': '9.0.1.0.0',
+    "author": "Numérigraphe, Sodexis, Odoo Community Association (OCA)",
     'category': 'Warehouse',
     'depends': ['stock'],
     'license': 'AGPL-3',
@@ -30,5 +14,5 @@
         'views/product_product_view.xml',
         'views/res_config_view.xml',
     ],
-    'installable': False,
+    'installable': True,
 }

--- a/stock_available/__openerp__.py
+++ b/stock_available/__openerp__.py
@@ -29,6 +29,6 @@
         'views/product_template_view.xml',
         'views/product_product_view.xml',
         'views/res_config_view.xml',
-    ]
+    ],
     'installable': False,
 }

--- a/stock_available/i18n/en.po
+++ b/stock_available/i18n/en.po
@@ -5,12 +5,12 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: stock-logistics-warehouse (8.0)\n"
+"Project-Id-Version: stock-logistics-warehouse (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-23 20:23+0000\n"
-"PO-Revision-Date: 2015-09-17 15:40+0000\n"
+"POT-Creation-Date: 2016-02-27 01:43+0000\n"
+"PO-Revision-Date: 2016-02-26 12:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: English (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-8-0/language/en/)\n"
+"Language-Team: English (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-9-0/language/en/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -18,12 +18,24 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: stock_available
-#: view:product.template:stock_available.view_stock_available_kanban
-msgid "Available to promise:"
-msgstr "Available to promise:"
+#: model:ir.ui.view,arch_db:stock_available.product_normal_form_view
+#: model:ir.ui.view,arch_db:stock_available.view_stock_available_form
+msgid "<span class=\"o_stat_text\">Available</span>"
+msgstr "<span class=\"o_stat_text\">Available</span>"
 
 #. module: stock_available
-#: field:stock.config.settings,module_stock_available_immediately:0
+#: model:ir.ui.view,arch_db:stock_available.view_stock_available_kanban
+msgid "Available to Promise:"
+msgstr "Available to Promise:"
+
+#. module: stock_available
+#: model:ir.model.fields,field_description:stock_available.field_product_product_immediately_usable_qty
+#: model:ir.model.fields,field_description:stock_available.field_product_template_immediately_usable_qty
+msgid "Available to promise"
+msgstr "Available to promise"
+
+#. module: stock_available
+#: model:ir.model.fields,field_description:stock_available.field_stock_config_settings_module_stock_available_immediately
 msgid "Exclude incoming goods"
 msgstr "Exclude incoming goods"
 
@@ -38,22 +50,26 @@ msgid "Product Template"
 msgstr "Product Template"
 
 #. module: stock_available
-#: view:stock.config.settings:stock_available.view_stock_configuration
+#: model:ir.ui.view,arch_db:stock_available.view_stock_configuration
 msgid "Stock available to promise"
 msgstr "Stock available to promise"
 
 #. module: stock_available
-#: help:stock.config.settings,module_stock_available_immediately:0
+#: model:ir.model.fields,help:stock_available.field_product_product_immediately_usable_qty
+#: model:ir.model.fields,help:stock_available.field_product_template_immediately_usable_qty
+msgid ""
+"Stock for this Product that can be safely proposed for sale to Customers.\n"
+"The definition of this value can be configured to suit your needs"
+msgstr "Stock for this Product that can be safely proposed for sale to Customers.\nThe definition of this value can be configured to suit your needs"
+
+#. module: stock_available
+#: model:ir.model.fields,help:stock_available.field_stock_config_settings_module_stock_available_immediately
 msgid ""
 "This will subtract incoming quantities from the quantities available to promise.\n"
 "This installs the module stock_available_immediately."
 msgstr "This will subtract incoming quantities from the quantities available to promise.\nThis installs the module stock_available_immediately."
 
 #. module: stock_available
-#: view:product.product:stock_available.view_stock_available_tree_variant
-#: view:product.template:stock_available.view_stock_available_tree
-msgid ""
-"red:immediately_usable_qty<0;blue:immediately_usable_qty>=0 and state in "
-"('draft', 'end', 'obsolete');black:immediately_usable_qty>=0 and state not "
-"in ('draft', 'end', 'obsolete')"
-msgstr "red:immediately_usable_qty<0;blue:immediately_usable_qty>=0 and state in ('draft', 'end', 'obsolete');black:immediately_usable_qty>=0 and state not in ('draft', 'end', 'obsolete')"
+#: model:ir.model,name:stock_available.model_stock_config_settings
+msgid "stock.config.settings"
+msgstr "stock.config.settings"

--- a/stock_available/i18n/fr.po
+++ b/stock_available/i18n/fr.po
@@ -6,12 +6,12 @@
 # Pierre Verkest <pverkest@anybox.fr>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: stock-logistics-warehouse (8.0)\n"
+"Project-Id-Version: stock-logistics-warehouse (9.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-23 20:23+0000\n"
-"PO-Revision-Date: 2015-09-27 20:28+0000\n"
-"Last-Translator: Pierre Verkest <pverkest@anybox.fr>\n"
-"Language-Team: French (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-8-0/language/fr/)\n"
+"POT-Creation-Date: 2016-02-27 01:43+0000\n"
+"PO-Revision-Date: 2016-02-26 16:56+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"Language-Team: French (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-9-0/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -19,12 +19,24 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: stock_available
-#: view:product.template:stock_available.view_stock_available_kanban
-msgid "Available to promise:"
-msgstr "Disponible à la vente:"
+#: model:ir.ui.view,arch_db:stock_available.product_normal_form_view
+#: model:ir.ui.view,arch_db:stock_available.view_stock_available_form
+msgid "<span class=\"o_stat_text\">Available</span>"
+msgstr ""
 
 #. module: stock_available
-#: field:stock.config.settings,module_stock_available_immediately:0
+#: model:ir.ui.view,arch_db:stock_available.view_stock_available_kanban
+msgid "Available to Promise:"
+msgstr ""
+
+#. module: stock_available
+#: model:ir.model.fields,field_description:stock_available.field_product_product_immediately_usable_qty
+#: model:ir.model.fields,field_description:stock_available.field_product_template_immediately_usable_qty
+msgid "Available to promise"
+msgstr ""
+
+#. module: stock_available
+#: model:ir.model.fields,field_description:stock_available.field_stock_config_settings_module_stock_available_immediately
 msgid "Exclude incoming goods"
 msgstr "Exclure les receptions attendues"
 
@@ -39,22 +51,26 @@ msgid "Product Template"
 msgstr "Modèle de produit"
 
 #. module: stock_available
-#: view:stock.config.settings:stock_available.view_stock_configuration
+#: model:ir.ui.view,arch_db:stock_available.view_stock_configuration
 msgid "Stock available to promise"
 msgstr "Stock disponible à la vente"
 
 #. module: stock_available
-#: help:stock.config.settings,module_stock_available_immediately:0
+#: model:ir.model.fields,help:stock_available.field_product_product_immediately_usable_qty
+#: model:ir.model.fields,help:stock_available.field_product_template_immediately_usable_qty
+msgid ""
+"Stock for this Product that can be safely proposed for sale to Customers.\n"
+"The definition of this value can be configured to suit your needs"
+msgstr ""
+
+#. module: stock_available
+#: model:ir.model.fields,help:stock_available.field_stock_config_settings_module_stock_available_immediately
 msgid ""
 "This will subtract incoming quantities from the quantities available to promise.\n"
 "This installs the module stock_available_immediately."
 msgstr "Ceci soustrait les réceptions attendues des quantitiés disponibles à la vente.\nCeci installe le module stock_available_immediately."
 
 #. module: stock_available
-#: view:product.product:stock_available.view_stock_available_tree_variant
-#: view:product.template:stock_available.view_stock_available_tree
-msgid ""
-"red:immediately_usable_qty<0;blue:immediately_usable_qty>=0 and state in "
-"('draft', 'end', 'obsolete');black:immediately_usable_qty>=0 and state not "
-"in ('draft', 'end', 'obsolete')"
-msgstr "red:immediately_usable_qty<0;blue:immediately_usable_qty>=0 and state in ('draft', 'end', 'obsolete');black:immediately_usable_qty>=0 and state not in ('draft', 'end', 'obsolete')"
+#: model:ir.model,name:stock_available.model_stock_config_settings
+msgid "stock.config.settings"
+msgstr ""

--- a/stock_available/models/__init__.py
+++ b/stock_available/models/__init__.py
@@ -1,23 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe, Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import product_template
-from . import product_product
-from . import res_config
+from . import product_template, product_product, res_config

--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -1,28 +1,13 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe, Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields, api
 from openerp.addons import decimal_precision as dp
 
 
 class ProductProduct(models.Model):
+
     """Add a field for the stock available to promise.
     Useful implementations need to be installed through the Settings menu or by
     installing one of the modules stock_available_*

--- a/stock_available/models/product_template.py
+++ b/stock_available/models/product_template.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe, Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields, api
 from openerp.addons import decimal_precision as dp

--- a/stock_available/models/res_config.py
+++ b/stock_available/models/res_config.py
@@ -1,27 +1,12 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Numérigraphe, Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields
 
 
 class StockConfig(models.TransientModel):
+
     """Add options to easily install the submodules"""
     _inherit = 'stock.config.settings'
 

--- a/stock_available/views/product_product_view.xml
+++ b/stock_available/views/product_product_view.xml
@@ -1,19 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- © 2014 Numérigraphe, Sodexis
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+
 <openerp>
     <data>
-        <record model="ir.ui.view" id="view_stock_available_tree_variant">
+        <record model="ir.ui.view" id="product_normal_form_view">
             <field name="name">Quantity available to promise (variant tree)</field>
             <field name="model">product.product</field>
-            <field name="inherit_id" ref="stock.view_stock_product_tree"/>
+            <field name="inherit_id" ref="stock.product_form_view_procurement_button" />
             <field name="arch" type="xml">
-                <data>
-                    <tree position="attributes">
-                        <attribute name="colors">red:immediately_usable_qty&lt;0;blue:immediately_usable_qty&gt;=0 and state in ('draft', 'end', 'obsolete');black:immediately_usable_qty&gt;=0 and state not in ('draft', 'end', 'obsolete')</attribute>
-                    </tree>
-                       <field name="virtual_available" position="after">
-                       <field name="immediately_usable_qty" />
-                    </field>
-                </data>
+                <xpath expr="//button[@name='%(stock.action_stock_level_forecast_report_product)d']"
+                    position="after">
+                    <button type="action" name="%(stock.product_open_quants)d"
+                        attrs="{'invisible':[('type', '!=', 'product')]}"
+                        class="oe_stat_button" icon="fa-building-o">
+                        <div class="o_form_field o_stat_info">
+                            <field name="immediately_usable_qty"
+                                widget="statinfo" nolabel="1" />
+                            <span class="o_stat_text">Available</span>
+                        </div>
+                    </button>
+                </xpath>
             </field>
         </record>
     </data>

--- a/stock_available/views/product_template_view.xml
+++ b/stock_available/views/product_template_view.xml
@@ -1,42 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- © 2014 Numérigraphe, Sodexis
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+
 <openerp>
     <data>
         <record model="ir.ui.view" id="view_stock_available_form">
             <field name="name">Quantity available to promise (form)</field>
             <field name="model">product.template</field>
-            <field name="inherit_id" ref="stock.view_template_property_form"/>
+            <field name="inherit_id" ref="stock.product_template_form_view_procurement_button" />
             <field name="arch" type="xml">
-                <field name="virtual_available" position="after">
-                    <newline/>
-                    <field name="immediately_usable_qty" />
-                </field>
+                <xpath expr="//button[@name='%(stock.action_stock_level_forecast_report_template)d']"
+                    position="after">
+                    <button type="object" name="action_open_quants"
+                        attrs="{'invisible':[('type', '!=', 'product')]}"
+                        class="oe_stat_button" icon="fa-building-o">
+                        <div class="o_form_field o_stat_info">
+                            <field name="immediately_usable_qty"
+                                widget="statinfo" nolabel="1" />
+                            <span class="o_stat_text">Available</span>
+                        </div>
+                    </button>
+                </xpath>
             </field>
         </record>
-        
         <record model="ir.ui.view" id="view_stock_available_tree">
             <field name="name">Quantity available to promise (tree)</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="stock.view_stock_product_template_tree"/>
             <field name="arch" type="xml">
-                <data>
-                    <tree position="attributes">
-                        <attribute name="colors">red:immediately_usable_qty&lt;0;blue:immediately_usable_qty&gt;=0 and state in ('draft', 'end', 'obsolete');black:immediately_usable_qty&gt;=0 and state not in ('draft', 'end', 'obsolete')</attribute>
-                    </tree>
-                       <field name="virtual_available" position="after">
-                       <field name="immediately_usable_qty" />
-                    </field>
-                </data>
+                <tree position="attributes">
+                    <attribute name="colors">red:immediately_usable_qty&lt;0;blue:immediately_usable_qty&gt;=0 and state in ('draft', 'end', 'obsolete');black:immediately_usable_qty&gt;=0 and state not in ('draft', 'end', 'obsolete')</attribute>
+                </tree>
+                <field name="virtual_available" position="after">
+                   <field name="immediately_usable_qty" />
+                </field>
             </field>
         </record>
-
         <record model="ir.ui.view" id="view_stock_available_kanban">
             <field name="name">Quantity available to promise (kanban)</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="stock.product_template_kanban_stock_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='virtual_available']/.." position="replace">
-                    <li t-if="record.type.raw_value != 'service'">Available to promise: <field name="immediately_usable_qty"/> <field name="uom_id"/></li>
-                </xpath>
+                <ul position="inside">
+                    <li t-if="record.type.raw_value == 'product'">Available to Promise: <field name="immediately_usable_qty"/> <field name="uom_id"/></li>
+                </ul>
             </field>
         </record>
     </data>

--- a/stock_available/views/res_config_view.xml
+++ b/stock_available/views/res_config_view.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- © 2014 Numérigraphe, Sodexis
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+
 <openerp>
     <data>
         <record id="view_stock_configuration" model="ir.ui.view">
@@ -12,7 +15,8 @@
                             <label for="id" string="Stock available to promise" />
                             <div>
                                 <div>
-                                    <field name="module_stock_available_immediately" class="oe_inline" />
+                                    <field name="module_stock_available_immediately"
+                                        class="oe_inline" />
                                     <label for="module_stock_available_immediately" />
                                 </div>
                                 <!-- <div>

--- a/stock_available_immediately/README.rst
+++ b/stock_available_immediately/README.rst
@@ -15,6 +15,7 @@ Contributors
 * Author: Guewen Baconnier (Camptocamp SA)
 * Sébastien BEAU (Akretion) <sebastien.beau@akretion.com>
 * Lionel Sausin (Numérigraphe) <ls@numerigraphe.com>
+* Sodexis <sodexis@sodexis.com>
 
 Maintainer
 ----------

--- a/stock_available_immediately/__init__.py
+++ b/stock_available_immediately/__init__.py
@@ -1,21 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Author Guewen Baconnier. Copyright Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Camptocamp, Akretion, Numérigraphe, Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/stock_available_immediately/__openerp__.py
+++ b/stock_available_immediately/__openerp__.py
@@ -1,31 +1,13 @@
 # -*- coding: utf-8 -*-
-#
-#
-#    Author: Guewen Baconnier
-#    Copyright 2010-2012 Camptocamp SA
-#    Copyright (C) 2011 Akretion Sébastien BEAU <sebastien.beau@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
+# © 2014 Camptocamp, Akretion, Numérigraphe, Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Ignore planned receptions in quantity available to promise",
-    "version": "8.0.2.0.0",
+    "version": "9.0.1.0.0",
     "depends": ["stock_available"],
-    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Sodexis,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Hidden",
-    'installable': False
+    'installable': True
 }

--- a/stock_available_immediately/__openerp__.py
+++ b/stock_available_immediately/__openerp__.py
@@ -27,5 +27,5 @@
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Hidden",
-    'installable': True
+    'installable': False
 }

--- a/stock_available_immediately/i18n/en.po
+++ b/stock_available_immediately/i18n/en.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_available_immediately
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: stock-logistics-warehouse (9.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-02-27 01:43+0000\n"
+"PO-Revision-Date: 2016-02-26 12:25+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"Language-Team: English (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-9-0/language/en/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: stock_available_immediately
+#: model:ir.model,name:stock_available_immediately.model_product_product
+msgid "Product"
+msgstr "Product"

--- a/stock_available_immediately/models/__init__.py
+++ b/stock_available_immediately/models/__init__.py
@@ -1,21 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Author Guewen Baconnier. Copyright Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Camptocamp, Akretion, Numérigraphe, Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import product_product

--- a/stock_available_immediately/models/product_product.py
+++ b/stock_available_immediately/models/product_product.py
@@ -1,23 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright 2010-2012 Camptocamp SA
-#    Copyright (C) 2011 Akretion Sébastien BEAU <sebastien.beau@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Camptocamp, Akretion, Numérigraphe, Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, api
 

--- a/stock_inventory_preparation_filter/__openerp__.py
+++ b/stock_inventory_preparation_filter/__openerp__.py
@@ -37,5 +37,5 @@
         "views/stock_inventory_view.xml",
         "security/ir.model.access.csv",
     ],
-    "installable": True,
+    'installable': False,
 }

--- a/stock_location_area_data/__openerp__.py
+++ b/stock_location_area_data/__openerp__.py
@@ -34,6 +34,6 @@
     'data': [
         'data/stock_location_area_data.xml',
     ],
-    'installable': True,
+    'installable': False,
     'application': False,
 }

--- a/stock_location_area_management/__openerp__.py
+++ b/stock_location_area_management/__openerp__.py
@@ -36,6 +36,6 @@
         'views/res_company.xml',
         'views/stock_location.xml',
     ],
-    'installable': True,
+    'installable': False,
     'application': False,
 }

--- a/stock_location_ownership/__openerp__.py
+++ b/stock_location_ownership/__openerp__.py
@@ -34,5 +34,5 @@
           ],
  'test': [],
  'auto_install': False,
- 'installable': True,
+ 'installable': False,
  }

--- a/stock_move_location/stock.py
+++ b/stock_move_location/stock.py
@@ -19,8 +19,9 @@
 #
 #################################################################################
 
-from osv import fields, osv
-from tools.translate import _
+from openerp.osv import fields, osv
+from openerop.tools.translate import _
+from openerp.tools.safe_eval import safe_eval
 
 #class stock_fill_inventory(osv.osv_memory):
 #    _inherit = "stock.fill.inventory"
@@ -116,7 +117,7 @@ class stock_inventory(osv.osv):
             model_id = mod_obj.search(cr, uid, [('name', '=', 'inventory_acquisition_link_1')])[0]
             act_id = mod_obj.read(cr, uid, model_id, ['res_id'])['res_id']
             act = act_obj.read(cr, uid, act_id)
-            context = eval(act['context'])
+            context = safe_eval(act['context'])
             context['default_inventory_id'] = inventory_data.id
             context['default_name'] = inventory_data.name
             act['context'] = context

--- a/stock_mts_mto_rule/__openerp__.py
+++ b/stock_mts_mto_rule/__openerp__.py
@@ -34,5 +34,5 @@
           'view/pull_rule.xml',
           'view/warehouse.xml',
           ],
- 'installable': True,
+ 'installable': False,
  }

--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -47,7 +47,7 @@ class ProcurementOrder(models.Model):
         origin = (proc.group_id and (proc.group_id.name + ":") or "") + \
                  (proc.rule_id and proc.rule_id.name or proc.origin or "/")
         return {
-            'name': rule.name,
+            'name': proc.name,
             'origin': origin,
             'product_qty': qty,
             'product_uos_qty': uos_qty,

--- a/stock_reserve/__openerp__.py
+++ b/stock_reserve/__openerp__.py
@@ -39,5 +39,5 @@
  'auto_install': False,
  'test': ['test/stock_reserve.yml',
           ],
- 'installable': True,
+ 'installable': False,
  }

--- a/stock_reserve_sale/__openerp__.py
+++ b/stock_reserve_sale/__openerp__.py
@@ -38,6 +38,6 @@
  'test': ['test/sale_reserve.yml',
           'test/sale_line_reserve.yml',
           ],
- 'installable': True,
+ 'installable': False,
  'auto_install': False,
  }


### PR DESCRIPTION
Stock move names are taken from rule instead of procurement. Normally it shows product name on other rules but it becomes "WH:Stock -> Customer"  in mto_mts_rule. (It is not intentional, is it?)

This commit turns is to product name. 
