### PR TITLE
stock move name fix

### DIFF
--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -56,7 +56,7 @@ class ProcurementOrder(models.Model):
         origin = (proc.group_id and (proc.group_id.name + ":") or "") + \
                  (proc.rule_id and proc.rule_id.name or proc.origin or "/")
         return {
-            'name': rule.name,
+            'name': proc.name,
             'origin': origin,
             'product_qty': qty,
             'product_uos_qty': uos_qty,


### PR DESCRIPTION
Stock move names are taken from rule instead of procurement. Normally it shows product name on other rules but it becomes "WH:Stock -> Customer"  in mto_mts_rule. (It is not intentional, is it?)

This commit turns is to product name. 
