### PR TITLE
Do no run mts mto procurement if it already has been splited into at least another procurement

### DIFF
--- a/stock_mts_mto_rule/README.rst
+++ b/stock_mts_mto_rule/README.rst
@@ -49,6 +49,15 @@ Configuration
 
 You have to select 'Use MTO+MTS rules' on the company's warehouse form.
 
+Known issues
+============
+
+If you cancel a delivery order and then recreate it from Recreate
+Delivery Order button in sale order form, then the stock level at the time of
+the Re-Creation won't be taken into account. So if a purchase order was created
+when the sale order was first validated, a similar purchase order will be created
+during the Re-creation of the delivery order, even if not needed regarding the actual stock.
+
 Bug Tracker
 ===========
 

--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -92,6 +92,8 @@ class ProcurementOrder(models.Model):
     def _run(self, procurement):
         if procurement.rule_id and \
                 procurement.rule_id.action == 'split_procurement':
+            if procurement.mts_mto_procurement_ids:
+                return super(ProcurementOrder, self)._run(procurement)
             uom_obj = self.env['product.uom']
             needed_qty = procurement.get_mto_qty_to_order()
             rule = procurement.rule_id


### PR DESCRIPTION
Fix the issue https://github.com/OCA/stock-logistics-warehouse/issues/111

But the fix is not perfect, that is why I have updated the readme file to put a known issue.

Explanation : 
With mts+mto rule, a procurement is created and then splited into 1 or 2 procurements depending of the stock level:  one MTS and the other MTO.
If we cancel the delivery order, the 3 procurement are also canceled.
If we recreate the delivery order, from the sale order form, then, the 3 procurement are back to confirm state (because they are all linked to sale order line) and are run again.
So the mto procurement create one move, the mts procurement create one move, and the mts+mto procurement split again and create 2 more procurements which create also 2 moves.
Consequently, the quantity in the delivery order is doubled.

I made a quick fix so if the mts+mto procurement has already been splited, it can't do it again.
So if we run it again, it won't do anything.
The problem is that when we recreate the delivery order, we won't take the actual stock to split into mts and mto procurement. So the old mto and mts are taken from the old procurements.
Still, it is way better than have too much product in the delivery order.

If you have any idea to improve it, I would be glad to hear it.
An idea would be not to propagate sale_line_id on the splited procurements, but it may have other bad consequences. And I think it is better if they are linked to a sale order line anyway...
