### PR TITLE
Stock available mrp fix list view recursive qty

### DIFF
--- a/stock_available_mrp/__openerp__.py
+++ b/stock_available_mrp/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Consider the production potential is available to promise',
-    'version': '8.0.3.1.0',
+    'version': '8.0.3.1.1',
     "author": u"Numérigraphe,"
               u"Odoo Community Association (OCA)",
     'category': 'Hidden',


### PR DESCRIPTION
Depends on PRs #135  and #136 

Bug: 
For example  I have a product P1 with BOM like that: P1 needs 1 P2 which needs 1 P3.

With 5 P3 in stock, when available to promise includes the production potential based on component's available to promise, we should have 5 P1, 5 P2, 5P3  

In form view no problem, in list view we have 0 available to promise P1.
