### PR TITLE
[9.0] update stock_available / stock_available_immediately

### DIFF
--- a/stock_available/__openerp__.py
+++ b/stock_available/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Stock available to promise',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     "author": "Numérigraphe, Sodexis, Odoo Community Association (OCA)",
     'category': 'Warehouse',
     'depends': ['stock'],

--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -21,8 +21,11 @@ class ProductProduct(models.Model):
 
         By default, available to promise = forecasted quantity.
 
-        Must be overridden by another module that actually implement
-        computations."""
+        **Each** sub-module **must** override this method in **both**
+            `product.product` **and** `product.template`, because we can't
+            decide in advance how to compute the template's quantity from the
+            variants.
+        """
         for prod in self:
             prod.immediately_usable_qty = prod.virtual_available
 

--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -14,7 +14,7 @@ class ProductProduct(models.Model):
     """
     _inherit = 'product.product'
 
-    @api.one
+    @api.multi
     @api.depends('virtual_available')
     def _immediately_usable_qty(self):
         """No-op implementation of the stock available to promise.
@@ -23,7 +23,8 @@ class ProductProduct(models.Model):
 
         Must be overridden by another module that actually implement
         computations."""
-        self.immediately_usable_qty = self.virtual_available
+        for prod in self:
+            prod.immediately_usable_qty = prod.virtual_available
 
     immediately_usable_qty = fields.Float(
         digits=dp.get_precision('Product Unit of Measure'),

--- a/stock_available/models/product_template.py
+++ b/stock_available/models/product_template.py
@@ -9,12 +9,15 @@ from openerp.addons import decimal_precision as dp
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
-    @api.one
-    @api.depends('virtual_available')
+    @api.multi
+    @api.depends('product_variant_ids.immediately_usable_qty')
     def _immediately_usable_qty(self):
         """Compute the quantity using all the variants"""
-        self.immediately_usable_qty = sum(
-            [v.immediately_usable_qty for v in self.product_variant_ids])
+        for tmpl in self:
+            tmpl.immediately_usable_qty = sum(
+                v.immediately_usable_qty
+                for v in tmpl.product_variant_ids
+            )
 
     immediately_usable_qty = fields.Float(
         digits=dp.get_precision('Product Unit of Measure'),

--- a/stock_available/models/product_template.py
+++ b/stock_available/models/product_template.py
@@ -12,12 +12,17 @@ class ProductTemplate(models.Model):
     @api.multi
     @api.depends('product_variant_ids.immediately_usable_qty')
     def _immediately_usable_qty(self):
-        """Compute the quantity using all the variants"""
+        """No-op implementation of the stock available to promise.
+
+        By default, available to promise = forecasted quantity.
+
+        **Each** sub-module **must** override this method in **both**
+            `product.product` **and** `product.template`, because we can't
+            decide in advance how to compute the template's quantity from the
+            variants.
+        """
         for tmpl in self:
-            tmpl.immediately_usable_qty = sum(
-                v.immediately_usable_qty
-                for v in tmpl.product_variant_ids
-            )
+            tmpl.immediately_usable_qty = tmpl.virtual_available
 
     immediately_usable_qty = fields.Float(
         digits=dp.get_precision('Product Unit of Measure'),

--- a/stock_available_immediately/__openerp__.py
+++ b/stock_available_immediately/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Ignore planned receptions in quantity available to promise",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.1.0",
     "depends": ["stock_available"],
     "author": "Camptocamp,Sodexis,Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/stock_available_immediately/models/__init__.py
+++ b/stock_available_immediately/models/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import product_product
+from . import product_template

--- a/stock_available_immediately/models/product_product.py
+++ b/stock_available_immediately/models/product_product.py
@@ -11,7 +11,9 @@ class ProductProduct(models.Model):
     @api.multi
     @api.depends('virtual_available', 'incoming_qty')
     def _immediately_usable_qty(self):
-        """Ignore the incoming goods in the quantity available to promise"""
+        """Ignore the incoming goods in the quantity available to promise
+
+        This is the same implementation as for templates."""
         super(ProductProduct, self)._immediately_usable_qty()
         for prod in self:
             prod.immediately_usable_qty -= prod.incoming_qty

--- a/stock_available_immediately/models/product_product.py
+++ b/stock_available_immediately/models/product_product.py
@@ -8,8 +8,10 @@ from openerp import models, api
 class ProductProduct(models.Model):
     _inherit = 'product.product'
 
-    @api.one
+    @api.multi
+    @api.depends('virtual_available', 'incoming_qty')
     def _immediately_usable_qty(self):
         """Ignore the incoming goods in the quantity available to promise"""
         super(ProductProduct, self)._immediately_usable_qty()
-        self.immediately_usable_qty -= self.incoming_qty
+        for prod in self:
+            prod.immediately_usable_qty -= prod.incoming_qty

--- a/stock_available_immediately/models/product_template.py
+++ b/stock_available_immediately/models/product_template.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    @api.multi
+    @api.depends('virtual_available', 'incoming_qty')
+    def _immediately_usable_qty(self):
+        """Ignore the incoming goods in the quantity available to promise
+
+        This is the same implementation as for variants."""
+        super(ProductTemplate, self)._immediately_usable_qty()
+        for tmpl in self:
+            tmpl.immediately_usable_qty -= tmpl.incoming_qty


### PR DESCRIPTION
The PRs porting stock_available and stock_available_immediately to v9 did not use the latest available version from 8.0. 

cherry-picked commits:
- 6e5525bd0de1b9f00ab46ddbb211f92a32d4e01e
- 0ba72645aa6c9fb4f94b63c1ea58b24736bc08bc
