### PR TITLE
Add stock_available_lot_locked

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,2 +1,3 @@
 stock-logistics-tracking
 stock-logistics-barcode
+stock-logistics-workflow

--- a/stock_available/i18n/fr.po
+++ b/stock_available/i18n/fr.po
@@ -58,3 +58,22 @@ msgid ""
 "('draft', 'end', 'obsolete');black:immediately_usable_qty>=0 and state not "
 "in ('draft', 'end', 'obsolete')"
 msgstr "red:immediately_usable_qty<0;blue:immediately_usable_qty>=0 and state in ('draft', 'end', 'obsolete');black:immediately_usable_qty>=0 and state not in ('draft', 'end', 'obsolete')"
+
+#. module: stock_available
+#: field:stock.config.settings,module_stock_available_lot_locked:0
+msgid "Exclude blocked lots/serial numbers"
+msgstr "Exclure les lots/numéros de série bloqués"
+
+#. module: stock_available
+#: help:stock.config.settings,module_stock_available_lot_locked:0
+msgid "This will subtract quantities from the blocked "
+"lots/serial numbers from the quantities available to promise.\n"
+"This installs the modules stock_available_lot_locked.\n"
+"If the module stock_lock_lot is not installed, this will install"
+"it too"
+msgstr "Ceci soustrait les quantités des lots bloqués "
+"des quantitiés disponibles à la vente.\n"
+"Ceci installe le module module_stock_available_lot_locked.\n"
+"Si le module stock_lock_lot n'est pas installé, ceci l'installera "
+"également"
+

--- a/stock_available/models/res_config.py
+++ b/stock_available/models/res_config.py
@@ -23,6 +23,14 @@ class StockConfig(models.TransientModel):
              "If the modules sale and sale_delivery_date are not "
              "installed, this will install them too")
 
+    module_stock_available_lot_locked = fields.Boolean(
+        string='Exclude blocked lots/serial numbers',
+        help="This will subtract quantities from the blocked "
+             "lots/serial numbers from the quantities available to promise.\n"
+             "This installs the modules stock_available_lot_locked.\n"
+             "If the module stock_lock_lot is not installed, this will install"
+             "it too")
+
     module_stock_available_mrp = fields.Boolean(
         string='Include the production potential',
         help="This will add the quantities of goods that can be "

--- a/stock_available/views/res_config_view.xml
+++ b/stock_available/views/res_config_view.xml
@@ -20,6 +20,10 @@
                                     <label for="module_stock_available_sale" />
                                 </div>
                                 <div>
+                                    <field name="module_stock_available_lot_locked" class="oe_inline" />
+                                    <label for="module_stock_available_lot_locked" />
+                                </div>
+                                <div>
                                     <field name="module_stock_available_mrp" class="oe_inline" />
                                     <label for="module_stock_available_mrp" />
                                 </div>

--- a/stock_available_lot_locked/README.rst
+++ b/stock_available_lot_locked/README.rst
@@ -1,0 +1,53 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+======================================================
+Consider the blocked lots are not available to promise
+======================================================
+
+If you use the module `stock_lock_lot`, blocked lots still count in the
+quantity available to promise. This module lets you ignore the quantity of
+blocked lots.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/153/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-warehouse/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+stock-logistics-warehouse/issues/new?body=module:%20
+stock_available%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+* Loïc Bellier (Numérigraphe) <lb@numerigraphe.com>
+* Lionel Sausin (Numérigraphe) <ls@numerigraphe.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_available_lot_locked/__init__.py
+++ b/stock_available_lot_locked/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/stock_available_lot_locked/__openerp__.py
+++ b/stock_available_lot_locked/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': 'Consider the blocked lots are not available to promise',
+    'version': '8.0.1.0.0',
+    "author": u"Numérigraphe,"
+              u"Odoo Community Association (OCA)",
+    'category': 'Hidden',
+    'depends': [
+        'stock_available',
+        'stock_lock_lot'
+    ],
+    'data': [
+        'views/product_template_view.xml',
+    ],
+    'license': 'AGPL-3',
+    'installable': True,
+}

--- a/stock_available_lot_locked/i18n/fr.po
+++ b/stock_available_lot_locked/i18n/fr.po
@@ -1,0 +1,26 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_available_lot_locked
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-12 12:42+0000\n"
+"PO-Revision-Date: 2016-04-12 12:42+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_available_lot_locked
+#: field:product.product,locked_qty:0
+msgid "Blocked"
+msgstr "Bloqué"
+
+#. module: stock_available_lot_locked
+#: field:product.template,locked_qty:0
+msgid "Blocked"
+msgstr "Bloqué"

--- a/stock_available_lot_locked/models/__init__.py
+++ b/stock_available_lot_locked/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import product_product
+from . import product_template

--- a/stock_available_lot_locked/models/product_product.py
+++ b/stock_available_lot_locked/models/product_product.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# © 2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+from openerp.addons import decimal_precision as dp
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    locked_qty = fields.Float(
+        compute='_get_locked_qty',
+        type='float',
+        digits_compute=dp.get_precision('Product Unit of Measure'),
+        string='Blocked',
+        help="Quantity of the Lots/Serial Numbers of this Product which are"
+             "blocked.")
+
+    @api.multi
+    @api.depends('locked_qty')
+    def _immediately_usable_qty(self):
+        """Subtract the blocked quantity from the qty available to promise.
+
+        This is the same implementation as for templates."""
+        super(ProductProduct, self)._immediately_usable_qty()
+        for product in self:
+            product.immediately_usable_qty -= product.locked_qty
+
+    @api.multi
+    def _get_locked_qty(self):
+        """Compute the total qty of blocked lots."""
+        # Domain of the quants of locked lots
+        domain_quant = [('product_id', 'in', self.ids), ('locked', '=', True)]
+        # Restrict to the requested locations, lot, owner, package
+        domain_quant += self._get_domain_locations()[0]
+        if self.env.context.get('lot_id'):
+            domain_quant.append(
+                ('lot_id', '=', self.env.context['lot_id']))
+        if self.env.context.get('owner_id'):
+            domain_quant.append(
+                ('owner_id', '=', self.env.context['owner_id']))
+        if self.env.context.get('package_id'):
+            domain_quant.append(
+                ('package_id', '=', self.env.context['package_id']))
+
+        quants = self.env['stock.quant'].read_group(
+            domain_quant, ['product_id', 'qty'], ['product_id'])
+        for quant in quants:
+            product = self.browse(quant['product_id'][0])
+            product.locked_qty = quant['qty']

--- a/stock_available_lot_locked/models/product_template.py
+++ b/stock_available_lot_locked/models/product_template.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# © 2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+from openerp.addons import decimal_precision as dp
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    locked_qty = fields.Float(
+        compute='_get_locked_qty',
+        type='float',
+        digits_compute=dp.get_precision('Product Unit of Measure'),
+        string='Blocked',
+        help="Quantity of the Lots/Serial Numbers of this Product which are"
+             "blocked.")
+
+    @api.multi
+    @api.depends('locked_qty')
+    def _immediately_usable_qty(self):
+        """Subtract quoted quantity from qty available to promise
+
+        This is the same implementation as for variants."""
+        super(ProductTemplate, self)._immediately_usable_qty()
+        for tmpl in self:
+            tmpl.immediately_usable_qty -= tmpl.locked_qty
+
+    @api.multi
+    @api.depends('product_variant_ids.locked_qty')
+    def _get_locked_qty(self):
+        """Compute the quantity using all the variants"""
+        for tmpl in self:
+            tmpl.locked_qty = sum(
+                tmpl.product_variant_ids.mapped("locked_qty"))

--- a/stock_available_lot_locked/tests/__init__.py
+++ b/stock_available_lot_locked/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_locked_qty

--- a/stock_available_lot_locked/tests/test_locked_qty.py
+++ b/stock_available_lot_locked/tests/test_locked_qty.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# © 2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+
+
+class TestLockedQty(TransactionCase):
+    def setUp(self):
+        super(TestLockedQty, self).setUp()
+        self.warehouse = self.env.ref('stock.warehouse0')
+        uom_unit = self.env.ref('product.product_uom_unit')
+        self.location = self.env['stock.location'].create(
+            {'location_id': self.warehouse.lot_stock_id.id,
+             'name': 'test location',
+             'usage': 'internal'})
+        self.env['stock.location']._parent_store_compute()
+        self.owner = self.env['res.partner'].create(
+            {'name': 'test owner'})
+        self.package = self.env['stock.quant.package'].create(
+            {'name': 'test package',
+             'owner_id': self.owner.id})
+
+        # Create product template
+        self.templateL = self.env['product.template'].create(
+            {'name': 'template_product_L',
+             'uom_id': uom_unit.id})
+        # Create product
+        self.productL = self.env['product.product'].create(
+            {'name': 'product L',
+             'standard_price': 1,
+             'type': 'product',
+             'uom_id': uom_unit.id,
+             'default_code': 'L',
+             'product_tmpl_id': self.templateL.id})
+        #  Create a lot
+        self.lot = self.env['stock.production.lot'].create(
+            {'name': 'Test locked lot',
+             'product_id': self.productL.id})
+
+        # Make sure we have this lot in stock
+        inventory = self.env['stock.inventory'].create(
+            {'name': 'Test locked lot',
+             'filter': 'partial',
+             'location_id': self.location.id})
+        inventory.prepare_inventory()
+        self.env['stock.inventory.line'].create(
+            {'inventory_id': inventory.id,
+             'product_id': self.productL.id,
+             'product_uom_id': self.productL.uom_id.id,
+             'product_qty': 15.0,
+             'location_id': self.location.id,
+             'prod_lot_id': self.lot.id,
+             'package_id': self.package.id,
+             'partner_id': self.owner.id})
+        # Add a second line without lots, packages, owners
+        self.env['stock.inventory.line'].create(
+            {'inventory_id': inventory.id,
+             'product_id': self.productL.id,
+             'product_uom_id': self.productL.uom_id.id,
+             'product_qty': 10.0,
+             'location_id': self.location.id})
+        inventory.action_done()
+        self.assertTrue(inventory.move_ids)
+        self.productL.refresh()
+        self.assertTrue(self.productL.qty_available,
+                        "The lot is not in stock")
+
+        #  Record the initial quantity available for sale
+        self.initial_usable_qty = self.productL.immediately_usable_qty
+        self.assertLockedQty(self.productL, 0.0)
+
+    def assertLockedQty(self, product, qty):
+        """Assert locked_qty and immediately_usable_qty equal the parameters"""
+        product.refresh()
+        self.assertEqual(
+            self.initial_usable_qty - product.immediately_usable_qty, qty,
+            "The variation of the qty available for sale is incorrect.")
+        #  Check the locked q in various contexts
+        for recordset in [
+                product,
+                product.with_context(location=self.location.id),
+                product.with_context(lot_id=self.lot.id),
+                product.with_context(owner_id=self.owner.id),
+                product.with_context(package_id=self.package.id)]:
+            self.assertEqual(
+                recordset.locked_qty, qty,
+                "The locked quantity is incorrect "
+                "with context %s" % recordset.env.context)
+
+    def test_lot_locked_qty(self):
+        # check quantity locked before lock
+        self.assertEqual(self.productL.qty_available, 25.0)
+        self.assertLockedQty(self.productL, 0.0)
+        self.assertLockedQty(self.templateL, 0.0)
+
+        # lock lot
+        self.lot.button_lock()
+        self.assertTrue(
+            self.lot.locked, "The lot should be locked to start the test")
+
+        # check quantity locked after lock
+        self.assertEqual(self.productL.qty_available, 25.0)
+        self.assertLockedQty(self.productL, 15.0)
+        self.assertLockedQty(self.templateL, 15.0)

--- a/stock_available_lot_locked/views/product_template_view.xml
+++ b/stock_available_lot_locked/views/product_template_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <!-- Add the quantity available to promise in the product form -->
+        <record id="view_product_form_potential_qty" model="ir.ui.view">
+            <field name="name">Potential quantity on product form</field>
+            <field name="model">product.template</field>
+            <field name="type">form</field>
+            <field name="inherit_id" ref="stock_available.view_stock_available_form" />
+            <field name="arch" type="xml">
+                <data>
+                    <xpath expr="//field[@name='immediately_usable_qty']" position="before">
+                        <field name="locked_qty"/>
+                    </xpath>
+                </data>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
New module to let users "ignore" locked lots when computing the quantity available for sale.
Uses "stock_lock_lot" from https://github.com/OCA/stock-logistics-workflow/
