### PR TITLE
8.0 stock_quant_merge: Better code and better perf

### DIFF
--- a/stock_quant_merge/models/stock.py
+++ b/stock_quant_merge/models/stock.py
@@ -19,6 +19,7 @@ class StockQuant(models.Model):
                 ('lot_id', '=', self.lot_id.id),
                 ('package_id', '=', self.package_id.id),
                 ('location_id', '=', self.location_id.id),
+                ('company_id', '=', self.company_id.id),
                 ('reservation_id', '=', False),
                 ('propagated_from_id', '=', self.propagated_from_id.id)]
 


### PR DESCRIPTION
This is a small code improvement:
- don't update the cost price on quant2merge if there are no merge (small perf improvement)
- write cost and qty at the same time (small perf improvement)
- the cost should not be a simple average, but an average weighted by qty (in most cases, the cost if the same because the 2 quants originate from the same stock move... but it's bad for my eyes to read code where we do a simple average and not a weighted average).

@pedrobaeza That's your code... tell us what you think of these changes. The code that manipulate quants is always "dangerous code" !
