### PR TITLE
[IMP] add search method on immediately_usable_qty fields

### DIFF
--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -28,9 +28,29 @@ class ProductProduct(models.Model):
         for prod in self:
             prod.immediately_usable_qty = prod.virtual_available
 
+    def _search_immediately_usable_quantity(self, operator, value):
+        res = []
+        assert operator in (
+            '<', '>', '=', '!=', '<=', '>='
+        ), 'Invalid domain operator'
+        assert isinstance(
+            value, (float, int)
+        ), 'Invalid domain value'
+        if operator == '=':
+            operator = '=='
+
+        ids = []
+        products = self.search([])
+        for prod in products:
+            if eval(str(prod.immediately_usable_qty) + operator + str(value)):
+                ids.append(prod.id)
+        res.append(('id', 'in', ids))
+        return res
+
     immediately_usable_qty = fields.Float(
         digits=dp.get_precision('Product Unit of Measure'),
         compute='_immediately_usable_qty',
+        search='_search_immediately_usable_quantity',
         string='Available to promise',
         help="Stock for this Product that can be safely proposed "
              "for sale to Customers.\n"

--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -4,6 +4,7 @@
 
 from openerp import models, fields, api
 from openerp.addons import decimal_precision as dp
+from openerp.tools.safe_eval import safe_eval
 
 
 class ProductProduct(models.Model):
@@ -42,7 +43,9 @@ class ProductProduct(models.Model):
         ids = []
         products = self.search([])
         for prod in products:
-            if eval(str(prod.immediately_usable_qty) + operator + str(value)):
+            expr = str(prod.immediately_usable_qty) + operator + str(value)
+            eval_dict = {'prod': prod, 'operator': operator, 'value': value}
+            if safe_eval(expr, eval_dict):
                 ids.append(prod.id)
         res.append(('id', 'in', ids))
         return res

--- a/stock_available/models/product_template.py
+++ b/stock_available/models/product_template.py
@@ -24,9 +24,17 @@ class ProductTemplate(models.Model):
         for tmpl in self:
             tmpl.immediately_usable_qty = tmpl.virtual_available
 
+    def _search_immediately_usable_quantity(self, operator, value):
+        prod_obj = self.env['product.product']
+        product_variants = prod_obj.search(
+            [('immediately_usable_qty', operator, value)]
+        )
+        return [('product_variant_ids', 'in', product_variants.ids)]
+
     immediately_usable_qty = fields.Float(
         digits=dp.get_precision('Product Unit of Measure'),
         compute='_immediately_usable_qty',
+        search='_search_immediately_usable_quantity',
         string='Available to promise',
         help="Stock for this Product that can be safely proposed "
              "for sale to Customers.\n"


### PR DESCRIPTION
Hello, 

This PR adds search methods on immediately_usable_qty fields.

I wrote it in a similar way as the other product quantity fields.

Thanks for the reviews
