### PR TITLE
FIX stock_inventory_preparation_filter search EAN13 for scanned products

### DIFF
--- a/stock_inventory_preparation_filter/models/stock_inventory.py
+++ b/stock_inventory_preparation_filter/models/stock_inventory.py
@@ -109,8 +109,10 @@ class StockInventory(models.Model):
                     tmp_lines[line.product_code] = line.product_qty
             inventory.empty_line_ids.unlink()
             for product_code in tmp_lines.keys():
-                products = product_obj.search(
-                    [('default_code', '=', product_code)])
+                products = product_obj.search([
+                    '|', ('default_code', '=', product_code),
+                    ('ean13', '=', product_code),
+                ])
                 if products:
                     product = products[0]
                     fake_inventory = StockInventoryFake(


### PR DESCRIPTION
When using the feature 'allows to make an inventory based on scanned
products', users might expect they can use the EAN13 barcode for
scanning their products.

Steps to reproduce:
- install module stock_inventory_preparation_filter
- create new stock.inventory record, select 'Empty list'
- Use your barcode scanner to enter EAN13 barcodes instead of typing the product reference them on the keyboard
- Click "start inventory"

Observed:
- No products are added to the inventory when their EAN13 barcode is used

Expected:
- The products are added to the inventory.
