### PR TITLE
[FIX] stock_quant_manual_assign: Don't let the browser call name_get …

### DIFF
--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2015 Mikel Arregi - AvanzOSC
 # (c) 2015 Oihane Crucelaegui - AvanzOSC
+# (c) 2016 Miku Laitinen - Avoin.Systems
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from openerp import api, exceptions, fields, models, _
@@ -65,11 +66,12 @@ class AssignManualQuants(models.TransientModel):
         ])
         quants_lines = [{
             'quant': x.id,
-            'lot_id': x.lot_id.id,
-            'package_id': x.package_id.id,
+            'quant_name': x.name,
+            'lot_name': x.lot_id.name,
+            'package_name': x.package_id.name,
             'selected': x in move.reserved_quant_ids,
             'qty': x.qty if x in move.reserved_quant_ids else 0,
-            'location_id': x.location_id.id,
+            'location_name': x.location_id.name,
         } for x in available_quants]
         return {'quants_lines': quants_lines}
 
@@ -96,17 +98,14 @@ class AssignManualQuantsLines(models.TransientModel):
     quant = fields.Many2one(
         comodel_name='stock.quant', string='Quant', required=True,
         ondelete='cascade')
-    location_id = fields.Many2one(
-        comodel_name='stock.location', string='Location',
-        related='quant.location_id', readonly=True)
-    lot_id = fields.Many2one(
-        comodel_name='stock.production.lot', string='Lot',
-        related='quant.lot_id', readonly=True,
+    quant_name = fields.Char(string='Quant')
+    location_name = fields.Char(string='Location')
+    lot_name = fields.Char(
+        string='Lot',
         groups="stock.group_production_lot")
-    package_id = fields.Many2one(
-        comodel_name='stock.quant.package', string='Package',
-        related='quant.package_id', readonly=True,
-        groups="stock.group_tracking_lot")
+    package_name = fields.Char(
+        string='Package',
+        groups="stock.group_production_lot")
     qty = fields.Float(
         string='QTY', digits=dp.get_precision('Product Unit of Measure'))
     selected = fields.Boolean(string='Select')

--- a/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
@@ -9,10 +9,11 @@
                     <group col='4' colspan="4">
                         <field name='quants_lines' colspan="4">
                             <tree editable="top" delete="0" create="0">
-                                <field name="quant" />
-                                <field name="location_id" />
-                                <field name="lot_id" />
-                                <field name="package_id" />
+                                <field name="quant" invisible="1"/>
+                                <field name="quant_name" readonly="1"/>
+                                <field name="location_name" readonly="1"/>
+                                <field name="lot_name" readonly="1" />
+                                <field name="package_name" readonly="1"/>
                                 <field name="selected" />
                                 <field name="qty" attrs="{'readonly':[('selected', '=' ,False)]}" sum="qty"/>
                             </tree>


### PR DESCRIPTION
…for each Many2one field in the wizard. Prefetch the record names instead.

**Steps to reproduce:**
1. Create a product `x` and generate `db_maxconn` + 10 quants for it
2. Create a picking and add a move with `x` as the product
3. Set the picking as "to do"
4. Open the stock move
5. Click "Manual quants"

**Expected result:**
The wizard opens and user is able to manually select quants

**Actual result:**
You get Connection Pool Error because Odoo is out of database connections.

At least `stock.quant` name is `store=False` and computed on the fly. When you have a large number of quants in the wizard list view, the browser will call `name_get` as many times, and attempt to open as many database connections. This will result in Connection Pool Error when `db_maxconn` is smaller than the number of rows.

The Many2one records (quant, package, lot, location) aren't needed for anything else than to display their names, so instead of letting browser call `name_get` a few hundred times when the wizard opens, prefetch the Many2one record names in `assign.manual.quants.default_get()`.
