### PR TITLE
[IMP] 8.0 Usability improvements for stock_inventory_preparation_filter

### DIFF
--- a/stock_inventory_preparation_filter/models/stock_inventory.py
+++ b/stock_inventory_preparation_filter/models/stock_inventory.py
@@ -119,6 +119,7 @@ class StockInventory(models.Model):
         elif inventory.filter == 'empty':
             tmp_lines = {}
             empty_line_obj = self.env['stock.inventory.line.empty']
+            inventory_line_obj = self.env['stock.inventory.line']
             lines_to_process = inventory.empty_line_ids.filtered(
                 lambda l: not l.added_to_inventory and l.product_found)
             for line in lines_to_process:
@@ -140,12 +141,13 @@ class StockInventory(models.Model):
                     if values:
                         values[0]['product_qty'] = tmp_lines[product_code]
                     else:
-                        empty_line_obj.create(
-                            {
-                                'product_code': product_code,
-                                'product_qty': tmp_lines[product_code],
-                                'inventory_id': inventory.id,
-                            })
+                        inventory_line_obj.create({
+                            'inventory_id': inventory.id,
+                            'product_qty': tmp_lines[product_code],
+                            'location_id': inventory.location_id.id,
+                            'product_id': product.id,
+                            'product_uom_id': product.uom_id.id,
+                        })
                     vals += values
         else:
             vals = super(StockInventory, self)._get_inventory_lines(

--- a/stock_inventory_preparation_filter/views/stock_inventory_view.xml
+++ b/stock_inventory_preparation_filter/views/stock_inventory_view.xml
@@ -29,10 +29,13 @@
                     <notebook position="inside">
                         <page string="Capture Lines"
                             attrs="{'invisible':[('filter','!=','empty')]}">
-                            <field name="empty_line_ids" nolabel="1">
-                                <tree editable="bottom">
+                            <field name="empty_line_ids" nolabel="1" attrs="{'readonly':[('state','!=','draft')]}">
+                                <tree colors="grey:added_to_inventory == True;blue:product_found == True;red:product_found == False" editable="bottom">
+                                    <field name="product_found" invisible="1"/>
+                                    <field name="added_to_inventory" invisible="1"/>
                                     <field name="product_code"/>
                                     <field name="product_qty"/>
+                                    <field name="product_id" />
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
The module stock_inventory_preparation_filter has an option for manually
setting a selection of products to process an inventory.

In the use case where a customer wants to use a barcode scanner to make
his inventory this module comes handy, but there are some usability problems:
- There is no verification of the user input before the inventory is validated
- When the inventory is validated, the capture lines are deleted.  When the users wants to go back and adjust input, this is no longer possible.
- When the inventory is validated, capture lines with invalid input are not added to the inventory and as such silently discarded.  When the users wants to go back and adjust input, this is no longer possible.

My proposal in this PR is to improve usability for this use case with:
- On the capture lines, indicate if a valid code has been entered
- On starting the inventory, don't remove the capture lines, but mark
  them as 'added'.
- On Cancel inventory, reset the added flag to the capture lines, so
  they can be reused.
- Capture lines are readonly unless the inventory state=draft
- Use color codes on the capture lines to indicate a line is added
  or not of if the product is found.
