### PR TITLE
[9.0][MIG] stock_manual_assign: port to 9.0

### DIFF
--- a/stock_quant_manual_assign/README.rst
+++ b/stock_quant_manual_assign/README.rst
@@ -30,7 +30,7 @@ help us smashing it by providing a detailed and welcomed `feedback
 <https://github.com/OCA/
 stock-logistics-warehouse/issues/new?body=module:%20
 stock_quant_manual_assign%0Aversion:%20
-8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+9.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 
 Credits

--- a/stock_quant_manual_assign/README.rst
+++ b/stock_quant_manual_assign/README.rst
@@ -6,7 +6,7 @@
 Stock - Manual Quant Assignment
 ===============================
 
-This module allow you to manually change the automatic quant selection.
+This module allows you to manually change the automatic quant selection.
 
 Usage
 =====

--- a/stock_quant_manual_assign/README.rst
+++ b/stock_quant_manual_assign/README.rst
@@ -2,23 +2,24 @@
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
-===========================
-Manual assignment of quants
-===========================
+===============================
+Stock - Manual Quant Assignment
+===============================
 
-With this module, user can manually change the automatic selection of quants.
+This module allow you to manually change the automatic quant selection.
 
 Usage
 =====
 
 To use this module, you need to:
 
-* You will able to select the quants from each stock.move. There will be a
-  button that opens a wizard directly from the move or from the picking.
+#. Select a stock move or a stock picking.
+#. Open the wizard with the button "Manual Quants".
+#. Select the quants to assign (reserve).
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/153/8.0
+   :target: https://runbot.odoo-community.org/runbot/153/9.0
 
 Bug Tracker
 ===========
@@ -26,12 +27,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/stock-logistics-warehouse/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed `feedback
-<https://github.com/OCA/
-stock-logistics-warehouse/issues/new?body=module:%20
-stock_quant_manual_assign%0Aversion:%20
-9.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
-
+help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======

--- a/stock_quant_manual_assign/__openerp__.py
+++ b/stock_quant_manual_assign/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Stock - Manual assignment of quants",
-    "version": "8.0.1.0.0",
+    "version": "9.0.1.0.0",
     "category": "Warehouse Management",
     "license": "AGPL-3",
     "author": "OdooMRP team, "
@@ -25,5 +25,5 @@
         "wizard/assign_manual_quants_view.xml",
         "views/stock_move_view.xml",
     ],
-    "installable": False,
+    "installable": True,
 }

--- a/stock_quant_manual_assign/__openerp__.py
+++ b/stock_quant_manual_assign/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {
-    "name": "Stock - Manual assignment of quants",
+    "name": "Stock - Manual Quant Assignment",
     "version": "9.0.1.0.0",
     "category": "Warehouse Management",
     "license": "AGPL-3",
@@ -12,12 +12,6 @@
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
               "Odoo Community Association (OCA)",
     "website": "http://www.odoomrp.com",
-    "contributors": [
-        "Mikel Arregi <mikelarregi@avanzosc.es>",
-        "Ana Juaristi Olalde <anajuaristi@avanzosc.es>",
-        "Pedro Manuel Baeza Romero <pedro.baeza@serviciosbaeza.com>"
-        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
-    ],
     "depends": [
         "stock",
     ],

--- a/stock_quant_manual_assign/i18n/en.po
+++ b/stock_quant_manual_assign/i18n/en.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: stock-logistics-warehouse (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-24 09:07+0000\n"
-"PO-Revision-Date: 2015-10-24 09:08+0000\n"
+"POT-Creation-Date: 2016-04-28 01:03+0000\n"
+"PO-Revision-Date: 2016-04-27 10:59+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: English (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-8-0/language/en/)\n"
 "MIME-Version: 1.0\n"
@@ -40,9 +40,21 @@ msgid "Created on"
 msgstr "Created on"
 
 #. module: stock_quant_manual_assign
+#: field:assign.manual.quants,display_name:0
+#: field:assign.manual.quants.lines,display_name:0
+msgid "Display Name"
+msgstr "Display Name"
+
+#. module: stock_quant_manual_assign
 #: field:assign.manual.quants,id:0 field:assign.manual.quants.lines,id:0
 msgid "ID"
 msgstr "ID"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,__last_update:0
+#: field:assign.manual.quants.lines,__last_update:0
+msgid "Last Modified on"
+msgstr "Last Modified on"
 
 #. module: stock_quant_manual_assign
 #: field:assign.manual.quants,write_uid:0
@@ -55,6 +67,16 @@ msgstr "Last Updated by"
 #: field:assign.manual.quants.lines,write_date:0
 msgid "Last Updated on"
 msgstr "Last Updated on"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,location_id:0
+msgid "Location"
+msgstr "Location"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,lot_id:0
+msgid "Lot"
+msgstr "Lot"
 
 #. module: stock_quant_manual_assign
 #: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
@@ -77,6 +99,11 @@ msgstr "Move"
 #: field:assign.manual.quants,name:0
 msgid "Name"
 msgstr "Name"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,package_id:0
+msgid "Package"
+msgstr "Package"
 
 #. module: stock_quant_manual_assign
 #: model:ir.model,name:stock_quant_manual_assign.model_stock_picking
@@ -105,6 +132,16 @@ msgid "Quants"
 msgstr "Quants"
 
 #. module: stock_quant_manual_assign
+#: field:assign.manual.quants,move_qty:0
+msgid "Remaining qty"
+msgstr "Remaining qty"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,lines_qty:0
+msgid "Reserved qty"
+msgstr "Reserved qty"
+
+#. module: stock_quant_manual_assign
 #: field:assign.manual.quants.lines,selected:0
 msgid "Select"
 msgstr "Select"
@@ -113,6 +150,11 @@ msgstr "Select"
 #: model:ir.model,name:stock_quant_manual_assign.model_stock_move
 msgid "Stock Move"
 msgstr "Stock Move"
+
+#. module: stock_quant_manual_assign
+#: help:assign.manual.quants.lines,package_id:0
+msgid "The package containing this quant"
+msgstr "The package containing this quant"
 
 #. module: stock_quant_manual_assign
 #: field:stock.move,picking_type_code:0

--- a/stock_quant_manual_assign/i18n/fi.po
+++ b/stock_quant_manual_assign/i18n/fi.po
@@ -3,13 +3,14 @@
 # * stock_quant_manual_assign
 # 
 # Translators:
+# Miku Laitinen <miku.laitinen@gmail.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: stock-logistics-warehouse (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-04 07:59+0000\n"
-"PO-Revision-Date: 2015-10-24 09:08+0000\n"
-"Last-Translator: <>\n"
+"POT-Creation-Date: 2016-05-27 14:19+0000\n"
+"PO-Revision-Date: 2016-05-27 13:28+0000\n"
+"Last-Translator: Miku Laitinen <miku.laitinen@gmail.com>\n"
 "Language-Team: Finnish (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-8-0/language/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -25,7 +26,7 @@ msgstr "Peruuta"
 #. module: stock_quant_manual_assign
 #: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
 msgid "Confirm"
-msgstr ""
+msgstr "Vahvista"
 
 #. module: stock_quant_manual_assign
 #: field:assign.manual.quants,create_uid:0
@@ -40,9 +41,21 @@ msgid "Created on"
 msgstr "Luotu"
 
 #. module: stock_quant_manual_assign
+#: field:assign.manual.quants,display_name:0
+#: field:assign.manual.quants.lines,display_name:0
+msgid "Display Name"
+msgstr "Nimi"
+
+#. module: stock_quant_manual_assign
 #: field:assign.manual.quants,id:0 field:assign.manual.quants.lines,id:0
 msgid "ID"
 msgstr "ID"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,__last_update:0
+#: field:assign.manual.quants.lines,__last_update:0
+msgid "Last Modified on"
+msgstr "Viimeksi muokattu"
 
 #. module: stock_quant_manual_assign
 #: field:assign.manual.quants,write_uid:0
@@ -57,47 +70,62 @@ msgid "Last Updated on"
 msgstr "Viimeksi päivitetty"
 
 #. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,location_id:0
+msgid "Location"
+msgstr "Sijainti"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,lot_id:0
+msgid "Lot"
+msgstr "Erä"
+
+#. module: stock_quant_manual_assign
 #: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
 #: view:stock.move:stock_quant_manual_assign.stock_move_manual_quants_form_view
 #: view:stock.move:stock_quant_manual_assign.stock_move_manual_quants_picking_form_view
 msgid "Manual Quants"
-msgstr ""
+msgstr "Valitse erä"
 
 #. module: stock_quant_manual_assign
 #: model:ir.actions.act_window,name:stock_quant_manual_assign.assign_manual_quants_action
 msgid "Manual quants"
-msgstr ""
+msgstr "Valitse erä"
 
 #. module: stock_quant_manual_assign
 #: field:assign.manual.quants.lines,assign_wizard:0
 msgid "Move"
-msgstr ""
+msgstr "Siirto"
 
 #. module: stock_quant_manual_assign
 #: field:assign.manual.quants,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nimi"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,package_id:0
+msgid "Package"
+msgstr "Pakkaus"
 
 #. module: stock_quant_manual_assign
 #: model:ir.model,name:stock_quant_manual_assign.model_stock_picking
 msgid "Picking List"
-msgstr ""
+msgstr "Keräilylista"
 
 #. module: stock_quant_manual_assign
 #: field:assign.manual.quants.lines,qty:0
 msgid "QTY"
-msgstr ""
+msgstr "Määrä"
 
 #. module: stock_quant_manual_assign
 #: field:assign.manual.quants.lines,quant:0
 msgid "Quant"
-msgstr ""
+msgstr "Satsi"
 
 #. module: stock_quant_manual_assign
 #: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:22
 #, python-format
 msgid "Quantity is higher than the needed one"
-msgstr ""
+msgstr "Määrä on tarvetta suurempi"
 
 #. module: stock_quant_manual_assign
 #: field:assign.manual.quants,quants_lines:0
@@ -105,19 +133,34 @@ msgid "Quants"
 msgstr "Määrät"
 
 #. module: stock_quant_manual_assign
+#: field:assign.manual.quants,move_qty:0
+msgid "Remaining qty"
+msgstr "Määrä jäljellä"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,lines_qty:0
+msgid "Reserved qty"
+msgstr "Määrä varattu"
+
+#. module: stock_quant_manual_assign
 #: field:assign.manual.quants.lines,selected:0
 msgid "Select"
-msgstr ""
+msgstr "Valitse"
 
 #. module: stock_quant_manual_assign
 #: model:ir.model,name:stock_quant_manual_assign.model_stock_move
 msgid "Stock Move"
-msgstr ""
+msgstr "Varastosiirto"
+
+#. module: stock_quant_manual_assign
+#: help:assign.manual.quants.lines,package_id:0
+msgid "The package containing this quant"
+msgstr "Tämän satsin sisältävä pakkaus"
 
 #. module: stock_quant_manual_assign
 #: field:stock.move,picking_type_code:0
 msgid "Type of Operation"
-msgstr ""
+msgstr "Operaation tyyppi"
 
 #. module: stock_quant_manual_assign
 #: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
@@ -127,4 +170,4 @@ msgstr "tai"
 #. module: stock_quant_manual_assign
 #: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
 msgid "qty"
-msgstr ""
+msgstr "määrä"

--- a/stock_quant_manual_assign/i18n/it.po
+++ b/stock_quant_manual_assign/i18n/it.po
@@ -1,0 +1,173 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_quant_manual_assign
+# 
+# Translators:
+# Paolo Valier, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: stock-logistics-warehouse (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-05-01 15:24+0000\n"
+"PO-Revision-Date: 2016-05-13 12:57+0000\n"
+"Last-Translator: Paolo Valier\n"
+"Language-Team: Italian (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-8-0/language/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: stock_quant_manual_assign
+#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
+msgid "Cancel"
+msgstr "Annulla"
+
+#. module: stock_quant_manual_assign
+#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
+msgid "Confirm"
+msgstr "Conferma"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,create_uid:0
+#: field:assign.manual.quants.lines,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,create_date:0
+#: field:assign.manual.quants.lines,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,display_name:0
+#: field:assign.manual.quants.lines,display_name:0
+msgid "Display Name"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,id:0 field:assign.manual.quants.lines,id:0
+msgid "ID"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,__last_update:0
+#: field:assign.manual.quants.lines,__last_update:0
+msgid "Last Modified on"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,write_uid:0
+#: field:assign.manual.quants.lines,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,write_date:0
+#: field:assign.manual.quants.lines,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,location_id:0
+msgid "Location"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,lot_id:0
+msgid "Lot"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
+#: view:stock.move:stock_quant_manual_assign.stock_move_manual_quants_form_view
+#: view:stock.move:stock_quant_manual_assign.stock_move_manual_quants_picking_form_view
+msgid "Manual Quants"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: model:ir.actions.act_window,name:stock_quant_manual_assign.assign_manual_quants_action
+msgid "Manual quants"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,assign_wizard:0
+msgid "Move"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,name:0
+msgid "Name"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,package_id:0
+msgid "Package"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: model:ir.model,name:stock_quant_manual_assign.model_stock_picking
+msgid "Picking List"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,qty:0
+msgid "QTY"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,quant:0
+msgid "Quant"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:22
+#, python-format
+msgid "Quantity is higher than the needed one"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,quants_lines:0
+msgid "Quants"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,move_qty:0
+msgid "Remaining qty"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,lines_qty:0
+msgid "Reserved qty"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,selected:0
+msgid "Select"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: model:ir.model,name:stock_quant_manual_assign.model_stock_move
+msgid "Stock Move"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: help:assign.manual.quants.lines,package_id:0
+msgid "The package containing this quant"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:stock.move,picking_type_code:0
+msgid "Type of Operation"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
+msgid "or"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
+msgid "qty"
+msgstr ""

--- a/stock_quant_manual_assign/i18n/sl.po
+++ b/stock_quant_manual_assign/i18n/sl.po
@@ -3,13 +3,13 @@
 # * stock_quant_manual_assign
 # 
 # Translators:
-# Matjaž Mozetič <m.mozetic@matmoz.si>, 2015
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2015-2016
 msgid ""
 msgstr ""
 "Project-Id-Version: stock-logistics-warehouse (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-24 09:07+0000\n"
-"PO-Revision-Date: 2015-10-25 07:18+0000\n"
+"POT-Creation-Date: 2016-04-28 01:03+0000\n"
+"PO-Revision-Date: 2016-04-27 15:34+0000\n"
 "Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>\n"
 "Language-Team: Slovenian (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-8-0/language/sl/)\n"
 "MIME-Version: 1.0\n"
@@ -41,9 +41,21 @@ msgid "Created on"
 msgstr "Ustvarjeno"
 
 #. module: stock_quant_manual_assign
+#: field:assign.manual.quants,display_name:0
+#: field:assign.manual.quants.lines,display_name:0
+msgid "Display Name"
+msgstr "Prikazni naziv"
+
+#. module: stock_quant_manual_assign
 #: field:assign.manual.quants,id:0 field:assign.manual.quants.lines,id:0
 msgid "ID"
 msgstr "ID"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,__last_update:0
+#: field:assign.manual.quants.lines,__last_update:0
+msgid "Last Modified on"
+msgstr "Zadnjič spremenjeno"
 
 #. module: stock_quant_manual_assign
 #: field:assign.manual.quants,write_uid:0
@@ -56,6 +68,16 @@ msgstr "Zadnji posodobil"
 #: field:assign.manual.quants.lines,write_date:0
 msgid "Last Updated on"
 msgstr "Zadnjič posodobljeno"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,location_id:0
+msgid "Location"
+msgstr "Lokacija"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,lot_id:0
+msgid "Lot"
+msgstr "Lot"
 
 #. module: stock_quant_manual_assign
 #: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
@@ -78,6 +100,11 @@ msgstr "Premik"
 #: field:assign.manual.quants,name:0
 msgid "Name"
 msgstr "Naziv"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,package_id:0
+msgid "Package"
+msgstr "Pakiranje"
 
 #. module: stock_quant_manual_assign
 #: model:ir.model,name:stock_quant_manual_assign.model_stock_picking
@@ -106,6 +133,16 @@ msgid "Quants"
 msgstr "Kvant"
 
 #. module: stock_quant_manual_assign
+#: field:assign.manual.quants,move_qty:0
+msgid "Remaining qty"
+msgstr "Preostala kol"
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,lines_qty:0
+msgid "Reserved qty"
+msgstr "Rezervirana kol"
+
+#. module: stock_quant_manual_assign
 #: field:assign.manual.quants.lines,selected:0
 msgid "Select"
 msgstr "Izbira"
@@ -114,6 +151,11 @@ msgstr "Izbira"
 #: model:ir.model,name:stock_quant_manual_assign.model_stock_move
 msgid "Stock Move"
 msgstr "Premik zaloge"
+
+#. module: stock_quant_manual_assign
+#: help:assign.manual.quants.lines,package_id:0
+msgid "The package containing this quant"
+msgstr "Pakiranje, ki vsebuje ta kvant"
 
 #. module: stock_quant_manual_assign
 #: field:stock.move,picking_type_code:0

--- a/stock_quant_manual_assign/i18n/stock_quant_manual_assign.pot
+++ b/stock_quant_manual_assign/i18n/stock_quant_manual_assign.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 8.0\n"
+"Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-01 12:46+0000\n"
-"PO-Revision-Date: 2015-10-01 12:46+0000\n"
+"POT-Creation-Date: 2016-07-02 10:02+0000\n"
+"PO-Revision-Date: 2016-07-02 10:02+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,56 +16,42 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_quant_manual_assign
-#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
+#: model:ir.ui.view,arch_db:stock_quant_manual_assign.assign_manual_quants_form_view
 msgid "Cancel"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
+#: model:ir.ui.view,arch_db:stock_quant_manual_assign.assign_manual_quants_form_view
 msgid "Confirm"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: field:assign.manual.quants,create_uid:0
-#: field:assign.manual.quants.lines,create_uid:0
+#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_create_uid
+#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_lines_create_uid
 msgid "Created by"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: field:assign.manual.quants,create_date:0
-#: field:assign.manual.quants.lines,create_date:0
+#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_create_date
+#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_lines_create_date
 msgid "Created on"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:21
-#: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:24
-#, python-format
-msgid "Error"
-msgstr ""
-
-#. module: stock_quant_manual_assign
-#: field:assign.manual.quants,id:0
-#: field:assign.manual.quants.lines,id:0
-msgid "ID"
-msgstr ""
-
-#. module: stock_quant_manual_assign
-#: field:assign.manual.quants,write_uid:0
-#: field:assign.manual.quants.lines,write_uid:0
+#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_lines_write_uid
+#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_write_uid
 msgid "Last Updated by"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: field:assign.manual.quants,write_date:0
-#: field:assign.manual.quants.lines,write_date:0
+#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_lines_write_date
+#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_write_date
 msgid "Last Updated on"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
-#: view:stock.move:stock_quant_manual_assign.stock_move_manual_quants_form_view
-#: view:stock.move:stock_quant_manual_assign.stock_move_manual_quants_picking_form_view
+#: model:ir.ui.view,arch_db:stock_quant_manual_assign.stock_move_manual_quants_form_view
+#: model:ir.ui.view,arch_db:stock_quant_manual_assign.stock_move_manual_quants_picking_form_view
 msgid "Manual Quants"
 msgstr ""
 
@@ -75,54 +61,38 @@ msgid "Manual quants"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: field:assign.manual.quants.lines,assign_wizard:0
-msgid "Move"
-msgstr ""
-
-#. module: stock_quant_manual_assign
-#: field:assign.manual.quants,name:0
-msgid "Name"
-msgstr ""
-
-#. module: stock_quant_manual_assign
-#: model:ir.model,name:stock_quant_manual_assign.model_stock_picking
-msgid "Picking List"
-msgstr ""
-
-#. module: stock_quant_manual_assign
-#: field:assign.manual.quants.lines,qty:0
-msgid "QTY"
-msgstr ""
-
-#. module: stock_quant_manual_assign
-#: field:assign.manual.quants.lines,quant:0
-msgid "Quant"
-msgstr ""
-
-#. module: stock_quant_manual_assign
 #: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:22
-#: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:24
 #, python-format
 msgid "Quantity is higher than the needed one"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: field:assign.manual.quants,quants_lines:0
-msgid "Quants"
+#: model:ir.model,name:stock_quant_manual_assign.model_stock_move
+msgid "Stock Move"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: field:assign.manual.quants.lines,selected:0
-msgid "Select"
+#: model:ir.model,name:stock_quant_manual_assign.model_stock_picking
+msgid "Transfer"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
+#: model:ir.model,name:stock_quant_manual_assign.model_assign_manual_quants
+msgid "assign.manual.quants"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: model:ir.model,name:stock_quant_manual_assign.model_assign_manual_quants_lines
+msgid "assign.manual.quants.lines"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: model:ir.ui.view,arch_db:stock_quant_manual_assign.assign_manual_quants_form_view
 msgid "or"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
+#: model:ir.ui.view,arch_db:stock_quant_manual_assign.assign_manual_quants_form_view
 msgid "qty"
 msgstr ""
 

--- a/stock_quant_manual_assign/i18n/stock_quant_manual_assign.pot
+++ b/stock_quant_manual_assign/i18n/stock_quant_manual_assign.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-02 10:02+0000\n"
-"PO-Revision-Date: 2016-07-02 10:02+0000\n"
+"POT-Creation-Date: 2015-10-01 12:46+0000\n"
+"PO-Revision-Date: 2015-10-01 12:46+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,42 +16,56 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_quant_manual_assign
-#: model:ir.ui.view,arch_db:stock_quant_manual_assign.assign_manual_quants_form_view
+#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
 msgid "Cancel"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: model:ir.ui.view,arch_db:stock_quant_manual_assign.assign_manual_quants_form_view
+#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
 msgid "Confirm"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_create_uid
-#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_lines_create_uid
+#: field:assign.manual.quants,create_uid:0
+#: field:assign.manual.quants.lines,create_uid:0
 msgid "Created by"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_create_date
-#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_lines_create_date
+#: field:assign.manual.quants,create_date:0
+#: field:assign.manual.quants.lines,create_date:0
 msgid "Created on"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_lines_write_uid
-#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_write_uid
+#: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:21
+#: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:24
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,id:0
+#: field:assign.manual.quants.lines,id:0
+msgid "ID"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,write_uid:0
+#: field:assign.manual.quants.lines,write_uid:0
 msgid "Last Updated by"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_lines_write_date
-#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_write_date
+#: field:assign.manual.quants,write_date:0
+#: field:assign.manual.quants.lines,write_date:0
 msgid "Last Updated on"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: model:ir.ui.view,arch_db:stock_quant_manual_assign.stock_move_manual_quants_form_view
-#: model:ir.ui.view,arch_db:stock_quant_manual_assign.stock_move_manual_quants_picking_form_view
+#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
+#: view:stock.move:stock_quant_manual_assign.stock_move_manual_quants_form_view
+#: view:stock.move:stock_quant_manual_assign.stock_move_manual_quants_picking_form_view
 msgid "Manual Quants"
 msgstr ""
 
@@ -61,38 +75,54 @@ msgid "Manual quants"
 msgstr ""
 
 #. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,assign_wizard:0
+msgid "Move"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants,name:0
+msgid "Name"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: model:ir.model,name:stock_quant_manual_assign.model_stock_picking
+msgid "Picking List"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,qty:0
+msgid "QTY"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: field:assign.manual.quants.lines,quant:0
+msgid "Quant"
+msgstr ""
+
+#. module: stock_quant_manual_assign
 #: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:22
+#: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:24
 #, python-format
 msgid "Quantity is higher than the needed one"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: model:ir.model,name:stock_quant_manual_assign.model_stock_move
-msgid "Stock Move"
+#: field:assign.manual.quants,quants_lines:0
+msgid "Quants"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: model:ir.model,name:stock_quant_manual_assign.model_stock_picking
-msgid "Transfer"
+#: field:assign.manual.quants.lines,selected:0
+msgid "Select"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: model:ir.model,name:stock_quant_manual_assign.model_assign_manual_quants
-msgid "assign.manual.quants"
-msgstr ""
-
-#. module: stock_quant_manual_assign
-#: model:ir.model,name:stock_quant_manual_assign.model_assign_manual_quants_lines
-msgid "assign.manual.quants.lines"
-msgstr ""
-
-#. module: stock_quant_manual_assign
-#: model:ir.ui.view,arch_db:stock_quant_manual_assign.assign_manual_quants_form_view
+#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
 msgid "or"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: model:ir.ui.view,arch_db:stock_quant_manual_assign.assign_manual_quants_form_view
+#: view:assign.manual.quants:stock_quant_manual_assign.assign_manual_quants_form_view
 msgid "qty"
 msgstr ""
 

--- a/stock_quant_manual_assign/views/stock_move_view.xml
+++ b/stock_quant_manual_assign/views/stock_move_view.xml
@@ -1,36 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openerp>
-    <data>
-        <record model="ir.ui.view" id="stock_move_manual_quants_form_view">
-            <field name="name">stock.move.form</field>
-            <field name="model">stock.move</field>
-            <field name="inherit_id" ref="stock.view_move_form" />
-            <field name="arch" type="xml">
-                <button name="action_done" position="after">
-                    <button name="%(assign_manual_quants_action)d" type="action"
-                            string="Manual Quants" class="oe_highlight"
-                            attrs="{'invisible':['|',('picking_type_code','=','incoming'),('state','not in',('confirmed','assigned'))]}"/>
-                </button>
-                <field name="picking_type_id" position="after">
-                    <field name="picking_type_code" invisible="1" />
-                </field>
+<odoo>
+    <record model="ir.ui.view" id="stock_move_manual_quants_form_view">
+        <field name="name">stock.move.form</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_move_form" />
+        <field name="arch" type="xml">
+            <field name="state" position="before">
+                <button name="%(assign_manual_quants_action)d" type="action"
+                        string="Manual Quants" class="oe_highlight"
+                        attrs="{'invisible':['|',('picking_type_code','=','incoming'),('state','not in',('confirmed','assigned'))]}"/>
             </field>
-        </record>
+            <field name="picking_type_id" position="after">
+                <field name="picking_type_code" invisible="1" />
+            </field>
+        </field>
+    </record>
 
-        <record model="ir.ui.view" id="stock_move_manual_quants_picking_form_view">
-            <field name="name">stock.move.form</field>
-            <field name="model">stock.move</field>
-            <field name="inherit_id" ref="stock.view_move_picking_form" />
-            <field name="arch" type="xml">
-                <button name="force_assign" position="after">
-                    <button name="%(assign_manual_quants_action)d" type="action"
-                            string="Manual Quants" class="oe_highlight"
-                            attrs="{'invisible':['|',('picking_type_code','=','incoming'),('state','not in',('confirmed','assigned'))]}" />
-                </button>
-                <field name="picking_type_id" position="after">
-                    <field name="picking_type_code" invisible="1" />
-                </field>
+    <record model="ir.ui.view" id="stock_move_manual_quants_picking_form_view">
+        <field name="name">stock.move.form</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_move_picking_form" />
+        <field name="arch" type="xml">
+            <field name="state" position="before">
+                <button name="%(assign_manual_quants_action)d" type="action"
+                        string="Manual Quants" class="oe_highlight"
+                        attrs="{'invisible':['|',('picking_type_code','=','incoming'),('state','not in',('confirmed','assigned'))]}" />
             </field>
-        </record>
-    </data>
-</openerp>
+            <field name="picking_type_id" position="after">
+                <field name="picking_type_code" invisible="1" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -63,17 +63,16 @@ class AssignManualQuants(models.TransientModel):
             ('reservation_id', '=', False),
             ('reservation_id', '=', move.id)
         ])
-        quants_lines = []
-        for x in available_quants:
-            quants_lines.append([0, 0, {
-                'quant': x.id,
-                'lot_id': x.lot_id.id,
-                'package_id': x.package_id.id,
-                'selected': x in move.reserved_quant_ids,
-                'qty': x.qty if x in move.reserved_quant_ids else 0,
-                'location_id': x.location_id.id,
-            }])
+        quants_lines = [{
+            'quant': x.id,
+            'lot_id': x.lot_id.id,
+            'package_id': x.package_id.id,
+            'selected': x in move.reserved_quant_ids,
+            'qty': x.qty if x in move.reserved_quant_ids else 0,
+            'location_id': x.location_id.id,
+        } for x in available_quants]
         res.update({'quants_lines': quants_lines})
+        res = self._convert_to_write(self._convert_to_cache(res))
         return res
 
 

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -17,7 +17,7 @@ class AssignManualQuants(models.TransientModel):
             if record.quants_lines:
                 move = self.env['stock.move'].browse(
                     self.env.context['active_id'])
-                if record.lines_qty > move.product_uom_qty:
+                if record.lines_qty > move.product_qty:
                     raise exceptions.Warning(
                         _('Quantity is higher than the needed one'))
 
@@ -26,7 +26,7 @@ class AssignManualQuants(models.TransientModel):
         move = self.env['stock.move'].browse(self.env.context['active_id'])
         lines_qty = sum(self.quants_lines.mapped('qty'))
         self.lines_qty = lines_qty
-        self.move_qty = move.product_uom_qty - lines_qty
+        self.move_qty = move.product_qty - lines_qty
 
     name = fields.Char(string='Name')
     lines_qty = fields.Float(
@@ -52,8 +52,8 @@ class AssignManualQuants(models.TransientModel):
         return {}
 
     @api.model
-    def default_get(self, var_fields):
-        super(AssignManualQuants, self).default_get(var_fields)
+    def default_get(self, fields):
+        res = super(AssignManualQuants, self).default_get(fields)
         move = self.env['stock.move'].browse(self.env.context['active_id'])
         available_quants = self.env['stock.quant'].search([
             ('location_id', 'child_of', move.location_id.id),
@@ -63,15 +63,18 @@ class AssignManualQuants(models.TransientModel):
             ('reservation_id', '=', False),
             ('reservation_id', '=', move.id)
         ])
-        quants_lines = [{
-            'quant': x.id,
-            'lot_id': x.lot_id.id,
-            'package_id': x.package_id.id,
-            'selected': x in move.reserved_quant_ids,
-            'qty': x.qty if x in move.reserved_quant_ids else 0,
-            'location_id': x.location_id.id,
-        } for x in available_quants]
-        return {'quants_lines': quants_lines}
+        quants_lines = []
+        for x in available_quants:
+            quants_lines.append([0, 0, {
+                'quant': x.id,
+                'lot_id': x.lot_id.id,
+                'package_id': x.package_id.id,
+                'selected': x in move.reserved_quant_ids,
+                'qty': x.qty if x in move.reserved_quant_ids else 0,
+                'location_id': x.location_id.id,
+            }])
+        res.update({'quants_lines': quants_lines})
+        return res
 
 
 class AssignManualQuantsLines(models.TransientModel):

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -17,7 +17,9 @@ class AssignManualQuants(models.TransientModel):
             if record.quants_lines:
                 move = self.env['stock.move'].browse(
                     self.env.context['active_id'])
-                if record.lines_qty > move.product_qty:
+                move_qty = self.env['product.uom']._compute_qty_obj(
+                        move.product_uom, move.product_uom_qty, move.product_id.uom_id)
+                if record.lines_qty > move_qty:
                     raise exceptions.Warning(
                         _('Quantity is higher than the needed one'))
 
@@ -26,7 +28,9 @@ class AssignManualQuants(models.TransientModel):
         move = self.env['stock.move'].browse(self.env.context['active_id'])
         lines_qty = sum(self.quants_lines.mapped('qty'))
         self.lines_qty = lines_qty
-        self.move_qty = move.product_qty - lines_qty
+        move_qty = self.env['product.uom']._compute_qty_obj(
+                move.product_uom, move.product_uom_qty, move.product_id.uom_id)
+        self.move_qty = move_qty - lines_qty
 
     name = fields.Char(string='Name')
     lines_qty = fields.Float(

--- a/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
@@ -1,38 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openerp>
-    <data>
-        <record model="ir.ui.view" id="assign_manual_quants_form_view">
-            <field name="name">assign.manual.quants.form</field>
-            <field name="model">assign.manual.quants</field>
-            <field name="arch" type="xml">
-                <form string="Manual Quants">
-                    <group col='4' colspan="4">
-                        <field name='quants_lines' colspan="4">
-                            <tree editable="top" delete="0" create="0">
-                                <field name="quant" />
-                                <field name="location_id" />
-                                <field name="lot_id" />
-                                <field name="package_id" />
-                                <field name="selected" />
-                                <field name="qty" attrs="{'readonly':[('selected', '=' ,False)]}" sum="qty"/>
-                            </tree>
-                        </field>
-                        <field name="move_qty" colspan="2" readonly="1"/>
-                        <field name="lines_qty" invisible="1" />
-                    </group>
-                    <footer>
-                        <button name="assign_quants" type="object"
-                            string="Confirm" class="oe_highlight" />
-                        or
-                        <button string="Cancel" class="oe_link"
-                            special="cancel" />
-                    </footer>
-                </form>
-            </field>
-        </record>
+<odoo>
+    <record model="ir.ui.view" id="assign_manual_quants_form_view">
+        <field name="name">assign.manual.quants.form</field>
+        <field name="model">assign.manual.quants</field>
+        <field name="arch" type="xml">
+            <form name="Manual Quants">
+                <group col='4' colspan="4">
+                    <field name='quants_lines' colspan="4">
+                        <tree editable="top" delete="0" create="0">
+                            <field name="quant" />
+                            <field name="location_id" />
+                            <field name="lot_id" />
+                            <field name="package_id" />
+                            <field name="selected" />
+                            <field name="qty" attrs="{'readonly':[('selected', '=' ,False)]}" sum="qty"/>
+                        </tree>
+                    </field>
+                    <field name="move_qty" colspan="2" readonly="1"/>
+                    <field name="lines_qty" invisible="1" />
+                </group>
+                <footer>
+                    <button name="assign_quants" type="object"
+                        string="Confirm" class="oe_highlight" />
+                    or
+                    <button name="cancel" string="Cancel" class="oe_link"
+                        special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
 
-        <act_window name="Manual quants" res_model="assign.manual.quants"
-            src_model="stock.move" view_mode="form" target="new"
-            id="assign_manual_quants_action" />
-    </data>
-</openerp>
+    <act_window name="Manual quants" res_model="assign.manual.quants"
+        src_model="stock.move" view_mode="form" target="new"
+        id="assign_manual_quants_action" />
+</odoo>

--- a/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
@@ -22,7 +22,6 @@
                 <footer>
                     <button name="assign_quants" type="object"
                         string="Confirm" class="oe_highlight" />
-                    or
                     <button name="cancel" string="Cancel" class="oe_link"
                         special="cancel" />
                 </footer>


### PR DESCRIPTION
Port to v9 and fix issue if move and quants haven't the same uom.

In README.rst, I don't update the runbot link because I don't find the right one for v9.

There's still an issue if you uncheck a selected quant, the remaining quantity doesn't update. I don't understand why, if someone has an idea.
