### PR TITLE
FIX picking edition by warehouse user due to related none readonly field

### DIFF
--- a/stock_quant_manual_assign/__openerp__.py
+++ b/stock_quant_manual_assign/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Stock - Manual assignment of quants",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.1.0",
     "category": "Warehouse Management",
     "license": "AGPL-3",
     "author": "OdooMRP team, "

--- a/stock_quant_manual_assign/models/stock_picking.py
+++ b/stock_quant_manual_assign/models/stock_picking.py
@@ -19,4 +19,4 @@ class StockMove(models.Model):
     _inherit = 'stock.move'
 
     picking_type_code = fields.Selection(
-        related='picking_type_id.code', store=True)
+        related='picking_type_id.code', store=True, readonly=True)


### PR DESCRIPTION
With "stock_quant_manual_assign", if a user with "warehouse / user" group try to add a line in a picking he raise an error due to no rights for writing on "stock.picking.type". 
This error is because the related field "picking_type_code" must be readonly
