### PR TITLE
[ADD] [8.0] stock_account_quant_merge

### DIFF
--- a/stock_account_quant_merge/README.rst
+++ b/stock_account_quant_merge/README.rst
@@ -17,8 +17,11 @@ merge them back if they still meet the following requirements:
 * same location
 * same package
 * same unit cost
+* same incoming date
 
-
+The restriction to only merge quants that have been received in the same
+date, with the the same cost is very important when the product is defined
+with the real costing method.
 
 Usage
 =====

--- a/stock_account_quant_merge/README.rst
+++ b/stock_account_quant_merge/README.rst
@@ -1,0 +1,61 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================
+Stock Account Quant merge
+=========================
+
+This module is an extension of "stock_quant_merge", and adds the cost as a
+criteria to merge quants.
+
+Odoo splits quants each time a reservation is done: this module makes Odoo
+merge them back if they still meet the following requirements:
+
+* same product
+* same serial number/lot
+* same location
+* same package
+* same unit cost
+
+
+
+Usage
+=====
+
+The merge is done automatically when a reservation is undone. No user intervention is needed.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/153/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_account_quant_merge/__init__.py
+++ b/stock_account_quant_merge/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/stock_account_quant_merge/__openerp__.py
+++ b/stock_account_quant_merge/__openerp__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Stock Account - Quant merge",
+    "version": "8.0.1.0.0",
+    "depends": [
+        "stock_account",
+        "stock_quant_merge"
+    ],
+    "author": "Eficent Business and IT Consulting Services S.L."
+              "Odoo Community Association (OCA)",
+    "website": "http://www.eficent.com",
+    "category": "Warehouse Management",
+    "installable": True,
+    "license": "AGPL-3",
+    "images": [],
+}

--- a/stock_account_quant_merge/models/__init__.py
+++ b/stock_account_quant_merge/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import stock

--- a/stock_account_quant_merge/models/stock.py
+++ b/stock_account_quant_merge/models/stock.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, api
+
+
+class StockQuant(models.Model):
+    _inherit = 'stock.quant'
+
+    @api.multi
+    def _mergeable_domain(self):
+        domain = super(StockQuant, self)._mergeable_domain(self)
+
+        if self.product_id.cost_method == 'real':
+            domain += [('cost', '=', self.cost)]
+
+        return domain

--- a/stock_account_quant_merge/models/stock.py
+++ b/stock_account_quant_merge/models/stock.py
@@ -10,7 +10,7 @@ class StockQuant(models.Model):
 
     @api.multi
     def _mergeable_domain(self):
-        domain = super(StockQuant, self)._mergeable_domain(self)
+        domain = super(StockQuant, self)._mergeable_domain()
 
         if self.product_id.cost_method == 'real':
             domain += [('cost', '=', self.cost),

--- a/stock_account_quant_merge/models/stock.py
+++ b/stock_account_quant_merge/models/stock.py
@@ -13,6 +13,7 @@ class StockQuant(models.Model):
         domain = super(StockQuant, self)._mergeable_domain(self)
 
         if self.product_id.cost_method == 'real':
-            domain += [('cost', '=', self.cost)]
+            domain += [('cost', '=', self.cost),
+                       ('in_date', '=', self.in_date)]
 
         return domain

--- a/stock_account_quant_merge/tests/__init__.py
+++ b/stock_account_quant_merge/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_merge

--- a/stock_account_quant_merge/tests/test_merge.py
+++ b/stock_account_quant_merge/tests/test_merge.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+
+
+class TestMerge(TransactionCase):
+    """Test the potential quantity on a product with a multi-line BoM"""
+
+    def setUp(self):
+        super(TestMerge, self).setUp()
+
+        # Get the warehouses
+        self.wh_main = self.browse_ref('stock.warehouse0')
+        self.wh_ch = self.browse_ref('stock.stock_warehouse_shop0')
+
+        # Get a product
+        self.product = self.browse_ref('product.product_product_4')
+
+        # Change the cost method to 'Real Price'
+        self.product.cost_method = 'real'
+
+        # Zero out the inventory of the product
+        inventory = self.env['stock.inventory'].create(
+            {'name': 'Remove product for test',
+             'location_id': self.ref('stock.stock_location_locations'),
+             'filter': 'product',
+             'product_id': self.product.id})
+        inventory.prepare_inventory()
+        inventory.reset_real_qty()
+        inventory.action_done()
+
+        # Make sure we have some products in Chicago
+        inventory = self.env['stock.inventory'].create(
+            {'name': 'Test stock available for reservation',
+             'location_id': self.wh_ch.lot_stock_id.id,
+             'filter': 'none'})
+        self.product.standard_price = 10
+        inventory.prepare_inventory()
+        self.env['stock.inventory.line'].create({
+            'inventory_id': inventory.id,
+            'product_id': self.product.id,
+            'location_id': self.wh_ch.lot_stock_id.id,
+            'product_qty': 10.0})
+        inventory.action_done()
+
+        # Make sure we have some products in Chicago
+        inventory = self.env['stock.inventory'].create(
+            {'name': 'Test stock available for reservation',
+             'location_id': self.wh_ch.lot_stock_id.id,
+             'filter': 'none'})
+        self.product.standard_price = 20
+        inventory.prepare_inventory()
+        self.env['stock.inventory.line'].create({
+            'inventory_id': inventory.id,
+            'product_id': self.product.id,
+            'location_id': self.wh_ch.lot_stock_id.id,
+            'product_qty': 10.0})
+        inventory.action_done()
+
+    def test_merge(self):
+        quant_obj = self.env['stock.quant']
+        domain = [('location_id', '=', self.wh_ch.lot_stock_id.id),
+                  ('product_id', '=', self.product.id)]
+
+        quants = quant_obj.search(domain)
+        self.assertEqual(len(quants), 2, "There should be 2 quants")
+
+        # Make a reservation to split the quants
+        move_1 = self.env['stock.move'].create(
+            {'name': 'Test move',
+             'product_id': self.product.id,
+             'location_id': self.wh_ch.lot_stock_id.id,
+             'location_dest_id': self.wh_main.lot_stock_id.id,
+             'product_uom_qty': 15.0,
+             'product_uom': self.product.uom_id.id})
+        move_1.action_confirm()
+        move_1.action_assign()
+
+        # Make a reservation to split the quants
+        move_2 = self.env['stock.move'].create(
+            {'name': 'Test move',
+             'product_id': self.product.id,
+             'location_id': self.wh_ch.lot_stock_id.id,
+             'location_dest_id': self.wh_main.lot_stock_id.id,
+             'product_uom_qty': 3.0,
+             'product_uom': self.product.uom_id.id})
+        move_2.action_confirm()
+        move_2.action_assign()
+
+        quants = quant_obj.search(domain)
+        self.assertEqual(len(quants), 4, "There should be 4 quants")
+
+        # Cancel the second move : the quants with unit cost 20 should be
+        # merged back together
+        move_1.action_cancel()
+        quants = quant_obj.search(domain)
+        self.assertEqual(len(quants), 3, "There should be 3 quants")
+
+        # Cancel the first move : the quants with unit cost 20 should be
+        # merged back together
+        move_1.action_cancel()
+        quants = quant_obj.search(domain)
+        self.assertEqual(len(quants), 2, "There should be 2 quants")

--- a/stock_account_quant_merge/tests/test_merge.py
+++ b/stock_account_quant_merge/tests/test_merge.py
@@ -3,7 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp.addons.stock.tests.common import TestStockCommon
-import time
 
 
 class TestMerge(TestStockCommon):

--- a/stock_account_quant_merge/tests/test_merge.py
+++ b/stock_account_quant_merge/tests/test_merge.py
@@ -2,66 +2,78 @@
 # © 2016 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp.tests.common import TransactionCase
+from openerp.addons.stock.tests.common import TestStockCommon
+import time
 
 
-class TestMerge(TransactionCase):
+class TestMerge(TestStockCommon):
     """Test the potential quantity on a product with a multi-line BoM"""
 
     def setUp(self):
         super(TestMerge, self).setUp()
-
-        # Get the warehouses
-        self.wh_main = self.browse_ref('stock.warehouse0')
-        self.wh_ch = self.browse_ref('stock.stock_warehouse_shop0')
-
-        # Get a product
-        self.product = self.browse_ref('product.product_product_4')
-
-        # Change the cost method to 'Real Price'
-        self.product.cost_method = 'real'
+        loc_supplier_id = self.env.ref('stock.stock_location_suppliers')
+        self.loc_stock = self.env.ref('stock.stock_location_stock')
+        self.loc_scrap = self.env.ref('stock.stock_location_scrapped')
+        self.product = self.env.ref('product.product_product_36')
 
         # Zero out the inventory of the product
         inventory = self.env['stock.inventory'].create(
             {'name': 'Remove product for test',
-             'location_id': self.ref('stock.stock_location_locations'),
+             'location_id': self.loc_stock.id,
              'filter': 'product',
              'product_id': self.product.id})
         inventory.prepare_inventory()
         inventory.reset_real_qty()
         inventory.action_done()
 
-        # Make sure we have some products in Chicago
-        inventory = self.env['stock.inventory'].create(
-            {'name': 'Test stock available for reservation',
-             'location_id': self.wh_ch.lot_stock_id.id,
-             'filter': 'none'})
-        self.product.standard_price = 10
-        inventory.prepare_inventory()
-        self.env['stock.inventory.line'].create({
-            'inventory_id': inventory.id,
-            'product_id': self.product.id,
-            'location_id': self.wh_ch.lot_stock_id.id,
-            'product_qty': 10.0})
-        inventory.action_done()
+        self.picking_obj = self.env['stock.picking']
+        move_obj = self.env['stock.move']
 
-        # Make sure we have some products in Chicago
-        inventory = self.env['stock.inventory'].create(
-            {'name': 'Test stock available for reservation',
-             'location_id': self.wh_ch.lot_stock_id.id,
-             'filter': 'none'})
-        self.product.standard_price = 20
-        inventory.prepare_inventory()
-        self.env['stock.inventory.line'].create({
-            'inventory_id': inventory.id,
-            'product_id': self.product.id,
-            'location_id': self.wh_ch.lot_stock_id.id,
-            'product_qty': 10.0})
-        inventory.action_done()
+        self.picking_type = self.env.ref('stock.picking_type_in')
+
+        # Change the cost method to 'Real Price'
+        self.product.cost_method = 'real'
+
+        self.picking_1 = self.picking_obj.create(
+            {'picking_type_id': self.picking_type.id})
+        move_obj.create({'name': '/',
+                         'picking_id': self.picking_1.id,
+                         'product_uom': self.product.uom_id.id,
+                         'location_id': loc_supplier_id.id,
+                         'location_dest_id': self.loc_stock.id,
+                         'product_id': self.product.id,
+                         'price_unit': 10,
+                         'product_uom_qty': 10})
+        self.picking_1.action_confirm()
+        self._process_picking(self.picking_1)
+
+        self.picking_2 = self.picking_obj.create(
+            {'picking_type_id': self.picking_type.id})
+        move_obj.create({'name': '/',
+                         'picking_id': self.picking_2.id,
+                         'product_uom': self.product.uom_id.id,
+                         'location_id': loc_supplier_id.id,
+                         'location_dest_id': self.loc_stock.id,
+                         'product_id': self.product.id,
+                         'price_unit': 20,
+                         'product_uom_qty': 10})
+        self.picking_2.action_confirm()
+        self._process_picking(self.picking_2)
+
+    def _process_picking(self, picking):
+        """ Receive the picking
+        """
+        wiz_detail_obj = self.env['stock.transfer_details']
+        wiz_detail = wiz_detail_obj.with_context(
+            active_model='stock.picking',
+            active_ids=[picking.id],
+            active_id=picking.id).create({'picking_id': picking.id})
+        wiz_detail.item_ids[0].quantity = 10
+        wiz_detail.do_detailed_transfer()
 
     def test_merge(self):
         quant_obj = self.env['stock.quant']
-        domain = [('location_id', '=', self.wh_ch.lot_stock_id.id),
+        domain = [('location_id', '=', self.loc_stock.id),
                   ('product_id', '=', self.product.id)]
 
         quants = quant_obj.search(domain)
@@ -71,8 +83,8 @@ class TestMerge(TransactionCase):
         move_1 = self.env['stock.move'].create(
             {'name': 'Test move',
              'product_id': self.product.id,
-             'location_id': self.wh_ch.lot_stock_id.id,
-             'location_dest_id': self.wh_main.lot_stock_id.id,
+             'location_id': self.loc_stock.id,
+             'location_dest_id': self.loc_scrap.id,
              'product_uom_qty': 15.0,
              'product_uom': self.product.uom_id.id})
         move_1.action_confirm()
@@ -82,8 +94,8 @@ class TestMerge(TransactionCase):
         move_2 = self.env['stock.move'].create(
             {'name': 'Test move',
              'product_id': self.product.id,
-             'location_id': self.wh_ch.lot_stock_id.id,
-             'location_dest_id': self.wh_main.lot_stock_id.id,
+             'location_id': self.loc_stock.id,
+             'location_dest_id': self.loc_scrap.id,
              'product_uom_qty': 3.0,
              'product_uom': self.product.uom_id.id})
         move_2.action_confirm()
@@ -94,7 +106,7 @@ class TestMerge(TransactionCase):
 
         # Cancel the second move : the quants with unit cost 20 should be
         # merged back together
-        move_1.action_cancel()
+        move_2.action_cancel()
         quants = quant_obj.search(domain)
         self.assertEqual(len(quants), 3, "There should be 3 quants")
 


### PR DESCRIPTION
This module is an extension of "stock_quant_merge", and adds the cost as a
criteria to merge quants.

Odoo splits quants each time a reservation is done: this module makes Odoo
merge them back if they still meet the following requirements:
- same product
- same serial number/lot
- same location
- same package
- same unit cost
- same incoming date

The restriction to only merge quants that have been received in the same
date, with the the same cost is very important when the product is defined
with the real costing method.
