### PR TITLE
[10.0] Migrate stock_mts_mto_rule

### DIFF
--- a/stock_mts_mto_rule/README.rst
+++ b/stock_mts_mto_rule/README.rst
@@ -49,6 +49,15 @@ Configuration
 
 You have to select 'Use MTO+MTS rules' on the company's warehouse form.
 
+Known issues
+============
+
+If you cancel a delivery order and then recreate it from Recreate
+Delivery Order button in sale order form, then the stock level at the time of
+the Re-Creation won't be taken into account. So if a purchase order was created
+when the sale order was first validated, a similar purchase order will be created
+during the Re-creation of the delivery order, even if not needed regarding the actual stock.
+
 Bug Tracker
 ===========
 

--- a/stock_mts_mto_rule/README.rst
+++ b/stock_mts_mto_rule/README.rst
@@ -70,8 +70,6 @@ stock-logistics-warehouse/issues/new?body=module:%20
 stock_mts_mto_rule%0Aversion:%20
 8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
-Note: In order to see this option, you must enable "Manage advanced routes for your warehouse" under Settings -> Configuration -> Warehouse.
-
 Credits
 =======
 

--- a/stock_mts_mto_rule/README.rst
+++ b/stock_mts_mto_rule/README.rst
@@ -42,7 +42,7 @@ You should not select both the mts+mto route and the mto route.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/153/8.0
+   :target: https://runbot.odoo-community.org/runbot/153/10.0
 
 Configuration
 =============
@@ -64,11 +64,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/stock-logistics-warehouse/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed `feedback
-<https://github.com/OCA/
-stock-logistics-warehouse/issues/new?body=module:%20
-stock_mts_mto_rule%0Aversion:%20
-8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======

--- a/stock_mts_mto_rule/README.rst
+++ b/stock_mts_mto_rule/README.rst
@@ -1,6 +1,8 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :alt: License: AGPL-3
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
+==================
 Stock MTS+MTO Rule
 ==================
 
@@ -35,13 +37,29 @@ After validation, a purchase order with 2 products will be created.
 Usage
 =====
 
-You have to choose the mts+mto route on the product form.
-You should not choose both mts+mto route and mto route.
+You have to select the mts+mto route on the product form.
+You should not select both the mts+mto route and the mto route.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/153/8.0
 
 Configuration
 =============
 
-You have to choose 'Use MTO+MTS rules' on the company's warehouse form.
+You have to select 'Use MTO+MTS rules' on the company's warehouse form.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-warehouse/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+stock-logistics-warehouse/issues/new?body=module:%20
+stock_mts_mto_rule%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Note: In order to see this option, you must enable "Manage advanced routes for your warehouse" under Settings -> Configuration -> Warehouse.
 
@@ -56,9 +74,9 @@ Contributors
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
@@ -66,4 +84,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_mts_mto_rule/__manifest__.py
+++ b/stock_mts_mto_rule/__manifest__.py
@@ -21,7 +21,7 @@
 ##############################################################################
 
 {'name': 'Stock MTS+MTO Rule',
- 'version': '8.0.1.0.0',
+ 'version': '9.0.1.0.0',
  'author': 'Akretion,Odoo Community Association (OCA)',
  'website': 'http://www.akretion.com',
  'license': 'AGPL-3',
@@ -34,5 +34,5 @@
           'view/pull_rule.xml',
           'view/warehouse.xml',
           ],
- 'installable': False,
+ 'installable': True,
  }

--- a/stock_mts_mto_rule/__manifest__.py
+++ b/stock_mts_mto_rule/__manifest__.py
@@ -1,27 +1,8 @@
 # -*- coding: utf-8 -*-
-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2015 Akretion (<http://www.akretion.com>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {'name': 'Stock MTS+MTO Rule',
- 'version': '9.0.1.0.0',
+ 'version': '10.0.1.0.0',
  'author': 'Akretion,Odoo Community Association (OCA)',
  'website': 'http://www.akretion.com',
  'license': 'AGPL-3',

--- a/stock_mts_mto_rule/data/stock_data.xml
+++ b/stock_mts_mto_rule/data/stock_data.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<odoo>
 
-        <!--
-             Procurement rules
-        -->
-        
-        <record id="route_mto_mts" model='stock.location.route'>
-            <field name="name">Make To Order + Make To Stock</field>
-            <field name="sequence">5</field>
-            <field name="product_selectable" eval="True"/>
-        </record>
+    <!--
+         Procurement rules
+    -->
 
+    <record id="route_mto_mts" model='stock.location.route'>
+        <field name="name">Make To Order + Make To Stock</field>
+        <field name="sequence">5</field>
+        <field name="product_selectable" eval="True"/>
+    </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/stock_mts_mto_rule/i18n/de.po
+++ b/stock_mts_mto_rule/i18n/de.po
@@ -1,0 +1,107 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_mts_mto_rule
+# 
+# Translators:
+# Rudolf Schnapka <rs@techno-flex.de>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: stock-logistics-warehouse (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-01-14 01:38+0000\n"
+"PO-Revision-Date: 2016-01-14 09:50+0000\n"
+"Last-Translator: Rudolf Schnapka <rs@techno-flex.de>\n"
+"Language-Team: German (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-8-0/language/de/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:53
+#, python-format
+msgid "Can't find MTO Rule on the warehouse"
+msgstr "Kann MTO-Regel zum Lager nicht finden"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:60
+#, python-format
+msgid "Can't find MTS Rule on the warehouse"
+msgstr "Kann MTS-Regel zum Lager nicht finden"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:49
+#, python-format
+msgid "Can't find any generic MTS+MTO route."
+msgstr "Kann keine allg. MTO- oder MTS-Route finden"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/rule.py:36
+#, python-format
+msgid "Choose between MTS and MTO"
+msgstr "Wähle aus MTO und MTS"
+
+#. module: stock_mts_mto_rule
+#: help:stock.warehouse,mto_mts_management:0
+msgid ""
+"If this new route is selected on product form view, a purchase order will be"
+" created only if the virtual stock is less than 0 else, the product will be "
+"taken from stocks"
+msgstr "Wird diese neue Route in der Produktdetailsicht gewählt, wird eine Beschaffung nur dann bewirkt, wenn der Planbestand unter 0 fällt, anderenfalls wird das Produkt aus dem Bestand genommen."
+
+#. module: stock_mts_mto_rule
+#: field:procurement.rule,mto_rule_id:0
+msgid "MTO Rule"
+msgstr "MTO-Regel"
+
+#. module: stock_mts_mto_rule
+#: field:stock.warehouse,mts_mto_rule_id:0
+msgid "MTO+MTS rule"
+msgstr "MTO+MTS-Regel"
+
+#. module: stock_mts_mto_rule
+#: field:procurement.rule,mts_rule_id:0
+msgid "MTS Rule"
+msgstr "MTS-Regel"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:63
+#, python-format
+msgid "MTS+MTO"
+msgstr "MTS+MTO"
+
+#. module: stock_mts_mto_rule
+#: model:stock.location.route,name:stock_mts_mto_rule.route_mto_mts
+msgid "Make To Order + Make To Stock"
+msgstr "MTO Auftragsfertigung + MTS Lagerfertigung"
+
+#. module: stock_mts_mto_rule
+#: field:procurement.order,mts_mto_procurement_id:0
+msgid "Mto+Mts Procurement"
+msgstr "MTO+MTS-Beschaffung"
+
+#. module: stock_mts_mto_rule
+#: model:ir.model,name:stock_mts_mto_rule.model_procurement_order
+msgid "Procurement"
+msgstr "Beschaffung"
+
+#. module: stock_mts_mto_rule
+#: model:ir.model,name:stock_mts_mto_rule.model_procurement_rule
+msgid "Procurement Rule"
+msgstr "Beschaffungsregel"
+
+#. module: stock_mts_mto_rule
+#: field:procurement.order,mts_mto_procurement_ids:0
+msgid "Procurements"
+msgstr "Beschaffungen"
+
+#. module: stock_mts_mto_rule
+#: field:stock.warehouse,mto_mts_management:0
+msgid "Use MTO+MTS rules"
+msgstr "Verwende MTO+MTS-Regeln"
+
+#. module: stock_mts_mto_rule
+#: model:ir.model,name:stock_mts_mto_rule.model_stock_warehouse
+msgid "Warehouse"
+msgstr "Warenlager"

--- a/stock_mts_mto_rule/i18n/es.po
+++ b/stock_mts_mto_rule/i18n/es.po
@@ -1,0 +1,107 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_mts_mto_rule
+# 
+# Translators:
+# Antonio Trueba, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: stock-logistics-warehouse (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-01-14 01:38+0000\n"
+"PO-Revision-Date: 2016-02-10 16:39+0000\n"
+"Last-Translator: Antonio Trueba\n"
+"Language-Team: Spanish (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-8-0/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:53
+#, python-format
+msgid "Can't find MTO Rule on the warehouse"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:60
+#, python-format
+msgid "Can't find MTS Rule on the warehouse"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:49
+#, python-format
+msgid "Can't find any generic MTS+MTO route."
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/rule.py:36
+#, python-format
+msgid "Choose between MTS and MTO"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: help:stock.warehouse,mto_mts_management:0
+msgid ""
+"If this new route is selected on product form view, a purchase order will be"
+" created only if the virtual stock is less than 0 else, the product will be "
+"taken from stocks"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: field:procurement.rule,mto_rule_id:0
+msgid "MTO Rule"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: field:stock.warehouse,mts_mto_rule_id:0
+msgid "MTO+MTS rule"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: field:procurement.rule,mts_rule_id:0
+msgid "MTS Rule"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:63
+#, python-format
+msgid "MTS+MTO"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: model:stock.location.route,name:stock_mts_mto_rule.route_mto_mts
+msgid "Make To Order + Make To Stock"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: field:procurement.order,mts_mto_procurement_id:0
+msgid "Mto+Mts Procurement"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: model:ir.model,name:stock_mts_mto_rule.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+
+#. module: stock_mts_mto_rule
+#: model:ir.model,name:stock_mts_mto_rule.model_procurement_rule
+msgid "Procurement Rule"
+msgstr "Regla de abastecimiento"
+
+#. module: stock_mts_mto_rule
+#: field:procurement.order,mts_mto_procurement_ids:0
+msgid "Procurements"
+msgstr "Abastecimientos"
+
+#. module: stock_mts_mto_rule
+#: field:stock.warehouse,mto_mts_management:0
+msgid "Use MTO+MTS rules"
+msgstr ""
+
+#. module: stock_mts_mto_rule
+#: model:ir.model,name:stock_mts_mto_rule.model_stock_warehouse
+msgid "Warehouse"
+msgstr "Almacén"

--- a/stock_mts_mto_rule/i18n/sl.po
+++ b/stock_mts_mto_rule/i18n/sl.po
@@ -1,0 +1,107 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_mts_mto_rule
+# 
+# Translators:
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: stock-logistics-warehouse (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-24 09:07+0000\n"
+"PO-Revision-Date: 2015-10-23 12:22+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>\n"
+"Language-Team: Slovenian (http://www.transifex.com/oca/OCA-stock-logistics-warehouse-8-0/language/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:53
+#, python-format
+msgid "Can't find MTO Rule on the warehouse"
+msgstr "Za skladišče ni pravila 'po naročilu'"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:60
+#, python-format
+msgid "Can't find MTS Rule on the warehouse"
+msgstr "Za skladišče ni pravila 'na zalogo'"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:49
+#, python-format
+msgid "Can't find any generic MTS+MTO route."
+msgstr "Ni generične proge 'na zalogo' + 'po naročilu'"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/rule.py:36
+#, python-format
+msgid "Choose between MTS and MTO"
+msgstr "Izbira med 'Na zalogo' in 'Po naročilu'"
+
+#. module: stock_mts_mto_rule
+#: help:stock.warehouse,mto_mts_management:0
+msgid ""
+"If this new route is selected on product form view, a purchase order will be"
+" created only if the virtual stock is less than 0 else, the product will be "
+"taken from stocks"
+msgstr "Če je na prikazu obrazca proizvoda izbrana ta proga, se nabavni nalog ustvari le, če je navidezna zaloga manj od 0. V nasprotnem primeru se proizvod vzame iz zaloge."
+
+#. module: stock_mts_mto_rule
+#: field:procurement.rule,mto_rule_id:0
+msgid "MTO Rule"
+msgstr "Pravilo 'Po naročilu'"
+
+#. module: stock_mts_mto_rule
+#: field:stock.warehouse,mts_mto_rule_id:0
+msgid "MTO+MTS rule"
+msgstr "Pravilo 'Po naročilu' + 'Na zalogo'"
+
+#. module: stock_mts_mto_rule
+#: field:procurement.rule,mts_rule_id:0
+msgid "MTS Rule"
+msgstr "Pravilo 'Na zalogo'"
+
+#. module: stock_mts_mto_rule
+#: code:addons/stock_mts_mto_rule/model/warehouse.py:63
+#, python-format
+msgid "MTS+MTO"
+msgstr "Na zalogo + Po naročilu"
+
+#. module: stock_mts_mto_rule
+#: model:stock.location.route,name:stock_mts_mto_rule.route_mto_mts
+msgid "Make To Order + Make To Stock"
+msgstr "Naredi po naročilu + Naredi na zalogo"
+
+#. module: stock_mts_mto_rule
+#: field:procurement.order,mts_mto_procurement_id:0
+msgid "Mto+Mts Procurement"
+msgstr "Oskrbovanja 'po naročilu'+'na zalogo'"
+
+#. module: stock_mts_mto_rule
+#: model:ir.model,name:stock_mts_mto_rule.model_procurement_order
+msgid "Procurement"
+msgstr "Oskrbovanje"
+
+#. module: stock_mts_mto_rule
+#: model:ir.model,name:stock_mts_mto_rule.model_procurement_rule
+msgid "Procurement Rule"
+msgstr "Oskrbovalno pravilo"
+
+#. module: stock_mts_mto_rule
+#: field:procurement.order,mts_mto_procurement_ids:0
+msgid "Procurements"
+msgstr "Oskrbovanja"
+
+#. module: stock_mts_mto_rule
+#: field:stock.warehouse,mto_mts_management:0
+msgid "Use MTO+MTS rules"
+msgstr "Uporabi pravila Po naročilu + Na zalogo"
+
+#. module: stock_mts_mto_rule
+#: model:ir.model,name:stock_mts_mto_rule.model_stock_warehouse
+msgid "Warehouse"
+msgstr "Skladišče"

--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -92,6 +92,8 @@ class ProcurementOrder(models.Model):
     def _run(self, procurement):
         if procurement.rule_id and \
                 procurement.rule_id.action == 'split_procurement':
+            if procurement.mts_mto_procurement_ids:
+                return super(ProcurementOrder, self)._run(procurement)
             uom_obj = self.env['product.uom']
             needed_qty = procurement.get_mto_qty_to_order()
             rule = procurement.rule_id

--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -19,11 +19,20 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ###############################################################################
-from openerp import models, api
+from openerp import models, api, fields
 
 
 class ProcurementOrder(models.Model):
     _inherit = 'procurement.order'
+
+    mts_mto_procurement_id = fields.Many2one(
+        'procurement.order',
+        string="Mto+Mts Procurement",
+        copy=False)
+    mts_mto_procurement_ids = fields.One2many(
+        'procurement.order',
+        'mts_mto_procurement_id',
+        string="Procurements")
 
     @api.multi
     def get_mto_qty_to_order(self):
@@ -52,23 +61,31 @@ class ProcurementOrder(models.Model):
             'product_qty': qty,
             'product_uos_qty': uos_qty,
             'rule_id': rule.id,
+            'mts_mto_procurement_id': proc.id,
         }
 
     @api.model
     def _check(self, procurement):
         if procurement.rule_id and \
                 procurement.rule_id.action == 'split_procurement':
-            if procurement.state == 'running':
+            cancel_proc_list = [x.state == 'cancel'
+                                for x in procurement.mts_mto_procurement_ids]
+            done_cancel_test_list = [
+                x.state in ('done', 'cancel')
+                for x in procurement.mts_mto_procurement_ids]
+            if all(cancel_proc_list):
+                procurement.write({'state': 'cancel'})
+            elif all(done_cancel_test_list):
                 return True
         return super(ProcurementOrder, self)._check(procurement)
 
     @api.multi
-    def run(self, autocommit=False):
-        res = super(ProcurementOrder, self).run(autocommit=autocommit)
-        for proc in self:
-            if proc.rule_id and \
-                    proc.rule_id.action == 'split_procurement':
-                proc.check()
+    def check(self, autocommit=False):
+        res = super(ProcurementOrder, self).check(autocommit=autocommit)
+        for procurement in self:
+            if procurement.mts_mto_procurement_id:
+                procurement.mts_mto_procurement_id.check(
+                    autocommit=autocommit)
         return res
 
     @api.model

--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -1,25 +1,7 @@
 # -*- coding: utf-8 -*-
-###############################################################################
-#
-#    Module for OpenERP
-#    Copyright (C) 2015 Akretion (http://www.akretion.com). All Rights Reserved
-#    @author Florian DA COSTA <florian.dacosta@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
-from openerp import api, fields, models
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
 
 
 class ProcurementOrder(models.Model):
@@ -37,13 +19,12 @@ class ProcurementOrder(models.Model):
     @api.multi
     def get_mto_qty_to_order(self):
         self.ensure_one()
-        uom_obj = self.env['product.uom']
         stock_location = self.warehouse_id.lot_stock_id.id
         proc_warehouse = self.with_context(location=stock_location)
         virtual_available = proc_warehouse.product_id.virtual_available
-        qty_available = uom_obj._compute_qty(self.product_id.uom_id.id,
-                                             virtual_available,
-                                             self.product_uom.id)
+        qty_available = self.product_id.uom_id._compute_quantity(
+            virtual_available, self.product_uom)
+
         if qty_available > 0:
             if qty_available >= self.product_qty:
                 return 0.0
@@ -51,16 +32,17 @@ class ProcurementOrder(models.Model):
                 return self.product_qty - qty_available
         return self.product_qty
 
-    @api.model
-    def _get_mts_mto_procurement(self, proc, rule, qty):
-        origin = (proc.group_id and (proc.group_id.name + ":") or "") + \
-                 (proc.rule_id and proc.rule_id.name or proc.origin or "/")
+    @api.multi
+    def _get_mts_mto_procurement(self, rule, qty):
+        self.ensure_one()
+        origin = (self.group_id and (self.group_id.name + ":") or "") + \
+                 (self.rule_id and self.rule_id.name or self.origin or "/")
         return {
-            'name': proc.name,
+            'name': self.name,
             'origin': origin,
             'product_qty': qty,
             'rule_id': rule.id,
-            'mts_mto_procurement_id': proc.id,
+            'mts_mto_procurement_id': self.id,
         }
 
     @api.model
@@ -87,34 +69,34 @@ class ProcurementOrder(models.Model):
                     autocommit=autocommit)
         return res
 
-    @api.model
-    def _run(self, procurement):
-        if procurement.rule_id and \
-                procurement.rule_id.action == 'split_procurement':
-            if procurement.mts_mto_procurement_ids:
-                return super(ProcurementOrder, self)._run(procurement)
-            needed_qty = procurement.get_mto_qty_to_order()
-            rule = procurement.rule_id
+    @api.multi
+    def _run(self):
+        self.ensure_one()
+        if self.rule_id and self.rule_id.action == 'split_procurement':
+            if self.mts_mto_procurement_ids:
+                return super(ProcurementOrder, self)._run()
+            needed_qty = self.get_mto_qty_to_order()
+            rule = self.rule_id
             if needed_qty == 0.0:
                 mts_vals = self._get_mts_mto_procurement(
-                    procurement, rule.mts_rule_id, procurement.product_qty)
-                mts_proc = procurement.copy(mts_vals)
+                    rule.mts_rule_id, self.product_qty)
+                mts_proc = self.copy(mts_vals)
                 mts_proc.run()
-            elif needed_qty == procurement.product_qty:
+            elif needed_qty == self.product_qty:
                 mto_vals = self._get_mts_mto_procurement(
-                    procurement, rule.mto_rule_id, procurement.product_qty)
-                mto_proc = procurement.copy(mto_vals)
+                    rule.mto_rule_id, self.product_qty)
+                mto_proc = self.copy(mto_vals)
                 mto_proc.run()
             else:
-                mts_qty = procurement.product_qty - needed_qty
+                mts_qty = self.product_qty - needed_qty
                 mts_vals = self._get_mts_mto_procurement(
-                    procurement, rule.mts_rule_id, mts_qty)
-                mts_proc = procurement.copy(mts_vals)
+                    rule.mts_rule_id, mts_qty)
+                mts_proc = self.copy(mts_vals)
                 mts_proc.run()
 
                 mto_vals = self._get_mts_mto_procurement(
-                    procurement, rule.mto_rule_id, needed_qty)
-                mto_proc = procurement.copy(mto_vals)
+                    rule.mto_rule_id, needed_qty)
+                mto_proc = self.copy(mto_vals)
                 mto_proc.run()
 
-        return super(ProcurementOrder, self)._run(procurement)
+        return super(ProcurementOrder, self)._run()

--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -56,7 +56,7 @@ class ProcurementOrder(models.Model):
         origin = (proc.group_id and (proc.group_id.name + ":") or "") + \
                  (proc.rule_id and proc.rule_id.name or proc.origin or "/")
         return {
-            'name': rule.name,
+            'name': proc.name,
             'origin': origin,
             'product_qty': qty,
             'product_uos_qty': uos_qty,

--- a/stock_mts_mto_rule/model/rule.py
+++ b/stock_mts_mto_rule/model/rule.py
@@ -1,26 +1,8 @@
 # -*- coding: utf-8 -*-
-###############################################################################
-#
-#    Module for OpenERP
-#    Copyright (C) 2015 Akretion (http://www.akretion.com). All Rights Reserved
-#    @author Florian DA COSTA <florian.dacosta@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
-from openerp import models, api, fields
-from openerp.tools.translate import _
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, api, fields
+from odoo.tools.translate import _
 
 
 class ProcurementRule(models.Model):

--- a/stock_mts_mto_rule/model/warehouse.py
+++ b/stock_mts_mto_rule/model/warehouse.py
@@ -1,26 +1,8 @@
 # -*- coding: utf-8 -*-
-###############################################################################
-#
-#    Module for OpenERP
-#    Copyright (C) 2015 Akretion (http://www.akretion.com). All Rights Reserved
-#    @author Florian DA COSTA <florian.dacosta@akretion.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
-from openerp import models, api, fields, exceptions
-from openerp.tools.translate import _
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, api, fields, exceptions
+from odoo.tools.translate import _
 
 
 class Warehouse(models.Model):
@@ -60,7 +42,7 @@ class Warehouse(models.Model):
             raise exceptions.Warning(_(
                 'Can\'t find MTS Rule on the warehouse'))
         return {
-            'name': self._format_routename(warehouse, _('MTS+MTO')),
+            'name': warehouse._format_routename(route_type='mts_mto'),
             'route_id': mts_mto_route.id,
             'action': 'split_procurement',
             'mto_rule_id': warehouse.mto_pull_id.id,
@@ -116,8 +98,7 @@ class Warehouse(models.Model):
                         warehouse.mts_mto_rule_id.unlink()
         res = super(Warehouse, self).write(vals)
         if 'mto_mts_management' in vals:
-            self.with_context({'active_test': False}).change_route(
-                warehouse, new_delivery_step=warehouse.delivery_steps)
+            self.with_context({'active_test': False})._update_routes()
         return res
 
     @api.model
@@ -141,21 +122,24 @@ class Warehouse(models.Model):
             )
         return res
 
-    @api.multi
-    def change_route(self, warehouse, new_reception_step=False,
-                     new_delivery_step=False):
-        res = super(Warehouse, self).change_route(
-            warehouse,
-            new_reception_step=new_reception_step,
-            new_delivery_step=new_delivery_step)
+    def _get_route_name(self, route_type):
+        names = {'mts_mto': _('MTS+MTO')}
+        if route_type in names:
+            return names[route_type]
 
-        mts_mto_rule_id = warehouse.mts_mto_rule_id
-        if new_delivery_step and mts_mto_rule_id:
+        return super(Warehouse, self)._get_route_name(route_type)
+
+    @api.multi
+    def _update_routes(self):
+        res = super(Warehouse, self)._update_routes()
+
+        mts_mto_rule_id = self.mts_mto_rule_id
+        if self.delivery_steps and mts_mto_rule_id:
             pull_model = self.env['procurement.rule']
-            warehouse.mts_mto_rule_id.location_id = (
-                warehouse.mto_pull_id.location_id)
-            mts_rules = pull_model.search(
-                [('location_src_id', '=', warehouse.lot_stock_id.id),
-                 ('route_id', '=', warehouse.delivery_route_id.id)])
-            warehouse.mts_mto_rule_id.mts_rule_id = mts_rules[0].id
+            self.mts_mto_rule_id.location_id = self.mto_pull_id.location_id
+            mts_rules = pull_model.search([
+                ('location_src_id', '=', self.lot_stock_id.id),
+                ('route_id', '=', self.delivery_route_id.id),
+            ])
+            self.mts_mto_rule_id.mts_rule_id = mts_rules[0].id
         return res

--- a/stock_mts_mto_rule/tests/test_mto_mts_route.py
+++ b/stock_mts_mto_rule/tests/test_mto_mts_route.py
@@ -34,12 +34,15 @@ class TestMtoMtsRoute(TransactionCase):
 
     def test_standard_mts_route(self):
         self.procurement.run()
+        procurement_id = self.procurement_obj.search([
+            ('group_id', '=', self.procurement.group_id.id),
+            ('move_ids', '!=', False)], limit=1)
         self.assertEqual('make_to_stock',
-                         self.procurement.move_ids[0].procure_method)
+                         procurement_id.move_ids[0].procure_method)
         self.assertEqual(self.procurement.product_qty,
-                         self.procurement.move_ids[0].product_uom_qty)
+                         procurement_id.move_ids[0].product_uom_qty)
         self.assertEqual('confirmed',
-                         self.procurement.move_ids[0].state)
+                         procurement_id.move_ids[0].state)
 
     def test_mts_mto_route_split(self):
         mto_mts_route = self.env.ref('stock_mts_mto_rule.route_mto_mts')
@@ -81,6 +84,7 @@ class TestMtoMtsRoute(TransactionCase):
         self.warehouse.mto_mts_management = True
         self.product = self.env.ref('product.product_product_4')
         self.company_partner = self.env.ref('base.main_partner')
+        self.procurement_obj = self.env['procurement.order']
         self.group = self.env['procurement.group'].create({
             'name': 'test',
         })

--- a/stock_mts_mto_rule/tests/test_mto_mts_route.py
+++ b/stock_mts_mto_rule/tests/test_mto_mts_route.py
@@ -1,19 +1,7 @@
-#    Author: Florian da Costa
-#    Copyright 2015 Akretion
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from openerp.tests.common import TransactionCase
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
 from datetime import datetime
 
 

--- a/stock_mts_mto_rule/tests/test_mto_mts_route.py
+++ b/stock_mts_mto_rule/tests/test_mto_mts_route.py
@@ -19,10 +19,24 @@ from datetime import datetime
 
 class TestMtoMtsRoute(TransactionCase):
 
+    def _procurement_create(self):
+        self.procurement = self.env['procurement.order'].create({
+            'location_id': self.env.ref('stock.stock_location_customers').id,
+            'product_id': self.product.id,
+            'product_qty': 2.0,
+            'product_uom': 1,
+            'warehouse_id': self.warehouse.id,
+            'priority': '1',
+            'date_planned': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            'name': self.product.name,
+            'origin': 'test',
+            'group_id': self.group.id,
+        })
+
     def test_standard_mto_route(self):
         mto_route = self.env.ref('stock.route_warehouse0_mto')
         self.product.route_ids = [(6, 0, [mto_route.id])]
-        self.procurement.run()
+        self._procurement_create()
         self.assertEqual(self.warehouse.mto_pull_id,
                          self.procurement.rule_id)
         self.assertEqual('make_to_order',
@@ -33,7 +47,7 @@ class TestMtoMtsRoute(TransactionCase):
                          self.procurement.move_ids[0].state)
 
     def test_standard_mts_route(self):
-        self.procurement.run()
+        self._procurement_create()
         procurement_id = self.procurement_obj.search([
             ('group_id', '=', self.procurement.group_id.id),
             ('move_ids', '!=', False)], limit=1)
@@ -48,7 +62,7 @@ class TestMtoMtsRoute(TransactionCase):
         mto_mts_route = self.env.ref('stock_mts_mto_rule.route_mto_mts')
         self.product.route_ids = [(6, 0, [mto_mts_route.id])]
         self.quant.qty = 1.0
-        self.procurement.run()
+        self._procurement_create()
         moves = self.env['stock.move'].search(
             [('group_id', '=', self.group.id)])
         self.assertEqual(2, len(moves))
@@ -58,7 +72,7 @@ class TestMtoMtsRoute(TransactionCase):
         mto_mts_route = self.env.ref('stock_mts_mto_rule.route_mto_mts')
         self.product.route_ids = [(6, 0, [mto_mts_route.id])]
         self.quant.qty = 0.0
-        self.procurement.run()
+        self._procurement_create()
         moves = self.env['stock.move'].search(
             [('group_id', '=', self.group.id)])
         self.assertEqual(1, len(moves))
@@ -70,7 +84,7 @@ class TestMtoMtsRoute(TransactionCase):
         mto_mts_route = self.env.ref('stock_mts_mto_rule.route_mto_mts')
         self.product.route_ids = [(6, 0, [mto_mts_route.id])]
         self.quant.qty = 3.0
-        self.procurement.run()
+        self._procurement_create()
         moves = self.env['stock.move'].search(
             [('group_id', '=', self.group.id)])
         self.assertEqual(1, len(moves))
@@ -88,18 +102,7 @@ class TestMtoMtsRoute(TransactionCase):
         self.group = self.env['procurement.group'].create({
             'name': 'test',
         })
-        self.procurement = self.env['procurement.order'].create({
-            'location_id': self.env.ref('stock.stock_location_customers').id,
-            'product_id': self.product.id,
-            'product_qty': 2.0,
-            'product_uom': 1,
-            'warehouse_id': self.warehouse.id,
-            'priority': '1',
-            'date_planned': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            'name': self.product.name,
-            'origin': 'test',
-            'group_id': self.group.id,
-        })
+
         self.quant = self.env['stock.quant'].create({
             'owner_id': self.company_partner.id,
             'location_id': self.env.ref('stock.stock_location_stock').id,

--- a/stock_mts_mto_rule/view/pull_rule.xml
+++ b/stock_mts_mto_rule/view/pull_rule.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openerp>
-    <data>
-        <record id="view_procurement_rule_form_mto_mto" model="ir.ui.view">
-            <field name="name">procurement.rule.mts.mto</field>
-            <field name="model">procurement.rule</field>
-            <field name="inherit_id" ref="procurement.view_procurement_rule_form" />
-            <field name="arch" type="xml">
-                <field name="action" position="after">
-                    <field name="mts_rule_id" 
-                           groups="stock.group_adv_location"
-                           attrs="{'invisible': [('action', '!=', 'split_procurement')]}"/>
-                    <field name="mto_rule_id" 
-                           groups="stock.group_adv_location"
-                           attrs="{'invisible': [('action', '!=', 'split_procurement')]}"/>
-                </field>
-            </field>
-        </record>
+<odoo>
 
-    </data>
-</openerp>
+    <record id="view_procurement_rule_form_mto_mto" model="ir.ui.view">
+        <field name="name">procurement.rule.mts.mto</field>
+        <field name="model">procurement.rule</field>
+        <field name="inherit_id" ref="procurement.view_procurement_rule_form" />
+        <field name="arch" type="xml">
+            <field name="action" position="after">
+                <field name="mts_rule_id" 
+                    groups="stock.group_adv_location"
+                    attrs="{'invisible': [('action', '!=', 'split_procurement')]}"/>
+                <field name="mto_rule_id" 
+                    groups="stock.group_adv_location"
+                    attrs="{'invisible': [('action', '!=', 'split_procurement')]}"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/stock_mts_mto_rule/view/warehouse.xml
+++ b/stock_mts_mto_rule/view/warehouse.xml
@@ -1,17 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-  <data>
+<odoo>
 
     <record id="view_warehouse_inherited" model="ir.ui.view">
-      <field name="name">view_warehouse_inherited</field>
-      <field name="model">stock.warehouse</field>
-      <field name="inherit_id" ref="stock.view_warehouse"/>
-      <field name="arch" type="xml">
-        <xpath expr="//field[@name='delivery_steps']" position="after">
-          <field name="mto_mts_management" />
-        </xpath>
-      </field>
+        <field name="name">view_warehouse_inherited</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.view_warehouse"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='delivery_steps']" position="after">
+                <field name="mto_mts_management" />
+            </xpath>
+        </field>
     </record>
 
-  </data>
-</openerp>
+</odoo>


### PR DESCRIPTION
Changes in this PR :
- Updated from v8.0 branch + included #157
- The `_compute_qty` method of product.uom has been replaced by `_compute_quantity`
- The `_get_mts_mto_procurement` and `_run` methods of procurement.order have been converted from @api.model to @api.multi
- Added the `_get_route_name` method override, to add the `mts_mto` type (+ adapted the corresponding `_format_routename` calls)
- The `change_route` method of stock.warehouse has been replaced by `_update_routes`, and no longer has any argument
