### PR TITLE
[10.0] Fix v10 migration

### DIFF
--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -45,20 +45,21 @@ class ProcurementOrder(models.Model):
             'mts_mto_procurement_id': self.id,
         }
 
-    @api.model
-    def _check(self, procurement):
-        if procurement.rule_id and \
-                procurement.rule_id.action == 'split_procurement':
+    @api.multi
+    def _check(self):
+        self.ensure_one()
+        if self.rule_id and \
+                self.rule_id.action == 'split_procurement':
             cancel_proc_list = [x.state == 'cancel'
-                                for x in procurement.mts_mto_procurement_ids]
+                                for x in self.mts_mto_procurement_ids]
             done_cancel_test_list = [
                 x.state in ('done', 'cancel')
-                for x in procurement.mts_mto_procurement_ids]
+                for x in self.mts_mto_procurement_ids]
             if all(cancel_proc_list):
-                procurement.write({'state': 'cancel'})
+                self.write({'state': 'cancel'})
             elif all(done_cancel_test_list):
                 return True
-        return super(ProcurementOrder, self)._check(procurement)
+        return super(ProcurementOrder, self)._check()
 
     @api.multi
     def check(self, autocommit=False):

--- a/stock_mts_mto_rule/model/warehouse.py
+++ b/stock_mts_mto_rule/model/warehouse.py
@@ -16,8 +16,9 @@ class Warehouse(models.Model):
     mts_mto_rule_id = fields.Many2one('procurement.rule',
                                       'MTO+MTS rule')
 
-    @api.model
-    def _get_mts_mto_rule(self, warehouse):
+    @api.multi
+    def _get_mts_mto_rule(self):
+        self.ensure_one()
         route_model = self.env['stock.location.route']
         pull_model = self.env['procurement.rule']
         try:
@@ -31,35 +32,50 @@ class Warehouse(models.Model):
             raise exceptions.Warning(_(
                 'Can\'t find any generic MTS+MTO route.'))
 
-        if not warehouse.mto_pull_id:
+        if not self.mto_pull_id:
             raise exceptions.Warning(_(
                 'Can\'t find MTO Rule on the warehouse'))
 
         mts_rules = pull_model.search(
-            [('location_src_id', '=', warehouse.lot_stock_id.id),
-             ('route_id', '=', warehouse.delivery_route_id.id)])
+            [('location_src_id', '=', self.lot_stock_id.id),
+             ('route_id', '=', self.delivery_route_id.id)])
         if not mts_rules:
             raise exceptions.Warning(_(
                 'Can\'t find MTS Rule on the warehouse'))
         return {
-            'name': warehouse._format_routename(route_type='mts_mto'),
+            'name': self._format_routename(route_type='mts_mto'),
             'route_id': mts_mto_route.id,
             'action': 'split_procurement',
-            'mto_rule_id': warehouse.mto_pull_id.id,
+            'mto_rule_id': self.mto_pull_id.id,
             'mts_rule_id': mts_rules[0].id,
-            'warehouse_id': warehouse.id,
-            'location_id': warehouse.mto_pull_id.location_id.id,
-            'picking_type_id': warehouse.mto_pull_id.picking_type_id.id,
+            'warehouse_id': self.id,
+            'location_id': self.mto_pull_id.location_id.id,
+            'picking_type_id': self.mto_pull_id.picking_type_id.id,
         }
 
-    @api.model
-    def _get_push_pull_rules(self, warehouse, active, values, new_route_id):
+    def _get_mto_pull_rules_values(self, route_values):
+        """
+        Prevent changing standard MTO rules' action from "move"
+        """
+        pull_rules_list = super(Warehouse, self)._get_mto_pull_rules_values(
+            route_values)
+        for pull_rule in pull_rules_list:
+            pull_rule['action'] = 'move'
+
+        return pull_rules_list
+
+    @api.multi
+    def _get_push_pull_rules_values(
+            self, route_values, values=None, push_values=None,
+            pull_values=None, name_suffix=''):
+        self.ensure_one()
         pull_obj = self.env['procurement.rule']
-        res = super(Warehouse, self)._get_push_pull_rules(
-            warehouse, active, values, new_route_id)
-        customer_location = warehouse._get_partner_locations()
+        res = super(Warehouse, self)._get_push_pull_rules_values(
+            route_values, values=values, push_values=push_values,
+            pull_values=pull_values, name_suffix=name_suffix)
+        customer_location = self._get_partner_locations()
         location_id = customer_location[0].id
-        if warehouse.mto_mts_management:
+        if self.mto_mts_management:
             for pull in res[1]:
                 if pull['location_id'] == location_id:
                     pull_mto_mts = pull.copy()
@@ -69,15 +85,15 @@ class Warehouse(models.Model):
                         'mto_rule_id': pull_mto_mts_id.id,
                         'mts_rule_id': pull_mto_mts_id.id,
                         'sequence': 10
-                        })
+                    })
         return res
 
     @api.multi
-    def create_routes(self, warehouse):
+    def create_routes(self):
         pull_model = self.env['procurement.rule']
-        res = super(Warehouse, self).create_routes(warehouse)
-        if warehouse.mto_mts_management:
-            mts_mto_pull_vals = self._get_mts_mto_rule(warehouse)
+        res = super(Warehouse, self).create_routes()
+        if self.mto_mts_management:
+            mts_mto_pull_vals = self._get_mts_mto_rule()
             mts_mto_pull = pull_model.create(mts_mto_pull_vals)
             res['mts_mto_rule_id'] = mts_mto_pull.id
         return res
@@ -89,7 +105,7 @@ class Warehouse(models.Model):
             if vals.get("mto_mts_management"):
                 for warehouse in self:
                     if not warehouse.mts_mto_rule_id:
-                        rule_vals = self._get_mts_mto_rule(warehouse)
+                        rule_vals = warehouse._get_mts_mto_rule()
                         mts_mto_pull = pull_model.create(rule_vals)
                         vals['mts_mto_rule_id'] = mts_mto_pull.id
             else:
@@ -102,24 +118,24 @@ class Warehouse(models.Model):
         return res
 
     @api.model
-    def get_all_routes_for_wh(self, warehouse):
-        all_routes = super(Warehouse, self).get_all_routes_for_wh(warehouse)
-        if (
-            warehouse.mto_mts_management and
-            warehouse.mts_mto_rule_id.route_id
-        ):
-            all_routes += [warehouse.mts_mto_rule_id.route_id.id]
+    def get_all_routes_for_wh(self):
+        all_routes = super(Warehouse, self).get_all_routes_for_wh()
+
+        if self.mto_mts_management and self.mts_mto_rule_id.route_id:
+            all_routes += self.mts_mto_rule_id.route_id
+
         return all_routes
 
-    @api.model
-    def _handle_renaming(self, warehouse, name, code):
-        res = super(Warehouse, self)._handle_renaming(warehouse, name, code)
+    @api.multi
+    def _update_name_and_code(self, name, code):
+        res = super(Warehouse, self)._update_name_and_code(name, code)
 
-        if warehouse.mts_mto_rule_id:
-            warehouse.mts_mto_rule_id.name = (
-                warehouse.mts_mto_rule_id.name.replace(
-                    warehouse.name, name, 1)
-            )
+        for warehouse in self:
+            if warehouse.mts_mto_rule_id:
+                warehouse.mts_mto_rule_id.name = (
+                    warehouse.mts_mto_rule_id.name.replace(
+                        warehouse.name, name, 1)
+                )
         return res
 
     def _get_route_name(self, route_type):

--- a/stock_mts_mto_rule/tests/test_mto_mts_route.py
+++ b/stock_mts_mto_rule/tests/test_mto_mts_route.py
@@ -125,7 +125,7 @@ class TestMtoMtsRoute(TransactionCase):
 
     def test_create_routes(self):
         rule_obj = self.env['procurement.rule']
-        created_routes = self.warehouse.create_routes(self.warehouse)
+        created_routes = self.warehouse.create_routes()
         mts_mto_route = rule_obj.browse(created_routes['mts_mto_rule_id'])
         self.assertEqual(mts_mto_route.warehouse_id, self.warehouse)
         self.assertEqual(
@@ -145,9 +145,9 @@ class TestMtoMtsRoute(TransactionCase):
         self.assertFalse(self.warehouse.mts_mto_rule_id)
 
     def test_get_all_routes_for_wh(self):
-        routes = self.warehouse.get_all_routes_for_wh(self.warehouse)
+        routes = self.warehouse.get_all_routes_for_wh()
         self.assertTrue(self.warehouse.mts_mto_rule_id)
-        self.assertTrue(self.warehouse.mts_mto_rule_id.route_id.id in routes)
+        self.assertTrue(self.warehouse.mts_mto_rule_id.route_id in routes)
 
     def test_rename_warehouse(self):
         rule_name = self.warehouse.mts_mto_rule_id.name

--- a/stock_mts_mto_rule/tests/test_mto_mts_route.py
+++ b/stock_mts_mto_rule/tests/test_mto_mts_route.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo import exceptions
 from odoo.tests.common import TransactionCase
 from datetime import datetime
 
@@ -56,6 +57,26 @@ class TestMtoMtsRoute(TransactionCase):
         self.assertEqual(2, len(moves))
         self.assertEqual(1.0, moves[0].product_uom_qty)
 
+    def test_mts_mto_route_split_done(self):
+        mto_mts_route = self.env.ref('stock_mts_mto_rule.route_mto_mts')
+        self.product.route_ids = [(6, 0, [mto_mts_route.id])]
+        self.quant.qty = 1.0
+        self._procurement_create()
+        self.assertEqual(self.procurement.state, 'running')
+        self.procurement.mts_mto_procurement_ids.mapped(
+            'move_ids').action_done()
+        self.assertEqual(self.procurement.state, 'done')
+
+    def test_mts_mto_route_split_cancel(self):
+        mto_mts_route = self.env.ref('stock_mts_mto_rule.route_mto_mts')
+        self.product.route_ids = [(6, 0, [mto_mts_route.id])]
+        self.quant.qty = 1.0
+        self._procurement_create()
+        self.procurement.mts_mto_procurement_ids.cancel()
+        self.assertEqual(self.procurement.state, 'running')
+        self.procurement.check()
+        self.assertEqual(self.procurement.state, 'cancel')
+
     def test_mts_mto_route_mts_only(self):
         mto_mts_route = self.env.ref('stock_mts_mto_rule.route_mto_mts')
         self.product.route_ids = [(6, 0, [mto_mts_route.id])]
@@ -79,6 +100,62 @@ class TestMtoMtsRoute(TransactionCase):
         self.assertEqual(2.0, moves[0].product_uom_qty)
         self.assertEqual('make_to_stock',
                          moves[0].procure_method)
+
+    def test_mts_mto_route_mto_removed(self):
+        self.env.ref('stock_mts_mto_rule.route_mto_mts').unlink()
+        self.warehouse.mts_mto_rule_id = False
+        with self.assertRaises(exceptions.Warning):
+            self.warehouse.mto_mts_management = True
+
+    def test_mts_mto_route_mts_removed(self):
+        self.warehouse.mto_mts_management = True
+        self.env['procurement.rule'].search([
+            ('location_src_id', '=', self.warehouse.lot_stock_id.id),
+            ('route_id', '=', self.warehouse.delivery_route_id.id),
+        ]).unlink()
+        self.warehouse.mts_mto_rule_id = False
+        with self.assertRaises(exceptions.Warning):
+            self.warehouse.mto_mts_management = True
+
+    def test_mts_mto_route_mto_no_mts_rule(self):
+        self.warehouse.mts_mto_rule_id = False
+        self.warehouse.mto_pull_id = False
+        with self.assertRaises(exceptions.Warning):
+            self.warehouse.mto_mts_management = True
+
+    def test_create_routes(self):
+        rule_obj = self.env['procurement.rule']
+        created_routes = self.warehouse.create_routes(self.warehouse)
+        mts_mto_route = rule_obj.browse(created_routes['mts_mto_rule_id'])
+        self.assertEqual(mts_mto_route.warehouse_id, self.warehouse)
+        self.assertEqual(
+            mts_mto_route.location_id, self.warehouse.mto_pull_id.location_id)
+        self.assertEqual(
+            mts_mto_route.picking_type_id,
+            self.warehouse.mto_pull_id.picking_type_id)
+        self.assertEqual(
+            mts_mto_route.route_id,
+            self.env.ref('stock_mts_mto_rule.route_mto_mts'))
+
+    def test_remove_mts_mto_management(self):
+        warehouse_rule = self.warehouse.mts_mto_rule_id
+        self.assertTrue(self.warehouse.mts_mto_rule_id)
+        self.warehouse.mto_mts_management = False
+        self.assertFalse(warehouse_rule.exists())
+        self.assertFalse(self.warehouse.mts_mto_rule_id)
+
+    def test_get_all_routes_for_wh(self):
+        routes = self.warehouse.get_all_routes_for_wh(self.warehouse)
+        self.assertTrue(self.warehouse.mts_mto_rule_id)
+        self.assertTrue(self.warehouse.mts_mto_rule_id.route_id.id in routes)
+
+    def test_rename_warehouse(self):
+        rule_name = self.warehouse.mts_mto_rule_id.name
+        new_warehouse_name = 'NewName'
+        new_rule_name = rule_name.replace(
+            self.warehouse.name, new_warehouse_name, 1)
+        self.warehouse.name = new_warehouse_name
+        self.assertEqual(new_rule_name, self.warehouse.mts_mto_rule_id.name)
 
     def setUp(self):
         super(TestMtoMtsRoute, self).setUp()


### PR DESCRIPTION
After adding in 10.0 the missing unit tests I added on 9.0, I discovered some bugs in the v10 migration of the stock_mts_mto_rule module.

This PR adds the missing unit tests and fixes the bugs revealed by these tests.
