### PR TITLE
[9.0]-[mig]-stock_orderpoint_uom

### DIFF
--- a/stock_orderpoint_uom/README.rst
+++ b/stock_orderpoint_uom/README.rst
@@ -1,0 +1,65 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+====================
+Stock Orderpoint UoM
+====================
+
+This module allows users users to define what unit of measure should be used
+in procurements created from minimum stock rules.
+
+A typical use case would be a product that is stocked in centimeters, and
+needs to be restocked in meters from another warehouse. When the picking is
+created, the quantity to be transferred will be expressed in meters, making
+it easier for the people responsible for the transfers to understand the
+requirement.
+
+
+Usage
+=====
+
+Go to 'Configuration / Reordering Rules' and indicate a Procurement UoM.
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/153/8.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-warehouse/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_orderpoint_uom/README.rst
+++ b/stock_orderpoint_uom/README.rst
@@ -15,17 +15,23 @@ created, the quantity to be transferred will be expressed in meters, making
 it easier for the people responsible for the transfers to understand the
 requirement.
 
+Configuration
+=============
+
+To configure this module, you need to 'Inventory > Configuration > Settings'
+and enable 'Some products may be sold/purchased in different unit of measures
+(advanced)' option.
 
 Usage
 =====
 
-Go to 'Configuration / Reordering Rules' and indicate a Procurement UoM.
+Go to 'Inventory > Inventory Control > Reordering Rules' and indicate a
+Procurement UoM.
 
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/153/8.0
-
 
 Bug Tracker
 ===========

--- a/stock_orderpoint_uom/__init__.py
+++ b/stock_orderpoint_uom/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/stock_orderpoint_uom/__openerp__.py
+++ b/stock_orderpoint_uom/__openerp__.py
@@ -6,7 +6,7 @@
     "name": "Stock Orderpoint UoM",
     "summary": "Allows to create procurement orders in the UoM indicated in "
                "the orderpoint",
-    "version": "8.0.1.0.0",
+    "version": "9.0.1.0.0",
     "author": "Eficent Business and IT Consulting Services S.L,"
               "Odoo Community Association (OCA)",
     "website": "https://www.odoo-community.org",

--- a/stock_orderpoint_uom/__openerp__.py
+++ b/stock_orderpoint_uom/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Stock Orderpoint UoM",
+    "summary": "Allows to create procurement orders in the UoM indicated in "
+               "the orderpoint",
+    "version": "8.0.1.0.0",
+    "author": "Eficent Business and IT Consulting Services S.L,"
+              "Odoo Community Association (OCA)",
+    "website": "https://www.odoo-community.org",
+    "category": "Warehouse Management",
+    "depends": ["stock"],
+    "data": ["views/stock_warehouse_orderpoint_view.xml"],
+    "license": "AGPL-3",
+    'installable': True,
+    'application': True,
+}

--- a/stock_orderpoint_uom/__openerp__.py
+++ b/stock_orderpoint_uom/__openerp__.py
@@ -15,5 +15,5 @@
     "data": ["views/stock_warehouse_orderpoint_view.xml"],
     "license": "AGPL-3",
     'installable': True,
-    'application': True,
+    'application': False,
 }

--- a/stock_orderpoint_uom/i18n/de.po
+++ b/stock_orderpoint_uom/i18n/de.po
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# Rudolf Schnapka <rs@techno-flex.de>, 2016
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-18 03:44+0000\n"
+"PO-Revision-Date: 2016-11-18 03:44+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr "Mindestbestandsregel"
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "Beschaffung"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr ""

--- a/stock_orderpoint_uom/i18n/es.po
+++ b/stock_orderpoint_uom/i18n/es.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-18 03:44+0000\n"
+"PO-Revision-Date: 2016-11-18 03:44+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr "Regla de inventario mínimo"
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr ""

--- a/stock_orderpoint_uom/i18n/es_MX.po
+++ b/stock_orderpoint_uom/i18n/es_MX.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# Juan González <bifomania@protonmail.com>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-29 18:43+0000\n"
+"PO-Revision-Date: 2016-11-29 18:43+0000\n"
+"Last-Translator: Juan González <bifomania@protonmail.com>, 2016\n"
+"Language-Team: Spanish (Mexico) (https://www.transifex.com/oca/teams/23907/es_MX/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_MX\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "Contratación"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr ""

--- a/stock_orderpoint_uom/i18n/fr.po
+++ b/stock_orderpoint_uom/i18n/fr.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-18 03:44+0000\n"
+"PO-Revision-Date: 2016-11-18 03:44+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "Procurement"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr ""

--- a/stock_orderpoint_uom/i18n/hr.po
+++ b/stock_orderpoint_uom/i18n/hr.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# Bole <bole@dajmi5.com>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-18 03:44+0000\n"
+"PO-Revision-Date: 2016-11-18 03:44+0000\n"
+"Last-Translator: Bole <bole@dajmi5.com>, 2016\n"
+"Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "Nabava"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr ""

--- a/stock_orderpoint_uom/i18n/it.po
+++ b/stock_orderpoint_uom/i18n/it.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# Paolo Valier <paolo.valier@hotmail.it>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-18 03:44+0000\n"
+"PO-Revision-Date: 2016-11-18 03:44+0000\n"
+"Last-Translator: Paolo Valier <paolo.valier@hotmail.it>, 2016\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "Approvvigionamento"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr ""

--- a/stock_orderpoint_uom/i18n/pt_BR.po
+++ b/stock_orderpoint_uom/i18n/pt_BR.po
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# Armando Vulcano Junior <vulcano@uol.com.br>, 2016
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-18 03:44+0000\n"
+"PO-Revision-Date: 2016-11-18 03:44+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/23907/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr "Regra minima de inventário"
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "Aprovisionamento"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr ""

--- a/stock_orderpoint_uom/i18n/ro.po
+++ b/stock_orderpoint_uom/i18n/ro.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# Dorin Hongu <dhongu@gmail.com>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-18 03:44+0000\n"
+"PO-Revision-Date: 2016-11-18 03:44+0000\n"
+"Last-Translator: Dorin Hongu <dhongu@gmail.com>, 2016\n"
+"Language-Team: Romanian (https://www.transifex.com/oca/teams/23907/ro/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "Aprovizionare"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr ""

--- a/stock_orderpoint_uom/i18n/sl.po
+++ b/stock_orderpoint_uom/i18n/sl.po
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-18 03:44+0000\n"
+"PO-Revision-Date: 2016-11-18 03:44+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>, 2016\n"
+"Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+"Napaka: privzeti enoti mere za proizvod  in enoto oskrbe morata biti iz iste"
+" kategorije."
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr "Pravilo minimalne zaloge"
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "Oskrbovanje"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr "EM oskrbovanja"

--- a/stock_orderpoint_uom/i18n/vi_VN.po
+++ b/stock_orderpoint_uom/i18n/vi_VN.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-18 03:44+0000\n"
+"PO-Revision-Date: 2016-11-18 03:44+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"Language-Team: Vietnamese (Viet Nam) (https://www.transifex.com/oca/teams/23907/vi_VN/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: vi_VN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "Mua sắm / Cung ứng"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr ""

--- a/stock_orderpoint_uom/i18n/zh_CN.po
+++ b/stock_orderpoint_uom/i18n/zh_CN.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * stock_orderpoint_uom
+# 
+# Translators:
+# Jeffery Chen Fan <jeffery9@gmail.com>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-18 03:44+0000\n"
+"PO-Revision-Date: 2016-11-18 03:44+0000\n"
+"Last-Translator: Jeffery Chen Fan <jeffery9@gmail.com>, 2016\n"
+"Language-Team: Chinese (China) (https://www.transifex.com/oca/teams/23907/zh_CN/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: stock_orderpoint_uom
+#: code:addons/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py:24
+#, python-format
+msgid ""
+"Error: The product default Unit of Measure and the procurement Unit of "
+"Measure must be in the same category."
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr ""
+
+#. module: stock_orderpoint_uom
+#: model:ir.model,name:stock_orderpoint_uom.model_procurement_order
+msgid "Procurement"
+msgstr "补货"
+
+#. module: stock_orderpoint_uom
+#: field:stock.warehouse.orderpoint,procure_uom_id:0
+msgid "Procurement UoM"
+msgstr ""

--- a/stock_orderpoint_uom/models/__init__.py
+++ b/stock_orderpoint_uom/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import stock_warehouse_orderpoint
+from . import procurement_order

--- a/stock_orderpoint_uom/models/procurement_order.py
+++ b/stock_orderpoint_uom/models/procurement_order.py
@@ -9,12 +9,6 @@ from openerp import api, models
 class ProcurementOrder(models.Model):
     _inherit = "procurement.order"
 
-    @api.multi
-    @api.onchange('product_id')
-    def onchange_product_id(self):
-        for rec in self:
-            rec.procure_uom_id = rec.product_id.uom_id
-
     @api.model
     def _prepare_orderpoint_procurement(self, orderpoint, product_qty):
         res = super(ProcurementOrder, self)._prepare_orderpoint_procurement(

--- a/stock_orderpoint_uom/models/procurement_order.py
+++ b/stock_orderpoint_uom/models/procurement_order.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, models
+
+
+class ProcurementOrder(models.Model):
+    _inherit = "procurement.order"
+
+    @api.multi
+    @api.onchange('product_id')
+    def onchange_product_id(self):
+        for rec in self:
+            rec.procure_uom_id = rec.product_id.uom_id
+
+    @api.model
+    def _prepare_orderpoint_procurement(self, orderpoint, product_qty):
+        res = super(ProcurementOrder,self)._prepare_orderpoint_procurement(
+            orderpoint, product_qty)
+        if orderpoint.procure_uom_id:
+            res['product_qty'] = orderpoint.procure_uom_id._compute_qty(
+                orderpoint.product_id.uom_id.id, product_qty,
+                orderpoint.procure_uom_id.id)
+            res['product_uom'] = orderpoint.procure_uom_id.id
+        return res

--- a/stock_orderpoint_uom/models/procurement_order.py
+++ b/stock_orderpoint_uom/models/procurement_order.py
@@ -17,7 +17,7 @@ class ProcurementOrder(models.Model):
 
     @api.model
     def _prepare_orderpoint_procurement(self, orderpoint, product_qty):
-        res = super(ProcurementOrder,self)._prepare_orderpoint_procurement(
+        res = super(ProcurementOrder, self)._prepare_orderpoint_procurement(
             orderpoint, product_qty)
         if orderpoint.procure_uom_id:
             res['product_qty'] = orderpoint.procure_uom_id._compute_qty(

--- a/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
+++ b/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
@@ -13,13 +13,6 @@ class StockWarehouseOrderpoint(models.Model):
     procure_uom_id = fields.Many2one(comodel_name='product.uom',
                                      string="Procurement UoM")
 
-    @api.multi
-    @api.onchange('product_id')
-    def onchange_product_id(self):
-        for rec in self:
-            if rec.procure_uom_id:
-                rec.procure_uom_id = False
-
     @api.constrains('product_uom', 'procure_uom_id')
     def _check_procure_uom(self):
         if any(orderpoint.product_uom

--- a/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
+++ b/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
@@ -15,12 +15,13 @@ class StockWarehouseOrderpoint(models.Model):
 
     @api.constrains('product_uom', 'procure_uom_id')
     def _check_procure_uom(self):
-        if any(orderpoint.product_uom
-               and orderpoint.procure_uom_id
-               and orderpoint.product_uom.category_id
-                != orderpoint.procure_uom_id.category_id
-               for orderpoint in self):
-            raise UserError(_('Error: The product default Unit of Measure and '
-                              'the procurement Unit of Measure must be in '
-                              'the same category.'))
+        if any(orderpoint.product_uom and
+                orderpoint.procure_uom_id and
+                orderpoint.product_uom.category_id !=
+                orderpoint.procure_uom_id.category_id
+                for orderpoint in self):
+                    raise UserError(
+                        _('Error: The product default Unit of Measure and '
+                          'the procurement Unit of Measure must be in the '
+                          'same category.'))
         return True

--- a/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
+++ b/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+
+
+class StockWarehouseOrderpoint(models.Model):
+    _inherit = "stock.warehouse.orderpoint"
+
+    procure_uom_id = fields.Many2one(comodel_name='product.uom',
+                                     string="Procurement UoM")
+
+    @api.multi
+    @api.onchange('product_id')
+    def onchange_product_id(self):
+        for rec in self:
+            rec.procure_uom_id = rec.product_id.uom_id

--- a/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
+++ b/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
@@ -3,7 +3,8 @@
 #   (http://www.eficent.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp import api, fields, models
+from openerp import api, fields, models, _
+from openerp.exceptions import Warning as UserError
 
 
 class StockWarehouseOrderpoint(models.Model):
@@ -18,3 +19,15 @@ class StockWarehouseOrderpoint(models.Model):
         for rec in self:
             if rec.procure_uom_id:
                 rec.procure_uom_id = False
+
+    @api.constrains('product_uom', 'procure_uom_id')
+    def _check_procure_uom(self):
+        if any(orderpoint.product_uom
+               and orderpoint.procure_uom_id
+               and orderpoint.product_uom.category_id
+                != orderpoint.procure_uom_id.category_id
+               for orderpoint in self):
+            raise UserError(_('Error: The product default Unit of Measure and '
+                              'the procurement Unit of Measure must be in '
+                              'the same category.'))
+        return True

--- a/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
+++ b/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
@@ -16,4 +16,5 @@ class StockWarehouseOrderpoint(models.Model):
     @api.onchange('product_id')
     def onchange_product_id(self):
         for rec in self:
-            rec.procure_uom_id = rec.product_id.uom_id
+            if rec.procure_uom_id:
+                rec.procure_uom_id = False

--- a/stock_orderpoint_uom/tests/__init__.py
+++ b/stock_orderpoint_uom/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_stock_orderpoint_procure_uom

--- a/stock_orderpoint_uom/tests/test_stock_orderpoint_procure_uom.py
+++ b/stock_orderpoint_uom/tests/test_stock_orderpoint_procure_uom.py
@@ -4,36 +4,55 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import openerp.tests.common as common
+from openerp.tools import mute_logger
+from openerp.exceptions import ValidationError
 
 
 class TestStockOrderpointProcureUom(common.TransactionCase):
 
-    def test_stock_orderpoont_procure_uom(self):
+    def setUp(self):
+        super(TestStockOrderpointProcureUom, self).setUp()
         productObj = self.env['product.product']
-        warehouse = self.env.ref('stock.warehouse0')
-        location_stock = self.env.ref('stock.stock_location_stock')
-        uom_unit = self.env.ref('product.product_uom_unit')
-        uom_dozen = self.env.ref('product.product_uom_dozen')
+        self.warehouse = self.env.ref('stock.warehouse0')
+        self.location_stock = self.env.ref('stock.stock_location_stock')
+        self.uom_unit = self.env.ref('product.product_uom_unit')
+        self.uom_dozen = self.env.ref('product.product_uom_dozen')
+        self.uom_kg = self.env.ref('product.product_uom_kgm')
 
-        productA = productObj.create(
+        self.productA = productObj.create(
             {'name': 'product A',
              'standard_price': 1,
              'type': 'product',
-             'uom_id': uom_unit.id,
+             'uom_id': self.uom_unit.id,
              'default_code': 'A',
              })
 
+    def test_stock_orderpoint_procure_uom(self):
+
         self.env['stock.warehouse.orderpoint'].create({
-            'warehouse_id': warehouse.id,
-            'location_id': location_stock.id,
-            'product_id': productA.id,
+            'warehouse_id': self.warehouse.id,
+            'location_id': self.location_stock.id,
+            'product_id': self.productA.id,
             'product_max_qty': 24,
             'product_min_qty': 12,
-            'procure_uom_id': uom_dozen.id,
+            'procure_uom_id': self.uom_dozen.id,
         })
 
         sched = self.env['procurement.order']
         sched.run_scheduler()
-        proc = sched.search([('product_id', '=', productA.id)])
-        self.assertEqual(proc.product_uom, uom_dozen)
+        proc = sched.search([('product_id', '=', self.productA.id)])
+        self.assertEqual(proc.product_uom, self.uom_dozen)
         self.assertEqual(proc.product_qty, 2)
+
+    def test_stock_orderpoint_wrong_uom(self):
+
+        with mute_logger('openerp.sql_db'):
+            with self.assertRaises(ValidationError):
+                self.env['stock.warehouse.orderpoint'].create({
+                    'warehouse_id': self.warehouse.id,
+                    'location_id': self.location_stock.id,
+                    'product_id': self.productA.id,
+                    'product_max_qty': 24,
+                    'product_min_qty': 12,
+                    'procure_uom_id': self.uom_kg.id,
+                })

--- a/stock_orderpoint_uom/tests/test_stock_orderpoint_procure_uom.py
+++ b/stock_orderpoint_uom/tests/test_stock_orderpoint_procure_uom.py
@@ -9,13 +9,11 @@ import openerp.tests.common as common
 class TestStockOrderpointProcureUom(common.TransactionCase):
 
     def test_stock_orderpoont_procure_uom(self):
-        super(TestStockOrderpointProcureUom, self).setUp()
         productObj = self.env['product.product']
         warehouse = self.env.ref('stock.warehouse0')
         location_stock = self.env.ref('stock.stock_location_stock')
         uom_unit = self.env.ref('product.product_uom_unit')
         uom_dozen = self.env.ref('product.product_uom_dozen')
-        self.company_partner = self.env.ref('base.main_partner')
 
         productA = productObj.create(
             {'name': 'product A',

--- a/stock_orderpoint_uom/tests/test_stock_orderpoint_procure_uom.py
+++ b/stock_orderpoint_uom/tests/test_stock_orderpoint_procure_uom.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import openerp.tests.common as common
+
+
+class TestStockOrderpointProcureUom(common.TransactionCase):
+
+    def test_stock_orderpoont_procure_uom(self):
+        super(TestStockOrderpointProcureUom, self).setUp()
+        productObj = self.env['product.product']
+        warehouse = self.env.ref('stock.warehouse0')
+        location_stock = self.env.ref('stock.stock_location_stock')
+        uom_unit = self.env.ref('product.product_uom_unit')
+        uom_dozen = self.env.ref('product.product_uom_dozen')
+        self.company_partner = self.env.ref('base.main_partner')
+
+        productA = productObj.create(
+            {'name': 'product A',
+             'standard_price': 1,
+             'type': 'product',
+             'uom_id': uom_unit.id,
+             'default_code': 'A',
+             })
+
+        self.env['stock.warehouse.orderpoint'].create({
+            'warehouse_id': warehouse.id,
+            'location_id': location_stock.id,
+            'product_id': productA.id,
+            'product_max_qty': 24,
+            'product_min_qty': 12,
+            'procure_uom_id': uom_dozen.id,
+        })
+
+        sched = self.env['procurement.order']
+        sched.run_scheduler()
+        proc = sched.search([('product_id', '=', productA.id)])
+        self.assertEqual(proc.product_uom, uom_dozen)
+        self.assertEqual(proc.product_qty, 2)

--- a/stock_orderpoint_uom/views/stock_warehouse_orderpoint_view.xml
+++ b/stock_orderpoint_uom/views/stock_warehouse_orderpoint_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record id="view_warehouse_orderpoint_tree" model="ir.ui.view">
+            <field name="name">stock.warehouse.orderpoint.tree</field>
+            <field name="model">stock.warehouse.orderpoint</field>
+            <field name="inherit_id"
+                   ref="stock.view_warehouse_orderpoint_tree"/>
+            <field name="arch" type="xml">
+                <field name="product_uom" position="after">
+                    <field name="procure_uom_id" groups="product.group_uom"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_warehouse_orderpoint_form" model="ir.ui.view">
+            <field name="name">stock.warehouse.orderpoint.form</field>
+            <field name="model">stock.warehouse.orderpoint</field>
+            <field name="inherit_id"
+                   ref="stock.view_warehouse_orderpoint_form"/>
+            <field name="arch" type="xml">
+                <field name="product_uom" position="after">
+                    <field name="procure_uom_id" class="oe_inline"
+                           groups="product.group_uom"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/stock_orderpoint_uom/views/stock_warehouse_orderpoint_view.xml
+++ b/stock_orderpoint_uom/views/stock_warehouse_orderpoint_view.xml
@@ -1,31 +1,29 @@
 <?xml version="1.0"?>
-<openerp>
-    <data>
+<odoo>
 
-        <record id="view_warehouse_orderpoint_tree" model="ir.ui.view">
-            <field name="name">stock.warehouse.orderpoint.tree</field>
-            <field name="model">stock.warehouse.orderpoint</field>
-            <field name="inherit_id"
-                   ref="stock.view_warehouse_orderpoint_tree"/>
-            <field name="arch" type="xml">
-                <field name="product_uom" position="after">
-                    <field name="procure_uom_id" groups="product.group_uom"/>
-                </field>
+    <record id="view_warehouse_orderpoint_tree" model="ir.ui.view">
+        <field name="name">stock.warehouse.orderpoint.tree</field>
+        <field name="model">stock.warehouse.orderpoint</field>
+        <field name="inherit_id"
+               ref="stock.view_warehouse_orderpoint_tree"/>
+        <field name="arch" type="xml">
+            <field name="product_uom" position="after">
+                <field name="procure_uom_id" groups="product.group_uom"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="view_warehouse_orderpoint_form" model="ir.ui.view">
-            <field name="name">stock.warehouse.orderpoint.form</field>
-            <field name="model">stock.warehouse.orderpoint</field>
-            <field name="inherit_id"
-                   ref="stock.view_warehouse_orderpoint_form"/>
-            <field name="arch" type="xml">
-                <field name="product_uom" position="after">
-                    <field name="procure_uom_id" class="oe_inline"
-                           groups="product.group_uom"/>
-                </field>
+    <record id="view_warehouse_orderpoint_form" model="ir.ui.view">
+        <field name="name">stock.warehouse.orderpoint.form</field>
+        <field name="model">stock.warehouse.orderpoint</field>
+        <field name="inherit_id"
+               ref="stock.view_warehouse_orderpoint_form"/>
+        <field name="arch" type="xml">
+            <field name="product_uom" position="after">
+                <field name="procure_uom_id" class="oe_inline"
+                       groups="product.group_uom"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-    </data>
-</openerp>
+</odoo>


### PR DESCRIPTION
Stock Orderpoint UoM
================

This module allows users users to define what unit of measure should be used
in procurements created from minimum stock rules.

A typical use case would be a product that is stocked in centimeters, and
needs to be restocked in meters from another warehouse. When the picking is
created, the quantity to be transferred will be expressed in meters, making
it easier for the people responsible for the transfers to understand the
requirement.


Usage
=====

Go to 'Configuration / Reordering Rules' and indicate a Procurement UoM.