### PR TITLE
[8.0] [stock_inventory_revaluation] fix quant unlink

### DIFF
--- a/stock_inventory_revaluation/README.rst
+++ b/stock_inventory_revaluation/README.rst
@@ -51,6 +51,15 @@ Usage
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/154/8.0
 
+Known issues / Roadmap
+======================
+
+* A negative quant can be revaluated, but can also ultimately be merged with
+  a positive quant. In that case, the associated revaluation quant record
+  will be removed. In a future version a chatter could be added to the stock
+  inventory revaluation, and this kind of action would be logged for better
+  traceability.
+
 Bug Tracker
 ===========
 

--- a/stock_inventory_revaluation/models/stock_inventory_revaluation.py
+++ b/stock_inventory_revaluation/models/stock_inventory_revaluation.py
@@ -382,7 +382,7 @@ class StockInventoryRevaluationQuant(models.Model):
                                      readonly=True)
 
     quant_id = fields.Many2one('stock.quant', 'Quant', required=True,
-                               readonly=True,
+                               readonly=True, ondelete='cascade',
                                domain=[('product_id.type', '=', 'product')])
 
     product_id = fields.Many2one('product.product', 'Product',


### PR DESCRIPTION
The stock inventory revaluation tool allows to revaluate negative quants. But these quants can ultimately be deleted automatically by the application, once they are merged with positive quants.

This PR allows to remove the records of 'stock.inventory.revaluation.quant' when the quant associated to them is deleted. Otherwise the users are stuck with the message:

`Integrity Error

The operation cannot be completed, probably due to the following:
- deletion: you may be trying to delete a record while other records still reference it
- creation/update: a mandatory field is not correctly set`