### PR TITLE
[FIX] Stock Orderpoint UOM

### DIFF
--- a/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
+++ b/stock_orderpoint_uom/models/stock_warehouse_orderpoint.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openerp import api, fields, models, _
-from openerp.exceptions import Warning as UserError
+from openerp.exceptions import UserError
 
 
 class StockWarehouseOrderpoint(models.Model):


### PR DESCRIPTION
Warning deprecated. Importing UserError directly.

Related to https://github.com/OCA/stock-logistics-warehouse/pull/233

https://github.com/odoo/odoo/blob/9.0/openerp/exceptions.py#L31-L38