### PR TITLE
[8.0][stock_putaway_strategy][FIX] Allows a user that is not Warehouse user or manager to access to the product form

### DIFF
--- a/stock_putaway_product/__openerp__.py
+++ b/stock_putaway_product/__openerp__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Putaway strategy per product',
     'summary': 'Set a product location and put-away strategy per product',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.0.1',
     'category': 'Inventory',
     'website': 'http://www.apertoso.be',
     'author': 'Apertoso N.V., Odoo Community Association (OCA)',

--- a/stock_putaway_product/security/ir.model.access.csv
+++ b/stock_putaway_product/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_stock_product_putaway_strategy,stock_product_putaway_strategy managers,model_stock_product_putaway_strategy,stock.group_stock_manager,1,1,1,1
 access_stock_product_putaway_user,stock_product_putaway_strategy user,model_stock_product_putaway_strategy,stock.group_stock_user,1,0,0,0
+access_stock_product_putaway_base_user,stock_product_putaway_strategy all users,model_stock_product_putaway_strategy,base.group_user,1,0,0,0

--- a/stock_putaway_product/views/product.xml
+++ b/stock_putaway_product/views/product.xml
@@ -38,7 +38,8 @@
                 <xpath expr="//group[@name='store']" position="inside">
                     <field name="product_putaway_ids"
                            context="{'default_product_template_id': active_id }"
-                           nolabel="1" colspan="2">
+                           nolabel="1" colspan="2"
+                           groups="stock.group_stock_user">
                         <tree>
                             <field name="putaway_id"/>
                             <field name="product_product_id"/>
@@ -58,7 +59,7 @@
                 <xpath expr="//group[@name='store']" position="inside">
                     <field name="product_putaway_ids"
                            context="{'default_product_template_id': product_tmpl_id, 'default_product_product_id': active_id}"
-                           nolabel="1" colspan="2" >
+                           nolabel="1" colspan="2" groups="stock.group_stock_user">
                         <tree>
                             <field name="putaway_id"/>
                             <field name="fixed_location_id"/>


### PR DESCRIPTION
When module "stock_putaway_strategy" is installed only Warehouse/User and Warehouse/Manager can access to the product form. 

After this PR, all users can access to the product form, but only users that belong to the group "Warehouse/User" can access to the section for Putaway strategies in the Inventory tab.

