### PR TITLE
[9.0][stock_putaway_strategy][FIX] Allows a user that is not Warehouse user or manager to access to the product form

### DIFF
--- a/stock_putaway_product/__openerp__.py
+++ b/stock_putaway_product/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Putaway strategy per product',
     'summary': 'Set a product location and put-away strategy per product',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'Inventory',
     'website': 'http://www.apertoso.be',
     'author': 'Apertoso N.V., '

--- a/stock_putaway_product/security/ir.model.access.csv
+++ b/stock_putaway_product/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_stock_product_putaway_strategy,stock_product_putaway_strategy managers,model_stock_product_putaway_strategy,stock.group_stock_manager,1,1,1,1
 access_stock_product_putaway_user,stock_product_putaway_strategy user,model_stock_product_putaway_strategy,stock.group_stock_user,1,0,0,0
+access_stock_product_putaway_base_user,stock_product_putaway_strategy all users,model_stock_product_putaway_strategy,base.group_user,1,0,0,0

--- a/stock_putaway_product/views/product.xml
+++ b/stock_putaway_product/views/product.xml
@@ -9,7 +9,7 @@
         <field name="inherit_id" ref="stock.view_template_property_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='stock_property']" position="before">
-                <group colspan="4" name="putaway" string="Put Away Locations">
+                <group colspan="4" name="putaway" string="Put Away Locations" groups="stock.group_stock_user">
                     <field name="product_putaway_ids"
                            context="{'default_product_tmpl_id': is_product_variant and product_tmpl_id or active_id,
                                      'default_product_product_id': is_product_variant and active_id or False}"


### PR DESCRIPTION
Warehouse/User and Warehouse/Manager can access to the product form.
After this PR, all users can access to the product form,
but only users that belong to the group "Warehouse/User"
can access to the section for Putaway strategies in the Inventory tab.

Same as #246 but for 9.0