### PR TITLE
[9.0] Add Automatic Reordering Rules

### DIFF
--- a/stock_orderpoint_generator/README.rst
+++ b/stock_orderpoint_generator/README.rst
@@ -6,7 +6,40 @@
 Order point generator
 =====================
 
-Add a wizard to configure order points for multiple products in one go.
+Add a wizard to configure reordering rules for multiple products in one go,
+and allow to automatically update reordering rules from rule templates.
+
+Configuration
+=============
+
+Reordering rule templates can be configured in "Inventory > Configuration >
+Products > Reordering Rule Templates".
+
+The frequency of the cron that updates the Reordering Rules can be configured
+in "Settings > Technical > Actions > Scheduled Actions". The name of the
+scheduled action is "Reordering Rule Templates Generator".
+
+Usage
+=====
+
+By activating the "Create Rules Automatically" on a reordering rule template,
+you are able to select a list of products. Any change on the template will then
+be replicated on the products Reordering Rules. The change is not immediate as
+it is processed by a scheduled action.
+
+On a product, you can also choose one or more Reordering Rule Templates. Any
+template added or removed on the product is immediately reflected on its
+Reordering Rules.
+
+Lastly, you can promptly create Reordering Rules for a product or a product
+template using the "Reordering Rules Generator". Note that it will replace all
+the existing rules for the product. You will usually not want to use this
+feature on products that have Automatic Reordering Rules Templates.
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/153/9.0
 
 
 Bug Tracker
@@ -22,9 +55,11 @@ Credits
 
 Contributors
 ------------
+
  * Yannick Vaucher <yannick.vaucher@camptocamp.com>
  * Matthieu Dietrich <matthieu.dietrich@camptocamp.com>
  * Cyril Gaudin <cyril.gaudin@camptocamp.com>
+ * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 
 Maintainer
 ----------

--- a/stock_orderpoint_generator/__openerp__.py
+++ b/stock_orderpoint_generator/__openerp__.py
@@ -13,7 +13,9 @@
     'depends': ['stock'],
     'data': [
         'views/orderpoint_template_views.xml',
+        'views/product_views.xml',
         "wizard/orderpoint_generator_view.xml",
+        "data/ir_cron.xml",
         "security/ir.model.access.csv",
     ],
     'installable': True,

--- a/stock_orderpoint_generator/__openerp__.py
+++ b/stock_orderpoint_generator/__openerp__.py
@@ -5,13 +5,14 @@
 {
     'name': 'Order point generator',
     'summary': 'Mass configuration of stock order points',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.1.0',
     'author': "Camptocamp, Odoo Community Association (OCA)",
     'category': 'Warehouse',
     'license': 'AGPL-3',
     'website': "http://www.camptocamp.com",
     'depends': ['stock'],
     'data': [
+        'views/orderpoint_template_views.xml',
         "wizard/orderpoint_generator_view.xml",
         "security/ir.model.access.csv",
     ],

--- a/stock_orderpoint_generator/data/ir_cron.xml
+++ b/stock_orderpoint_generator/data/ir_cron.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+  <record id="ir_cron_auto_orderpoint_template" model="ir.cron">
+    <field name="name">Reordering Rule Templates Generator</field>
+    <field name="interval_number">1</field>
+    <field name="interval_type">hours</field>
+    <field name="numbercall">-1</field>
+    <field eval="False" name="doall"/>
+    <field eval="'stock.warehouse.orderpoint.template'" name="model"/>
+    <field eval="'_cron_create_auto_orderpoints'" name="function"/>
+    <field eval="'()'" name="args"/>
+    <field name="active" eval="True" />
+  </record>
+
+</odoo>

--- a/stock_orderpoint_generator/models/__init__.py
+++ b/stock_orderpoint_generator/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import orderpoint_template
+from . import product

--- a/stock_orderpoint_generator/models/orderpoint_template.py
+++ b/stock_orderpoint_generator/models/orderpoint_template.py
@@ -18,6 +18,7 @@ class OrderpointTemplate(models.Model):
     _table is redefined to separate templates from orderpoints
     """
     _name = 'stock.warehouse.orderpoint.template'
+    _description = 'Reordering Rule Templates'
 
     _inherit = 'stock.warehouse.orderpoint'
     _table = 'stock_warehouse_orderpoint_template'

--- a/stock_orderpoint_generator/models/product.py
+++ b/stock_orderpoint_generator/models/product.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from openerp import api, fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    auto_orderpoint_template_ids = fields.Many2many(
+        comodel_name='stock.warehouse.orderpoint.template',
+        string="Automatic Reordering Rules",
+        domain=[('auto_generate', '=', True)],
+        help="When one or several automatic reordering rule is selected, "
+             "a Scheduled Action will automatically generate or update "
+             "the reordering rules of the product."
+    )
+
+    @api.model
+    def create(self, vals):
+        record = super(ProductProduct, self).create(vals)
+        if vals.get('auto_orderpoint_template_ids'):
+            record.auto_orderpoint_template_ids.create_orderpoints(record.ids)
+        return record
+
+    @api.multi
+    def write(self, vals):
+        result = super(ProductProduct, self).write(vals)
+        if vals.get('auto_orderpoint_template_ids'):
+            orderpoint_templates = self.mapped('auto_orderpoint_template_ids')
+            orderpoint_templates.create_orderpoints(self.ids)
+        return result

--- a/stock_orderpoint_generator/views/orderpoint_template_views.xml
+++ b/stock_orderpoint_generator/views/orderpoint_template_views.xml
@@ -5,16 +5,15 @@
     <field name="name">stock.warehouse.orderpoint.template.tree</field>
     <field name="model">stock.warehouse.orderpoint.template</field>
     <field name="mode">primary</field>
-    <field name="inherit_id" ref="stock.view_warehouse_orderpoint_tree"/>
     <field name="arch" type="xml">
-      <xpath expr="//tree" position="attributes">
-        <attribute name="name">Reordering Rule Templates</attribute>
-      </xpath>
-      <field name="product_max_qty" position="after">
+      <tree string="Reordering Rule Templates">
+        <field name="name"/>
+        <field name="warehouse_id" groups="stock.group_locations"/>
+        <field name="location_id" groups="stock.group_locations"/>
+        <field name="product_min_qty"/>
+        <field name="product_max_qty"/>
         <field name="auto_generate"/>
-      </field>
-      <field name="product_id" position="replace"></field>
-      <field name="product_uom" position="replace"></field>
+      </tree>
     </field>
   </record>
 
@@ -22,41 +21,64 @@
     <field name="name">stock.warehouse.orderpoint.template.search</field>
     <field name="model">stock.warehouse.orderpoint.template</field>
     <field name="mode">primary</field>
-    <field name="inherit_id" ref="stock.warehouse_orderpoint_search"/>
     <field name="arch" type="xml">
-      <xpath expr="//search" position="attributes">
-        <attribute name="name">Reordering Rule Templates</attribute>
-      </xpath>
-      <field name="product_id" position="replace"></field>
+      <search string="Reordering Rule Templates Search">
+        <field name="name" string="Reordering Rule Templates"/>
+        <field name="warehouse_id"/>
+        <field name="location_id" groups="stock.group_locations"/>
+        <field name="company_id" groups="base.group_multi_company"/>
+        <group expand="0" string="Group By">
+          <filter string="Warehouse" domain="[]"  context="{'group_by':'warehouse_id'}"/>
+          <filter string="Location" domain="[]" context="{'group_by':'location_id'}"/>
+        </group>
+      </search>
     </field>
   </record>
 
   <record id="view_warehouse_orderpoint_template_form" model="ir.ui.view">
     <field name="name">stock.warehouse.orderpoint.template.form</field>
     <field name="model">stock.warehouse.orderpoint.template</field>
-    <field name="mode">primary</field>
-    <field name="inherit_id" ref="stock.view_warehouse_orderpoint_form"/>
     <field name="arch" type="xml">
-      <xpath expr="//form" position="attributes">
-        <attribute name="name">Reordering Rule Templates</attribute>
-      </xpath>
-      <field name="product_id" position="replace"></field>
-      <field name="active" position="after">
-        <field name="auto_generate"/>
-      </field>
-
-      <sheet position="before">
+      <form string="Reordering Rule Template">
         <header>
           <button name="create_auto_orderpoints" type="object" string="Generate Automatic Rules"
             help="Reordering rules will be created for the selected products. This is equivalent to the Scheduled Action action."
             attrs="{'invisible': [('auto_generate', '=', False)]}"/>
         </header>
-      </sheet>
-      <xpath expr="//sheet/group[2]" position="inside">
-        <group string="Automatic Rules" name="auto_rules" attrs="{'invisible': [('auto_generate', '=', False)]}">
-          <field name="auto_product_ids"/>
-        </group>
-      </xpath>
+        <sheet>
+          <group>
+            <group>
+              <field name="name" />
+            </group>
+            <group>
+              <field name="warehouse_id" on_change="onchange_warehouse_id(warehouse_id)" widget="selection" groups="stock.group_locations"/>
+              <field name="location_id" groups="stock.group_locations"/>
+              <field name="group_id" groups="stock.group_adv_location"/>
+              <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+            </group>
+          </group>
+          <group>
+            <group string="Rules">
+              <field name="product_min_qty" />
+              <field name="product_max_qty" />
+              <field name="qty_multiple" string="Quantity Multiple"/>
+            </group>
+            <group string="Misc">
+              <field name="active" />
+              <field name="auto_generate"/>
+              <label for="lead_days"/>
+              <div class="o_row">
+                <field name="lead_days"/>
+                <field name="lead_type"/>
+              </div>
+            </group>
+            <group string="Automatic Rules" name="auto_rules" attrs="{'invisible': [('auto_generate', '=', False)]}">
+              <field name="auto_product_ids"/>
+            </group>
+          </group>
+        </sheet>
+      </form>
+
     </field>
   </record>
 

--- a/stock_orderpoint_generator/views/orderpoint_template_views.xml
+++ b/stock_orderpoint_generator/views/orderpoint_template_views.xml
@@ -10,6 +10,9 @@
       <xpath expr="//tree" position="attributes">
         <attribute name="name">Reordering Rule Templates</attribute>
       </xpath>
+      <field name="product_max_qty" position="after">
+        <field name="auto_generate"/>
+      </field>
       <field name="product_id" position="replace"></field>
       <field name="product_uom" position="replace"></field>
     </field>
@@ -38,6 +41,22 @@
         <attribute name="name">Reordering Rule Templates</attribute>
       </xpath>
       <field name="product_id" position="replace"></field>
+      <field name="active" position="after">
+        <field name="auto_generate"/>
+      </field>
+
+      <sheet position="before">
+        <header>
+          <button name="create_auto_orderpoints" type="object" string="Generate Automatic Rules"
+            help="Reordering rules will be created for the selected products. This is equivalent to the Scheduled Action action."
+            attrs="{'invisible': [('auto_generate', '=', False)]}"/>
+        </header>
+      </sheet>
+      <xpath expr="//sheet/group[2]" position="inside">
+        <group string="Automatic Rules" name="auto_rules" attrs="{'invisible': [('auto_generate', '=', False)]}">
+          <field name="auto_product_ids"/>
+        </group>
+      </xpath>
     </field>
   </record>
 

--- a/stock_orderpoint_generator/views/orderpoint_template_views.xml
+++ b/stock_orderpoint_generator/views/orderpoint_template_views.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="view_warehouse_orderpoint_template_tree" model="ir.ui.view">
+    <field name="name">stock.warehouse.orderpoint.template.tree</field>
+    <field name="model">stock.warehouse.orderpoint.template</field>
+    <field name="mode">primary</field>
+    <field name="inherit_id" ref="stock.view_warehouse_orderpoint_tree"/>
+    <field name="arch" type="xml">
+      <xpath expr="//tree" position="attributes">
+        <attribute name="name">Reordering Rule Templates</attribute>
+      </xpath>
+      <field name="product_id" position="replace"></field>
+      <field name="product_uom" position="replace"></field>
+    </field>
+  </record>
+
+  <record model="ir.ui.view" id="view_warehouse_orderpoint_template_search">
+    <field name="name">stock.warehouse.orderpoint.template.search</field>
+    <field name="model">stock.warehouse.orderpoint.template</field>
+    <field name="mode">primary</field>
+    <field name="inherit_id" ref="stock.warehouse_orderpoint_search"/>
+    <field name="arch" type="xml">
+      <xpath expr="//search" position="attributes">
+        <attribute name="name">Reordering Rule Templates</attribute>
+      </xpath>
+      <field name="product_id" position="replace"></field>
+    </field>
+  </record>
+
+  <record id="view_warehouse_orderpoint_template_form" model="ir.ui.view">
+    <field name="name">stock.warehouse.orderpoint.template.form</field>
+    <field name="model">stock.warehouse.orderpoint.template</field>
+    <field name="mode">primary</field>
+    <field name="inherit_id" ref="stock.view_warehouse_orderpoint_form"/>
+    <field name="arch" type="xml">
+      <xpath expr="//form" position="attributes">
+        <attribute name="name">Reordering Rule Templates</attribute>
+      </xpath>
+      <field name="product_id" position="replace"></field>
+    </field>
+  </record>
+
+  <record id="action_orderpoint_template" model="ir.actions.act_window">
+    <field name="name">Reordering Rule Templates</field>
+    <field name="res_model">stock.warehouse.orderpoint.template</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">tree,form</field>
+    <field name="view_id" ref="view_warehouse_orderpoint_template_tree"/>
+    <field name="search_view_id" ref="view_warehouse_orderpoint_template_search" />
+    <field name="help" type="html">
+      <p class="oe_view_nocontent_create">
+        Click to add a reordering rule template.
+      </p>
+    </field>
+  </record>
+
+  <menuitem
+    id="menu_orderpoint_template" name="Reordering Rule Templates"
+    parent="stock.menu_product_in_config_stock"
+    action="action_orderpoint_template"
+    />
+
+</odoo>

--- a/stock_orderpoint_generator/views/product_views.xml
+++ b/stock_orderpoint_generator/views/product_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="product_normal_form_view" model="ir.ui.view">
+    <field name="name">product.product.form</field>
+    <field name="model">product.product</field>
+    <field name="inherit_id" ref="product.product_normal_form_view"/>
+    <field name="arch" type="xml">
+      <field name="seller_ids" position="before">
+        <separator string="Automatic Reordering Rules"/>
+        <field name="auto_orderpoint_template_ids" context="{'default_auto_generate': True}"/>
+      </field>
+    </field>
+  </record>
+</odoo>

--- a/stock_orderpoint_generator/wizard/orderpoint_generator.py
+++ b/stock_orderpoint_generator/wizard/orderpoint_generator.py
@@ -21,7 +21,7 @@ class OrderpointGenerator(models.TransientModel):
     orderpoint_template_id = fields.Many2many(
         'stock.warehouse.orderpoint.template',
         rel='order_point_generator_rel',
-        string='Stock rule template'
+        string='Reordering Rule Templates'
     )
 
     @api.multi

--- a/stock_orderpoint_generator/wizard/orderpoint_generator_view.xml
+++ b/stock_orderpoint_generator/wizard/orderpoint_generator_view.xml
@@ -5,21 +5,20 @@
         <field name="name">stock.warehouse.orderpoint.generator</field>
         <field name="model">stock.warehouse.orderpoint.generator</field>
         <field name="arch" type="xml">
-            <form string="Product warehouse config">
+            <form string="Reordering Rules Generator">
                 <label string="This wizard will apply the following orderpoint to selected product(s)"/>
                 <group string="Templates" colspan="4">
                     <field name="orderpoint_template_id" colspan="4"/>
                 </group>
                 <footer>
-                    <button name="action_configure" string="Apply" type="object" class="oe_highlight"
-                            icon="gtk-execute"/>
-                    <button string="Cancel" class="oe_link" special="cancel"/>
+                    <button name="action_configure" string="Apply" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-default" special="cancel"/>
                 </footer>
             </form>
         </field>
     </record>
 
-    <act_window name="Product warehouse config"
+    <act_window name="Reordering Rules Generator"
                 res_model="stock.warehouse.orderpoint.generator"
                 src_model="product.product"
                 view_mode="form"
@@ -27,7 +26,7 @@
                 key2="client_action_multi"
                 id="act_create_product_conf"/>
 
-    <act_window name="Product warehouse config"
+    <act_window name="Reordering Rules Generator"
                 res_model="stock.warehouse.orderpoint.generator"
                 src_model="product.template"
                 view_mode="form"


### PR DESCRIPTION
When a product variant is created with a (or several) rule template(s), it
automatically generates (on the fly) the corresponding rule(s). When a rule
template is modified, it automatically updates the existing rules of the
linked products (it uses the mechanism in place, disable the old and create
a fresh one). The latter update is done by a cron because it might take a
long time to update all the products reordering rules.