### PR TITLE
Fix: avoid remove assigned lots on manual assignement

### DIFF
--- a/stock_quant_manual_assign/models/stock_picking.py
+++ b/stock_quant_manual_assign/models/stock_picking.py
@@ -2,17 +2,7 @@
 # (c) 2015 Mikel Arregi - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from openerp import api, fields, models
-
-
-class StockPicking(models.Model):
-    _inherit = 'stock.picking'
-
-    @api.multi
-    def action_assign(self):
-        # This is to assure that stock.pack.operation are reprocessed
-        self.mapped('pack_operation_ids').unlink()
-        return super(StockPicking, self).action_assign()
+from openerp import fields, models
 
 
 class StockMove(models.Model):

--- a/stock_quant_manual_assign/tests/test_stock_quant_manual_assign.py
+++ b/stock_quant_manual_assign/tests/test_stock_quant_manual_assign.py
@@ -108,6 +108,9 @@ class TestStockQuantManualAssign(common.TransactionCase):
             wizard.lines_qty)
         for quant in self.move.reserved_quant_ids:
             self.assertTrue(quant in selected_quants)
+        wizard.assign_quants()
+        self.assertEqual(len(wizard.quants_lines.filtered('selected')),
+                         len(self.move.reserved_quant_ids))
 
     def test_quant_assign_wizard_after_availability_check(self):
         self.move.action_assign()

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -44,6 +44,9 @@ class AssignManualQuants(models.TransientModel):
         move = self.env['stock.move'].browse(self.env.context['active_id'])
         move.picking_id.mapped('pack_operation_ids').unlink()
         quants = []
+        # Mark as recompute pack needed
+        if move.picking_id:  # pragma: no cover
+            move.picking_id.recompute_pack_op = True
         for quant_id in move.reserved_quant_ids.ids:
             move.write({'reserved_quant_ids': [[3, quant_id]]})
         for line in self.quants_lines:


### PR DESCRIPTION
When a user are assigned lots on a picking and recheck availability, lots are removed.

With this, lots are not removed, and button is shown in order to allow user to change or not lots assigned.

cc @Tecnativa