### PR TITLE
[FIX] stock_quant_manual_assign: computed field is not the same

### DIFF
--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -5,6 +5,7 @@
 
 from openerp import api, exceptions, fields, models, _
 import openerp.addons.decimal_precision as dp
+from openerp.tools.float_utils import float_compare
 
 
 class AssignManualQuants(models.TransientModel):
@@ -13,13 +14,14 @@ class AssignManualQuants(models.TransientModel):
     @api.multi
     @api.constrains('quants_lines')
     def check_qty(self):
-        for record in self:
-            if record.quants_lines:
-                move = self.env['stock.move'].browse(
-                    self.env.context['active_id'])
-                if record.lines_qty > move.product_uom_qty:
-                    raise exceptions.Warning(
-                        _('Quantity is higher than the needed one'))
+        precision_digits = dp.get_precision('Product Unit of Measure'
+                                            )(self.env.cr)[1]
+        move = self.env['stock.move'].browse(self.env.context['active_id'])
+        for record in self.filtered(lambda x: x.quants_lines):
+            if float_compare(record.lines_qty, move.product_uom_qty,
+                             precision_digits=precision_digits) > 0:
+                raise exceptions.Warning(
+                    _('Quantity is higher than the needed one'))
 
     @api.depends('quants_lines', 'quants_lines.qty')
     def _compute_qties(self):


### PR DESCRIPTION
I've got a stock move with 0.015 qty. When I launch the quant manual assign wizard, I get one quant with qty 16 to select. When I select this quant, the qty reserved changes to 0.015. There is a computed field which sums all reserved qty in quants in the wizard, its value is 0.015. When comparing the computed field with the move qty 0.015 > 0.015 it returns True, this is wrong, but If I compare the sum instead of the computed field it returns False.