### PR TITLE
[9.0][stock_inventory_revaluation] Allow to delete quants

### DIFF
--- a/stock_inventory_revaluation/models/stock_inventory_revaluation.py
+++ b/stock_inventory_revaluation/models/stock_inventory_revaluation.py
@@ -425,7 +425,7 @@ class StockInventoryRevaluationQuant(models.Model):
                                      readonly=True)
 
     quant_id = fields.Many2one('stock.quant', 'Quant', required=True,
-                               readonly=True,
+                               readonly=True, ondelete='cascade',
                                domain=[('product_id.type', '=', 'product')])
 
     product_id = fields.Many2one('product.product', 'Product',

--- a/stock_inventory_revaluation/tests/test_stock_inventory_revaluation.py
+++ b/stock_inventory_revaluation/tests/test_stock_inventory_revaluation.py
@@ -234,6 +234,12 @@ class TestStockInventoryRevaluation(TransactionCase):
                                  'Incorrect inventory revaluation for '
                                  'type Price Change.')
 
+        quants = self.env['stock.quant'].search([('product_id', '=',
+                                                 self.product_real_1.id)])
+
+        # We should be able to delete the quants afterwards
+        quants.with_context(force_unlink=True).unlink()
+
     def create_inventory_revaluation_price_change_average(self):
         revaluation_type = 'price_change'
         # Create an Inventory Revaluation for average cost product


### PR DESCRIPTION
Now when an inventory revaluation has been posted for a product that has real price costing methods, if you revaluate some quants and then these quants need to be deleted afterwards, the user gets an error.

Deleting quants is done automatically by the system in some cases. For example, when you unreserve a delivery order and serveral quants are merged together.