### PR TITLE
[9.0][stock_cycle_count] Assign zones to cycle count rules

### DIFF
--- a/stock_cycle_count/README.rst
+++ b/stock_cycle_count/README.rst
@@ -32,6 +32,15 @@ To install this module, you need to:
 * Download this module to your addons path.
 * Install the module in your database.
 
+Recommendations
+---------------
+
+It is highly recommended to use this module in conjunction with:
+
+* `stock_inventory_verification_request`: Adds the capability to request Slot
+  Verifications.
+* `stock_inventory_lockdown`: Lock down locations during inventories.
+
 Configuration
 =============
 

--- a/stock_cycle_count/README.rst
+++ b/stock_cycle_count/README.rst
@@ -18,6 +18,7 @@ can propose Zero-Confirmations which are simple and opportunistic counts to
 check whether a locations has actually became empty or not.
 
 With this strategy it is possible to:
+
 * Remove the need to perform full physical inventories and to stop the
   production in the warehouse.
 * Measure the accuracy of the inventory records and improve it.
@@ -36,14 +37,12 @@ Configuration
 
 You can configure the rules to compute the cycle count, acting as follow:
 
-#. Go to "Inventory > Configuration > Cycle Count Rules"
+#. Go to *Inventory > Configuration > Cycle Count Rules*.
 #. Create as much cycle count rules as you want.
-#. Assign the rules to the Warehouse where you want to apply the rules in.
-#. Set a "Cycle Count Planning Horizon" for each warehouse.
-
-.. figure:: path/to/local/image.png
-   :alt: alternative description
-   :width: 600 px
+#. Assign the rules to the Warehouse or zones where you want to apply the rules
+   in.
+#. Go to *Inventory > Configuration > Warehouse Management > Warehouses* and
+   set a *Cycle Count Planning Horizon* for each warehouse.
 
 Usage
 =====
@@ -53,20 +52,18 @@ is described below.
 
 #. Go to "Inventory > Configuration > Warehouse Management > Warehouses".
 #. Select all the warehouses you want to compute the rules in.
-#. Click on "Action" and then in "Compute Cycle Count Rules".
+#. Click on "Action" and then in "Compute Cycle Count Rules". (**note**: A
+   cron job will do this for every warehouse daily.)
 #. Go to "Inventory Control > Cycle Counts".
-#. Select a Cycle Count planned an confirm it, this will create a draft
+#. Select a planned Cycle Count and confirm it, this will create a draft
    Inventory Adjustment.
-#. In the right top corner of the form view you can access the generated
+#. In the right top corner of the form view you can access to the generated
    Inventory Adjustment.
 #. Proceed with the Inventory Adjustment as usual.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/153/9.0
-
-.. repo_id is available in https://github.com/OCA/stock-logistics-warehouse
-.. branch is "9.0" for example
 
 
 Bug Tracker

--- a/stock_cycle_count/__openerp__.py
+++ b/stock_cycle_count/__openerp__.py
@@ -6,7 +6,7 @@
     "name": "Stock Cycle Count",
     "summary": "Adds the capability to schedule cycle counts in a "
                "warehouse through different rules defined by the user",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.1.0",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",

--- a/stock_cycle_count/models/stock_cycle_count.py
+++ b/stock_cycle_count/models/stock_cycle_count.py
@@ -27,30 +27,33 @@ class StockCycleCount(models.Model):
         return company_id
 
     name = fields.Char(string='Name', readonly=True)
-    location_id = fields.Many2one(comodel_name='stock.location',
-                                  string='Location',
-                                  required=True)
-    responsible_id = fields.Many2one(comodel_name='res.users',
-                                     string='Assigned to')
-    date_deadline = fields.Date(string='Required Date')
+    location_id = fields.Many2one(
+        comodel_name='stock.location', string='Location', required=True,
+        readonly=True, states={'draft': [('readonly', False)]})
+    responsible_id = fields.Many2one(
+        comodel_name='res.users', string='Assigned to',
+        readonly=True, states={'draft': [('readonly', False)]},
+        track_visibility='onchange')
+    date_deadline = fields.Date(
+        string='Required Date', readonly=True,
+        states={'draft': [('readonly', False)]})
     cycle_count_rule_id = fields.Many2one(
-        comodel_name='stock.cycle.count.rule',
-        string='Cycle count rule',
-        required=True)
+        comodel_name='stock.cycle.count.rule', string='Cycle count rule',
+        required=True, readonly=True, states={'draft': [('readonly', False)]})
     state = fields.Selection(selection=[
         ('draft', 'Planned'),
         ('open', 'Execution'),
         ('cancelled', 'Cancelled'),
         ('done', 'Done')
-    ], string='State', default='draft')
+    ], string='State', default='draft', track_visibility='onchange')
     stock_adjustment_ids = fields.One2many(comodel_name='stock.inventory',
                                            inverse_name='cycle_count_id',
-                                           string='Inventory Adjustment')
+                                           string='Inventory Adjustment',
+                                           track_visibility='onchange')
     inventory_adj_count = fields.Integer(compute=_count_inventory_adj)
-    company_id = fields.Many2one(comodel_name='res.company',
-                                 string='Company',
-                                 required=True,
-                                 default=_company_get)
+    company_id = fields.Many2one(
+        comodel_name='res.company', string='Company', required=True,
+        default=_company_get, readonly=True)
 
     @api.one
     def do_cancel(self):

--- a/stock_cycle_count/models/stock_cycle_count.py
+++ b/stock_cycle_count/models/stock_cycle_count.py
@@ -8,6 +8,7 @@ from openerp import api, fields, models
 
 class StockCycleCount(models.Model):
     _name = 'stock.cycle.count'
+    _description = "Stock Cycle Counts"
     _inherit = 'mail.thread'
 
     @api.one

--- a/stock_cycle_count/models/stock_cycle_count.py
+++ b/stock_cycle_count/models/stock_cycle_count.py
@@ -36,10 +36,11 @@ class StockCycleCount(models.Model):
         track_visibility='onchange')
     date_deadline = fields.Date(
         string='Required Date', readonly=True,
-        states={'draft': [('readonly', False)]})
+        states={'draft': [('readonly', False)]}, track_visibility='onchange')
     cycle_count_rule_id = fields.Many2one(
         comodel_name='stock.cycle.count.rule', string='Cycle count rule',
-        required=True, readonly=True, states={'draft': [('readonly', False)]})
+        required=True, readonly=True, states={'draft': [('readonly', False)]},
+        track_visibility='onchange')
     state = fields.Selection(selection=[
         ('draft', 'Planned'),
         ('open', 'Execution'),

--- a/stock_cycle_count/models/stock_cycle_count.py
+++ b/stock_cycle_count/models/stock_cycle_count.py
@@ -3,7 +3,8 @@
 #   (http://www.eficent.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp import api, fields, models
+from openerp import api, fields, models, _
+from openerp.exceptions import UserError
 
 
 class StockCycleCount(models.Model):
@@ -71,6 +72,10 @@ class StockCycleCount(models.Model):
 
     @api.one
     def action_create_inventory_adjustment(self):
+        if self.state != 'draft':
+            raise UserError(_(
+                "You can only confirm cycle counts in state 'Planned'."
+            ))
         data = self._prepare_inventory_adjustment()
         self.env['stock.inventory'].create(data)
         self.state = 'open'

--- a/stock_cycle_count/models/stock_cycle_count_rule.py
+++ b/stock_cycle_count/models/stock_cycle_count_rule.py
@@ -152,6 +152,8 @@ class StockCycleCountRule(models.Model):
                         latest_inventory,
                         DEFAULT_SERVER_DATETIME_FORMAT) + timedelta(
                         days=period)
+                    if next_date < datetime.today():
+                        next_date = datetime.today()
                 except Exception as e:
                     raise UserError(
                         _('Error found determining the frequency of periodic '

--- a/stock_cycle_count/models/stock_inventory.py
+++ b/stock_cycle_count/models/stock_inventory.py
@@ -3,7 +3,8 @@
 #   (http://www.eficent.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp import api, fields, models
+from openerp import api, fields, models, _
+from openerp.exceptions import UserError
 
 PERCENT = 100.0
 
@@ -22,9 +23,9 @@ class StockInventory(models.Model):
         if not self.line_ids and self.state == 'done':
             self.inventory_accuracy = 100.0
 
-    cycle_count_id = fields.Many2one(comodel_name='stock.cycle.count',
-                                     string='Stock Cycle Count',
-                                     ondelete='cascade')
+    cycle_count_id = fields.Many2one(
+        comodel_name='stock.cycle.count', string='Stock Cycle Count',
+        ondelete='cascade', readonly=True)
     inventory_accuracy = fields.Float(string='Accuracy',
                                       compute=_compute_inventory_accuracy,
                                       digits=(3, 2))
@@ -34,3 +35,13 @@ class StockInventory(models.Model):
         if self.cycle_count_id:
             self.cycle_count_id.state = 'done'
         return super(StockInventory, self).action_done()
+
+    @api.multi
+    def write(self, vals):
+        for inventory in self:
+            if (inventory.cycle_count_id and 'state' not in vals.keys() and
+                    inventory.state == 'draft'):
+                raise UserError(
+                    _('You cannot modify the configuration of an Inventory '
+                      'Adjustment related to a Cycle Count.'))
+        return super(StockInventory, self).write(vals)

--- a/stock_cycle_count/models/stock_warehouse.py
+++ b/stock_cycle_count/models/stock_warehouse.py
@@ -91,15 +91,13 @@ class StockWarehouse(models.Model):
                     existing_earliest_date = sorted(
                         existing_cycle_counts.mapped('date_deadline'))[0]
                     if cycle_count_proposed['date'] < existing_earliest_date:
-                        self.env['stock.cycle.count'].create({
+                        cc_to_update = existing_cycle_counts.search([
+                            ('date_deadline', '=', existing_earliest_date)])
+                        cc_to_update.write({
                             'date_deadline': cycle_count_proposed['date'],
-                            'location_id': cycle_count_proposed['location'].id,
                             'cycle_count_rule_id': cycle_count_proposed[
                                 'rule_type'].id,
-                            'state': 'draft'
                         })
-                        # TODO: cancel all or just the closest in time?
-                        existing_cycle_counts.write({'state': 'cancelled'})
                 delta = datetime.strptime(
                     cycle_count_proposed['date'],
                     DEFAULT_SERVER_DATETIME_FORMAT) - datetime.today()

--- a/stock_cycle_count/models/stock_warehouse.py
+++ b/stock_cycle_count/models/stock_warehouse.py
@@ -36,24 +36,30 @@ class StockWarehouse(models.Model):
         return date_horizon
 
     @api.model
-    def _get_cycle_count_locations_search_domain(self):
-        wh_parent_left = self.view_location_id.parent_left
-        wh_parent_right = self.view_location_id.parent_right
-        domain = [('parent_left', '>', wh_parent_left),
-                  ('parent_right', '<', wh_parent_right),
+    def _get_cycle_count_locations_search_domain(
+            self, parent):
+        domain = [('parent_left', '>=', parent.parent_left),
+                  ('parent_right', '<=', parent.parent_right),
                   ('cycle_count_disabled', '=', False)]
         return domain
 
     @api.model
-    def _search_cycle_count_locations(self):
-        locations = self.env['stock.location'].search(
-            self._get_cycle_count_locations_search_domain())
+    def _search_cycle_count_locations(self, rule):
+        locations = self.env['stock.location']
+        if rule.apply_in == 'warehouse':
+            locations = self.env['stock.location'].search(
+                self._get_cycle_count_locations_search_domain(
+                    self.view_location_id))
+        elif rule.apply_in == 'location':
+            for loc in rule.location_ids:
+                locations += self.env['stock.location'].search(
+                    self._get_cycle_count_locations_search_domain(loc))
         return locations
 
     @api.model
     def _cycle_count_rules_to_compute(self):
         rules = self.cycle_count_rule_ids.search([
-            ('rule_type', '!=', 'zero')])
+            ('rule_type', '!=', 'zero'), ('warehouse_ids', '=', self.id)])
         return rules
 
     @api.one
@@ -62,10 +68,10 @@ class StockWarehouse(models.Model):
         returns a list with required dates for the cycle count of each
         location '''
         proposed_cycle_counts = []
-        locations = self._search_cycle_count_locations()
         rules = self._cycle_count_rules_to_compute()
-        if locations:
-            for rule in rules:
+        for rule in rules:
+            locations = self._search_cycle_count_locations(rule)
+            if locations:
                 proposed_cycle_counts.extend(rule.compute_rule(locations))
         if proposed_cycle_counts:
             locations = list(set([d['location'] for d in

--- a/stock_cycle_count/views/stock_cycle_count_rule_view.xml
+++ b/stock_cycle_count/views/stock_cycle_count_rule_view.xml
@@ -11,6 +11,7 @@
             <tree string="Stock Cycle Count">
                 <field name="name"/>
                 <field name="warehouse_ids"/>
+                <field name="location_ids"/>
                 <field name="rule_type"/>
             </tree>
         </field>
@@ -47,12 +48,19 @@
                             </div>
                         </group>
                     </group>
+                    <group name="applied_in" string="Applied in:">
+                        <p colspan="4">You can apply the cycle count rules in complete
+                        warehouses or specific zones. A zone it is
+                        understood as a location and all its children.</p>
+                        <p colspan="4">In either case you can exclude specific locations
+                        going to the locations form and checking the box
+                        "Exclude from Cycle Count".</p>
+                        <field name="apply_in"/>
+                        <field name="warehouse_ids" widget="many2many_tags"/>
+                        <field name="location_ids"
+                               attrs="{'invisible': [('apply_in', '!=', 'location')]}"/>
+                    </group>
 
-                    <notebook>
-                        <page string="Applied in">
-                            <field name="warehouse_ids"/>
-                        </page>
-                    </notebook>
                 </sheet>
 
             </form>

--- a/stock_cycle_count/views/stock_cycle_count_view.xml
+++ b/stock_cycle_count/views/stock_cycle_count_view.xml
@@ -8,7 +8,9 @@
         <field name="name">stock.cycle.count.tree</field>
         <field name="model">stock.cycle.count</field>
         <field name="arch" type="xml">
-            <tree string="Stock Cycle Count">
+            <tree string="Stock Cycle Count"
+                  decoration-muted="state == 'cancelled'"
+                  decoration-info="state == 'draft'">
                 <field name="name"/>
                 <field name="location_id"/>
                 <field name="cycle_count_rule_id"/>
@@ -76,11 +78,51 @@
         </field>
     </record>
 
+    <record id="stock_cycle_count_search_view" model="ir.ui.view">
+            <field name="name">stock.cycle.count.search</field>
+            <field name="model">stock.cycle.count</field>
+            <field name="arch" type="xml">
+                <search string="Search Cycle Count">
+                    <field name="name" string="Cycle Count"/>
+                    <separator/>
+                    <field name="state"/>
+                    <filter name="planned" string="Planned"
+                            domain="[('state','=', 'draft')]"
+                            help="Cycle Counts Planned"/>
+                    <filter name="execution" string="Execution"
+                            domain="[('state','=', 'open')]"
+                            help="Cycle Counts in Execution"/>
+                    <filter name="done" string="Done"
+                            domain="[('state','=', 'done')]"
+                            help="Cycle Counts Done"/>
+                    <filter name="cancelled" string="Cancelled"
+                            domain="[('state','=', 'cancelled')]"
+                            help="Cycle Counts Cancelled"/>
+                    <filter name="assigned_to_user" string="Assigned to me"
+                            domain="[('responsible_id','=', uid)]"
+                            help="Cycle Counts Assigned to me"/>
+                    <field name="responsible_id" />
+                    <group expand="0" string="Group By...">
+                        <filter string="Location"
+                                domain="[]"
+                                context="{'group_by':'location_id'}"/>
+                        <filter string="State"
+                                domain="[]"
+                                context="{'group_by':'state'}"/>
+                        <filter string="Assigned to"
+                                domain="[]"
+                                context="{'group_by':'responsible_id'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
     <!-- Action to open Stock Cycle Count -->
     <act_window id="action_stock_cycle_count"
-                 name="Stock Cycle Count"
-                 res_model="stock.cycle.count"
-                 view_mode="tree,form" />
+                name="Stock Cycle Count"
+                res_model="stock.cycle.count"
+                view_mode="tree,form"
+                context="{'search_default_planned':1,'search_default_execution':1}"/>
     <menuitem id="menu_stock_cycle_count"
               name="Cycle Counts" parent="stock.menu_stock_inventory_control"
               action="action_stock_cycle_count" />

--- a/stock_cycle_count/views/stock_cycle_count_view.xml
+++ b/stock_cycle_count/views/stock_cycle_count_view.xml
@@ -127,4 +127,26 @@
               name="Cycle Counts" parent="stock.menu_stock_inventory_control"
               action="action_stock_cycle_count" />
 
+    <!-- Action to confirm several Stock Cycle Counts -->
+    <record id="action_server_cycle_count_confirm"
+            model="ir.actions.server">
+        <field name="name">Confirm Cycle Counts</field>
+        <field name="condition">True</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="model_stock_cycle_count" />
+        <field name="state">code</field>
+        <field name="code">self.action_create_inventory_adjustment(cr, uid, context.get('active_ids', []), context=context)</field>
+    </record>
+
+    <record model="ir.values" id="action_cycle_count_confirm">
+        <field name="name">confirm several cycle counts</field>
+        <field name="action_id"
+               ref="action_server_cycle_count_confirm" />
+        <field name="value" eval="'ir.actions.server,' + str(ref('action_server_cycle_count_confirm'))" />
+        <field name="key">action</field>
+        <field name="model_id" ref="model_stock_cycle_count" />
+        <field name="model">stock.cycle.count</field>
+        <field name="key2">client_action_multi</field>
+    </record>
+
 </odoo>

--- a/stock_cycle_count/views/stock_warehouse_view.xml
+++ b/stock_cycle_count/views/stock_warehouse_view.xml
@@ -10,15 +10,14 @@
         <field name="inherit_id" ref="stock.view_warehouse"/>
         <field name="arch" type="xml">
             <notebook position="before">
-                <group string="Cycle Counting">
-                    <group >
-                        <field name="cycle_count_planning_horizon"/>
-                        <field name="counts_for_accuracy_qty"/>
-                    </group>
-                    <group>
-                        <field name="cycle_count_rule_ids" nolabel="1">Cycle
-                            count rules</field>
-                    </group>
+                <group string="Cycle Counting" colspan="4">
+                    <field name="cycle_count_planning_horizon"/>
+                    <field name="counts_for_accuracy_qty"/>
+                    <br></br>
+                    <center colspan="4"><h3 colspan="4">Cycle Count Rules
+                    applied in this Warehouse:</h3></center>
+                    <field name="cycle_count_rule_ids" nolabel="1" colspan="4">
+                        Cycle count rules</field>
                 </group>
             </notebook>
         </field>


### PR DESCRIPTION
This PR improves the cycle count by allowing users to define zones (locations) to which the rules should be applied. If the user does not indicate a zone, the application will use all the locations of the warehouse that was selected.

cc @lreficent