### PR TITLE
FIX attribute field name

### DIFF
--- a/stock_putaway_product/models/product_putaway.py
+++ b/stock_putaway_product/models/product_putaway.py
@@ -59,7 +59,7 @@ class FixedPutawayStrat(models.Model):
 
     putaway_id = fields.Many2one(
         comodel_name='product.putaway',
-        sting='Put Away Method',
+        string='Put Away Method',
         required=True,
         select=True)
     product_template_id = fields.Many2one(


### PR DESCRIPTION
Typo error in v8:

s/sting/string

Fixed in v9

Thanks for your nice module
ping @jbeficent @JosDeGraeve @carlosdauden
