### PR TITLE
[9.0][FIX] stock_inventory_revaluation: able to cancel

### DIFF
--- a/stock_inventory_revaluation/models/stock_inventory_revaluation.py
+++ b/stock_inventory_revaluation/models/stock_inventory_revaluation.py
@@ -404,7 +404,8 @@ class StockInventoryRevaluation(models.Model):
     def button_cancel(self):
         for revaluation in self:
             for reval_quant in revaluation.reval_quant_ids:
-                reval_quant.quant_id.write({'cost': reval_quant.old_cost})
+                reval_quant.quant_id.sudo().write(
+                    {'cost': reval_quant.old_cost})
             if revaluation.account_move_ids:
                 # second, invalidate the move(s)
                 revaluation.account_move_ids.button_cancel()


### PR DESCRIPTION
Currently no one able to cancel revaluations and the following error raises:

  Sorry, you are not allowed to modify this document. Please  contact your system administrator if you think 
  this is an error.
  (Document model: stock.quant)   