### PR TITLE
[10.0][IMP] stock_putaway_product: Boost get_product_putaway_strategies

### DIFF
--- a/stock_putaway_product/README.rst
+++ b/stock_putaway_product/README.rst
@@ -72,6 +72,7 @@ Contributors
 * Jos De Graeve - Apertoso N.V. <Jos.DeGraeve@apertoso.be>
 * Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
 * Denis Roussel - ACSONE SA/NV <denis.roussel@acsone.eu>
+* Thomas Fossoul - WINK SA/NV <tfossoul@wink.be>
 
 
 Maintainer

--- a/stock_putaway_product/__manifest__.py
+++ b/stock_putaway_product/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Putaway strategy per product',
     'summary': 'Set a product location and put-away strategy per product',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Inventory',
     'website': 'http://www.apertoso.be',
     'author': 'Apertoso N.V., '

--- a/stock_putaway_product/models/product_putaway.py
+++ b/stock_putaway_product/models/product_putaway.py
@@ -23,11 +23,17 @@ class ProductPutaway(models.Model):
 
     @api.multi
     def get_product_putaway_strategies(self, product):
+        """ Get linked product putaway strategy that contain fixed location.
+        product.product_putaway_ids is the fasted way to get strategy
+        especially when we have thousand of products.
+        """
         self.ensure_one()
-        return self.product_location_ids.filtered(lambda x: (
-            x.product_product_id == product or
-            (not x.product_product_id and
-             x.product_tmpl_id == product.product_tmpl_id)))
+        strategy = product.product_putaway_ids.filtered(
+            lambda strategy: (strategy.putaway_id == self))
+        if not strategy:
+            strategy = product.product_tmpl_id.product_putaway_ids.filtered(
+                lambda strategy: (strategy.putaway_id == self))
+        return strategy
 
     def putaway_apply(self, product):
         if self.method == 'per_product':


### PR DESCRIPTION
This fix boost the execution to the def get_product_putaway_strategies.

You can see result when system try to generate a backorder for an incoming shipment:

Create an incoming shipment with 1000 products with all differents fixed_location_id.
If you process only one line and you validate the picking you'll see the system will need about 2 min and half to get all the product fixed_location_ids.

