### PR TITLE
[8.0][FIX] stock_quant_manual_assign: Use do_unreserve instead of cut the link from quants.

### DIFF
--- a/stock_quant_manual_assign/__openerp__.py
+++ b/stock_quant_manual_assign/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Stock - Manual assignment of quants",
-    "version": "8.0.1.2.0",
+    "version": "8.0.1.2.1",
     "category": "Warehouse Management",
     "license": "AGPL-3",
     "author": "OdooMRP team, "

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -44,8 +44,7 @@ class AssignManualQuants(models.TransientModel):
         move = self.env['stock.move'].browse(self.env.context['active_id'])
         move.picking_id.mapped('pack_operation_ids').unlink()
         quants = []
-        for quant_id in move.reserved_quant_ids.ids:
-            move.write({'reserved_quant_ids': [[3, quant_id]]})
+        move.do_unreserve()
         for line in self.quants_lines:
             if line.selected:
                 quants.append([line.quant, line.qty])


### PR DESCRIPTION
We modifyed the function assign_quants of _assign.manual.quants_ to use the do_unreserve function from _stock.move_ instead of cut the link from the quants.
Using do_unreserve we maintain the checks of unassign quants from _stock.move_ of _stock.picking_ in done or cancel state, the _stock.move_ state update correctly and all the other checks that Odoo does.