### PR TITLE
[10.0][FIX] purchase_packaging: fix price_subtotal recomputation

### DIFF
--- a/purchase_packaging/models/procurement_order.py
+++ b/purchase_packaging/models/procurement_order.py
@@ -20,14 +20,15 @@ class ProcurementOrder(models.Model):
             quantity=res['product_qty'],
             date=po.date_order and fields.Date.from_string(po.date_order),
             uom_id=self.product_id.uom_po_id)
+
         if seller.packaging_id:
-                res['packaging_id'] = seller.packaging_id.id
-                new_uom_id = seller.product_uom
-                if new_uom_id.id != res['product_uom']:
-                    res['product_uom'] = new_uom_id
-                    qty = self.product_uom._compute_quantity(
-                        self.product_qty, new_uom_id)
-                    res['product_qty'] = max(qty, seller.min_qty)
+            res['packaging_id'] = seller.packaging_id.id
+            new_uom = seller.product_uom
+            if new_uom.id != res['product_uom']:
+                res['product_uom'] = new_uom.id
+                qty = self.product_uom._compute_quantity(
+                    self.product_qty, new_uom)
+                res['product_qty'] = max(qty, seller.min_qty)
         return res
 
 

--- a/purchase_packaging/models/purchase_order_line.py
+++ b/purchase_packaging/models/purchase_order_line.py
@@ -47,6 +47,13 @@ class PurchaseOrderLine(models.Model):
             fields.Date.from_string(self.order_id.date_order),
             uom_id=self.product_uom)
 
+    @api.depends('product_purchase_qty',
+                 'product_qty',
+                 'price_unit',
+                 'taxes_id')
+    def _compute_amount(self):
+        return super(PurchaseOrderLine, self)._compute_amount()
+
     @api.multi
     @api.depends('product_purchase_uom_id', 'product_purchase_qty')
     def _compute_product_qty(self):

--- a/purchase_packaging/tests/test_procurement_order.py
+++ b/purchase_packaging/tests/test_procurement_order.py
@@ -304,10 +304,8 @@ class TestProcurementOrder(common.TransactionCase):
         # change order_point level and rerun
         orderpoint.product_min_qty = 13
         orderpoint.product_max_qty = 13
-
         procurement_obj.run_scheduler()
         procs = procurement_obj.search([('orderpoint_id', '=', orderpoint.id)])
-
         self.assertTrue(procs)
         self.assertEqual(len(procs), 2)
 

--- a/purchase_packaging/tests/test_purchase_order_line.py
+++ b/purchase_packaging/tests/test_purchase_order_line.py
@@ -56,12 +56,17 @@ class TestPurchaseOrderLine(common.TransactionCase):
 
         po = self.env['purchase.order'].create(
             {'partner_id': self.product_supplier_info.name.id})
-        po_line = po.order_line.new({
-            'product_id': self.product_tmpl_id.product_variant_id,
+        po_line = po.order_line.create({
+            'name': self.product_tmpl_id.product_variant_id.name,
+            'date_planned': po.date_order,
+            'product_id': self.product_tmpl_id.product_variant_id.id,
             'product_purchase_qty': 1.0,
             'product_purchase_uom_id':
-                po.order_line._default_product_purchase_uom_id(),
-            'order_id': po
+                po.order_line._default_product_purchase_uom_id().id,
+            'product_uom':
+                po.order_line._default_product_purchase_uom_id().id,
+            'price_unit': 0,
+            'order_id': po.id,
         })
         po_line.onchange_product_id()
         self.assertEqual(po_line.packaging_id.id,
@@ -75,6 +80,7 @@ class TestPurchaseOrderLine(common.TransactionCase):
         subtotal = po_line.price_unit * po_line.product_qty
         self.assertAlmostEqual(po_line.price_subtotal,
                                subtotal)
+        # by changing the purchase qty we expect the price to be recomputed
         po_line.product_purchase_qty = 3
         self.assertNotEqual(po_line.price_subtotal,
                             subtotal)

--- a/purchase_packaging/tests/test_purchase_order_line.py
+++ b/purchase_packaging/tests/test_purchase_order_line.py
@@ -70,6 +70,15 @@ class TestPurchaseOrderLine(common.TransactionCase):
                          self.product_uom_8.id)
         self.assertAlmostEqual(po_line.product_purchase_qty, 2)
         self.assertAlmostEqual(po_line.product_qty, 16)
+
+        # test subtotal computation
+        subtotal = po_line.price_unit * po_line.product_qty
+        self.assertAlmostEqual(po_line.price_subtotal,
+                               subtotal)
+        po_line.product_purchase_qty = 3
+        self.assertNotEqual(po_line.price_subtotal,
+                            subtotal)
+
         self.assertTrue(po_line.price_unit)
         self.assertEqual(po_line.product_uom.id,
                          self.env.ref('product.product_uom_dozen').id)
@@ -83,7 +92,7 @@ class TestPurchaseOrderLine(common.TransactionCase):
                          self.product_packaging_dozen.id)
         self.assertEqual(sm.product_uom.id,
                          self.env.ref('product.product_uom_dozen').id)
-        self.assertAlmostEqual(sm.product_uom_qty, 16)
+        self.assertAlmostEqual(sm.product_uom_qty, 24)
 
     def test_po_line_no_product(self):
         self.product_supplier_info.min_qty_uom_id = self.product_uom_8


### PR DESCRIPTION
purchase_line.price_subtotal is not recalculated when you adapt quantity.

**To reproduce:**
- Create a request for quotation
- Add some line without setting quantity.
- Save
- Edit
- Set quantity. You'll see the price subtotal will be recomputed.
- Save
The price subtotal will back to the previous amount.

