### PR TITLE
[10.0] purchase_packaging fix _get_product_seller with no date_order

### DIFF
--- a/purchase_packaging/__manifest__.py
+++ b/purchase_packaging/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Purchase Packaging",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": 'ACSONE SA/NV, '
               'Odoo Community Association (OCA)',
     "category": "Warehouse",

--- a/purchase_packaging/models/procurement_order.py
+++ b/purchase_packaging/models/procurement_order.py
@@ -18,7 +18,8 @@ class ProcurementOrder(models.Model):
         seller = self.product_id._select_seller(
             partner_id=supplier.name,
             quantity=res['product_qty'],
-            date=po.date_order and fields.Date.from_string(po.date_order),
+            date=po.date_order and fields.Date.to_string(
+                fields.Date.from_string(po.date_order)) or None,
             uom_id=self.product_id.uom_po_id)
         if seller.packaging_id:
                 res['packaging_id'] = seller.packaging_id.id

--- a/purchase_packaging/models/purchase_order_line.py
+++ b/purchase_packaging/models/purchase_order_line.py
@@ -43,8 +43,8 @@ class PurchaseOrderLine(models.Model):
         return self.product_id._select_seller(
             partner_id=self.order_id.partner_id,
             quantity=self.product_qty,
-            date=self.order_id.date_order and
-            fields.Date.from_string(self.order_id.date_order),
+            date=self.order_id.date_order and fields.Date.to_string(
+                fields.Date.from_string(self.order_id.date_order)) or None,
             uom_id=self.product_uom)
 
     @api.multi

--- a/purchase_packaging/tests/test_procurement_order.py
+++ b/purchase_packaging/tests/test_procurement_order.py
@@ -2,6 +2,8 @@
 # Copyright 2015-2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import odoo.tests.common as common
+from datetime import timedelta
+from odoo import fields
 
 
 class TestProcurementOrder(common.TransactionCase):
@@ -19,6 +21,8 @@ class TestProcurementOrder(common.TransactionCase):
         self.sp_30 = self.env.ref('product.product_supplierinfo_1')
         self.sp_30.product_tmpl_id = self.product_packaging_3.product_tmpl_id
         self.sp_30.currency_id = self.env.user.company_id.currency_id
+        self.sp_30.date_start = fields.Datetime.from_string(
+            fields.Datetime.now()) - timedelta(days=10)
         self.product_uom_8 = self.env['product.uom'].create(
             {'category_id': self.env.ref('product.product_uom_categ_unit').id,
              'name': 'COL8',


### PR DESCRIPTION
on the def _select_seller() the system try to compare "date" with seller.date_start and seller.date_end.
seller.date_start and seller.date_end are str type and here we send date() type.
It generate an error.