### PR TITLE
[FIX] purchase_packaging/orderpoint with purchase multiple: consider po in "sent" and "to approve" state

### DIFF
--- a/purchase_packaging/models/procurement_order.py
+++ b/purchase_packaging/models/procurement_order.py
@@ -55,7 +55,7 @@ class Orderpoint(models.Model):
                  ('state', 'not in', ['cancel', 'done'])])
             if procs:
                 po_lines = procs.mapped('purchase_line_id').filtered(
-                    lambda x: x.state == 'draft')
+                    lambda x: x.state in ['draft', 'sent', 'to approve'])
                 if po_lines:
                     qty = sum([line.product_qty for line in po_lines])
                     precision = orderpoint.product_uom.rounding

--- a/purchase_packaging/tests/test_procurement_order.py
+++ b/purchase_packaging/tests/test_procurement_order.py
@@ -315,6 +315,124 @@ class TestProcurementOrder(common.TransactionCase):
             self.assertTrue(proc.purchase_line_id)
             self.assertEqual(proc.purchase_line_id.product_qty, 24)
 
+    def test_procurement_from_orderpoint_sent_po(self):
+        # Define a multiple of 12 on supplier info
+        # Trigger a stock minimum rule of 10 PC
+        # A purchase line with 12 PC should be generated
+        # Send the purchase order
+        # Change the stock minimum to 11 PC
+        # No new purchase should be generated
+        # Change the stock minimum to 13 PC
+        # A new purchase should be generated
+        warehouse = self.env.ref('stock.warehouse0')
+        product = self.env.ref('product.product_product_3')
+        product.route_ids = [(
+            4, self.env.ref("purchase.route_warehouse0_buy").id)]
+        self.env.ref('product.product_uom_dozen').rounding = 1
+        procurement_obj = self.env['procurement.order']
+
+        self.sp_30.min_qty = 1
+        self.sp_30.min_qty_uom_id = self.env.ref('product.product_uom_dozen')
+
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'warehouse_id': warehouse.id,
+            'location_id': warehouse.lot_stock_id.id,
+            'product_id': product.id,
+            'product_min_qty': 10,
+            'product_max_qty': 10,
+        })
+        procurement_obj.run_scheduler()
+        proc = procurement_obj.search([('orderpoint_id', '=', orderpoint.id)])
+        self.assertEqual(len(proc), 1)
+        self.assertTrue(proc.purchase_line_id)
+        self.assertEqual(proc.purchase_line_id.product_qty, 12)
+
+        proc.purchase_line_id.order_id.write({'state': 'sent'})
+
+        # change order_point level and rerun
+        orderpoint.product_min_qty = 11
+        orderpoint.product_max_qty = 11
+
+        procurement_obj.run_scheduler()
+        proc = procurement_obj.search([('orderpoint_id', '=', orderpoint.id)])
+
+        self.assertTrue(proc)
+        self.assertEqual(len(proc), 1)
+        self.assertEqual(proc.purchase_line_id.product_qty, 12)
+
+        # change order_point level and rerun
+        orderpoint.product_min_qty = 13
+        orderpoint.product_max_qty = 13
+
+        procurement_obj.run_scheduler()
+        procs = procurement_obj.search([('orderpoint_id', '=', orderpoint.id)])
+
+        self.assertTrue(procs)
+        self.assertEqual(len(procs), 2)
+
+        for proc in procs:
+            self.assertTrue(proc.purchase_line_id)
+            self.assertEqual(proc.purchase_line_id.product_qty, 12)
+
+    def test_procurement_from_orderpoint_to_approve_po(self):
+        # Define a multiple of 12 on supplier info
+        # Trigger a stock minimum rule of 10 PC
+        # A purchase line with 12 PC should be generated
+        # Set the purchase order to approve
+        # Change the stock minimum to 11 PC
+        # No new purchase should be generated
+        # Change the stock minimum to 13 PC
+        # A new purchase should be generated
+        warehouse = self.env.ref('stock.warehouse0')
+        product = self.env.ref('product.product_product_3')
+        product.route_ids = [(
+            4, self.env.ref("purchase.route_warehouse0_buy").id)]
+        self.env.ref('product.product_uom_dozen').rounding = 1
+        procurement_obj = self.env['procurement.order']
+
+        self.sp_30.min_qty = 1
+        self.sp_30.min_qty_uom_id = self.env.ref('product.product_uom_dozen')
+
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'warehouse_id': warehouse.id,
+            'location_id': warehouse.lot_stock_id.id,
+            'product_id': product.id,
+            'product_min_qty': 10,
+            'product_max_qty': 10,
+        })
+        procurement_obj.run_scheduler()
+        proc = procurement_obj.search([('orderpoint_id', '=', orderpoint.id)])
+        self.assertEqual(len(proc), 1)
+        self.assertTrue(proc.purchase_line_id)
+        self.assertEqual(proc.purchase_line_id.product_qty, 12)
+
+        proc.purchase_line_id.order_id.write({'state': 'to approve'})
+
+        # change order_point level and rerun
+        orderpoint.product_min_qty = 11
+        orderpoint.product_max_qty = 11
+
+        procurement_obj.run_scheduler()
+        proc = procurement_obj.search([('orderpoint_id', '=', orderpoint.id)])
+
+        self.assertTrue(proc)
+        self.assertEqual(len(proc), 1)
+        self.assertEqual(proc.purchase_line_id.product_qty, 12)
+
+        # change order_point level and rerun
+        orderpoint.product_min_qty = 13
+        orderpoint.product_max_qty = 13
+
+        procurement_obj.run_scheduler()
+        procs = procurement_obj.search([('orderpoint_id', '=', orderpoint.id)])
+
+        self.assertTrue(procs)
+        self.assertEqual(len(procs), 2)
+
+        for proc in procs:
+            self.assertTrue(proc.purchase_line_id)
+            self.assertEqual(proc.purchase_line_id.product_qty, 12)
+
     def test_procurement_from_orderpoint_confirmed_po(self):
         # Define a multiple of 12 on supplier info
         # Trigger a stock minimum rule of 10 PC


### PR DESCRIPTION
These states were totally ignored by the compute method so too much procurement orders are generated.