### PR TITLE
[11.0] Putaway strategy: add module to restore the method field

### DIFF
--- a/stock_putaway_method/README.rst
+++ b/stock_putaway_method/README.rst
@@ -1,0 +1,50 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=======================
+Putaway strategy method
+=======================
+
+This module adds the putaway strategy method back, removed from the stock module in Odoo 11.
+
+Installation
+============
+
+To install this module, just click the install button. This module is automatically installed when installing relying modules such as *stock_putaway_product*.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-warehouse/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
+
+Contributors
+------------
+
+* Alexandre Saunier - Camptocamp SA <alexandre.saunier@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_putaway_method/__init__.py
+++ b/stock_putaway_method/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import models
+from . import tests

--- a/stock_putaway_method/__manifest__.py
+++ b/stock_putaway_method/__manifest__.py
@@ -1,0 +1,20 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Putaway strategy method',
+    'summary': 'Add the putaway strategy method back, '
+               'removed from the stock module in Odoo 11',
+    'version': '11.0.1.0.0',
+    'category': 'Inventory',
+    'website': 'https://www.camptocamp.com',
+    'author': 'Camptocamp SA, '
+              'Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'depends': [
+        'product',
+        'stock'
+    ],
+    'data': [
+        'views/product_strategy_views.xml'
+    ],
+    'demo': []
+}

--- a/stock_putaway_method/models/__init__.py
+++ b/stock_putaway_method/models/__init__.py
@@ -1,0 +1,2 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import product_strategy

--- a/stock_putaway_method/models/product_strategy.py
+++ b/stock_putaway_method/models/product_strategy.py
@@ -1,0 +1,18 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class PutAwayStrategy(models.Model):
+    _inherit = 'product.putaway'
+
+    method = fields.Selection(
+        selection='_get_putaway_options',
+        string='Method',
+        default='fixed',
+        required=True,
+    )
+
+    @api.model
+    def _get_putaway_options(self):
+        return [('fixed', 'Fixed Location')]

--- a/stock_putaway_method/tests/__init__.py
+++ b/stock_putaway_method/tests/__init__.py
@@ -1,0 +1,2 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import test_putaway_method

--- a/stock_putaway_method/tests/test_putaway_method.py
+++ b/stock_putaway_method/tests/test_putaway_method.py
@@ -1,0 +1,12 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestPutawayMethod(TransactionCase):
+
+    # Check if "fixed" is a valid putaway method
+    def test_01_putaway_methods(self):
+        field_method = self.env['product.putaway']._fields.get('method')
+        self.assertIn('fixed', field_method.get_values(self.env))

--- a/stock_putaway_method/views/product_strategy_views.xml
+++ b/stock_putaway_method/views/product_strategy_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="view_putaway" model="ir.ui.view">
+        <field name="name">product.putaway.form.method</field>
+        <field name="model">product.putaway</field>
+        <field name="inherit_id" ref="stock.view_putaway"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']/../.." position="replace">
+                <form string="Putaway">
+                    <group colspan="4">
+                        <field name="name"/>
+                        <field name="method"/>
+                    </group>
+                    <div attrs="{'invisible': [('method', '!=', 'fixed')]}">
+                        <separator string="Fixed Locations Per Categories"/>
+                        <field name="fixed_location_ids" colspan="4" nolabel="1">
+                            <tree editable="top">
+                                <field name="sequence" widget='handle'/>
+                                <field name="category_id"/>
+                                <field name="fixed_location_id"/>
+                            </tree>
+                        </field>
+                    </div>
+                </form>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The method field was removed in module 'stock' of Odoo 11. See
https://github.com/odoo/odoo/commit/f2926823e848f4aee89542ced9fb846c74a524d2

Since the field is used by OCA modules such as stock_putaway_product
(eg. to add a 'per_product' method), the new stock_putaway_method module
is added to restore this feature if needed.

Current putaway strategy editing panel in the inventory configuration:

![capture du 2018-02-16 09-59-10](https://user-images.githubusercontent.com/1192331/36300092-2467abbc-1300-11e8-977a-abbaef874ea4.png)

With the new stock_putaway_method module:

![capture du 2018-02-15 17-40-35](https://user-images.githubusercontent.com/1192331/36300128-3d05002a-1300-11e8-8772-050af2d057a9.png)
