### PR TITLE
[9.0][stock_demand_estimate] Fix qty return by estimate

### DIFF
--- a/stock_demand_estimate/models/stock_demand_estimate.py
+++ b/stock_demand_estimate/models/stock_demand_estimate.py
@@ -77,8 +77,7 @@ class StockDemandEstimate(models.Model):
 
         # We need only the periods that overlap
         # the dates introduced by the user.
-        if (date_start <= period_date_start <= date_end or date_start <=
-                period_date_end <= date_end):
+        if period_date_start <= date_end and period_date_end >= date_start:
             overlap_date_start = max(period_date_start, date_start)
             overlap_date_end = min(period_date_end, date_end)
             days = (abs(overlap_date_end-overlap_date_start)).days + 1


### PR DESCRIPTION
In this present logic, it considers that the estimate period (date range) is always shorter than the period correspondig to the date_start / date_end passed in arguments.

But, if it is not the case, it won't work. An example to be clearer : 

date_start = 2018-02-19
date_end = 2018-02-26

Estimate date_range goes from 2018-02-01 to 2018-02-28
quantity = 28

With present code, it will return a qty of 0
After the fix, the qty returned would be 7, as expected.

@lreficent @mpanarin @jbeficent 