### PR TITLE
[11.0][IMP] stock_request_purchase: Remove hook

### DIFF
--- a/stock_request_purchase/__manifest__.py
+++ b/stock_request_purchase/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Request Purchase",
     "summary": "Internal request for stock",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "license": "LGPL-3",
     "website": "https://github.com/stock-logistics-warehouse",
     "author": "Eficent, "
@@ -13,7 +13,6 @@
     "depends": [
         "stock_request",
         "purchase",
-        "purchase_procurement_run_buy_hook"
     ],
     "data": [
         "security/ir.model.access.csv",

--- a/stock_request_purchase/models/procurement_rule.py
+++ b/stock_request_purchase/models/procurement_rule.py
@@ -15,13 +15,10 @@ class ProcurementRule(models.Model):
             vals['stock_request_ids'] = [(4, values['stock_request_id'])]
         return vals
 
-    def _prepare_purchase_order_line_update(self, line,
-                                            procurement_uom_po_qty,
-                                            price_unit, values):
-        vals = super(ProcurementRule,
-                     self)._prepare_purchase_order_line_update(
-            line, procurement_uom_po_qty, price_unit, values
-        )
+    def _update_purchase_order_line(self, product_id, product_qty, product_uom,
+                                    values, line, partner):
+        vals = super(ProcurementRule, self)._update_purchase_order_line(
+            product_id, product_qty, product_uom, values, line, partner)
         if 'stock_request_id' in values:
             vals['stock_request_ids'] = [(4, values['stock_request_id'])]
         return vals


### PR DESCRIPTION
The module `purchase_procurement_run_buy_hook` is not needed anymore.