### PR TITLE
[ADD] updated parameter values pass to run() method, to avoid twice qty calculation

### DIFF
--- a/stock_orderpoint_manual_procurement/models/stock_warehouse_orderpoint.py
+++ b/stock_orderpoint_manual_procurement/models/stock_warehouse_orderpoint.py
@@ -24,14 +24,6 @@ class StockWarehouseOrderpoint(models.Model):
         compute="_compute_procure_recommended",
     )
 
-    def _prepare_procurement_values(self, product_qty, date=False,
-                                    group=False):
-        res = super(StockWarehouseOrderpoint,
-                    self)._prepare_procurement_values(product_qty, date=date,
-                                                      group=group)
-        res.update({'qty': product_qty})
-        return res
-
     @api.multi
     def _get_procure_recommended_qty(self, virtual_qty, op_qtys):
         self.ensure_one()

--- a/stock_orderpoint_manual_procurement/wizards/make_procurement_orderpoint.py
+++ b/stock_orderpoint_manual_procurement/wizards/make_procurement_orderpoint.py
@@ -71,7 +71,7 @@ class MakeProcurementOrderpoint(models.TransientModel):
                 self.env['procurement.group'].run(
                     item.orderpoint_id.product_id,
                     item.qty,
-                    item.orderpoint_id.product_uom,
+                    item.uom_id,
                     item.orderpoint_id.location_id,
                     item.orderpoint_id.name,
                     item.orderpoint_id.name,


### PR DESCRIPTION
Need to review:

- Remove `_prepare_procurement_values()` method
- Pass context to `run()` method to avoid twice quantity calculation.