### PR TITLE
[11.0][IMP] stock_available_unreserved: allow searching by unreserved quantities

### DIFF
--- a/stock_available_unreserved/README.rst
+++ b/stock_available_unreserved/README.rst
@@ -48,6 +48,7 @@ Contributors
 * Jordi Ballester Alomar <jordi.ballester@eficent.com>
 * Stefan Rijnhart <stefan@opener.amsterdam>
 * Mykhailo Panarin <m.panarin@mobilunity.com>
+* Atte Isopuro <atte.isopuro@avoin.systems>
 
 
 Maintainer

--- a/stock_available_unreserved/views/product_view.xml
+++ b/stock_available_unreserved/views/product_view.xml
@@ -14,6 +14,17 @@
             </field>
         </record>
 
+        <record id="product_template_search_form_view_stock" model="ir.ui.view">
+            <field name="name">product.template.search.stock.form.inherit</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="stock.product_template_search_form_view_stock"/>
+            <field name="arch" type="xml">
+                <filter name="real_stock_available" position="after">
+                    <filter name="real_stock_unreserved" string="Reservable Products" domain="[('qty_available_not_res','&gt;',0)]"/>
+                </filter>
+            </field>
+        </record>
+
         <record model="ir.ui.view" id="product_template_kanban_stock_view">
             <field name="name">Product Template Kanban Stock</field>
             <field name="model">product.template</field>


### PR DESCRIPTION
In the Odoo core it is possible to search based on product quantities, i.e you can make searches like "all products with available stock greater than 4" or "all products with virtual stock less than 0". This change allows the same to be done with the Unreserved Quantity field added by `stock_available_unreserved`.