### PR TITLE
[11.0][IMP] stock_request: create request order from products

### DIFF
--- a/stock_request/README.rst
+++ b/stock_request/README.rst
@@ -72,6 +72,7 @@ Contributors
 
 * Jordi Ballester (EFICENT) <jordi.ballester@eficent.com>.
 * Enric Tobella <etobella@creublanca.es>
+* Atte Isopuro <atte.isopuro@avoin.systems>
 
 Maintainer
 ----------

--- a/stock_request/__manifest__.py
+++ b/stock_request/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Request",
     "summary": "Internal request for stock",
-    "version": "11.0.2.1.0",
+    "version": "11.0.2.2.0",
     "license": "LGPL-3",
     "website": "https://github.com/stock-logistics-warehouse",
     "author": "Eficent, "
@@ -16,6 +16,7 @@
     "data": [
         "security/stock_request_security.xml",
         "security/ir.model.access.csv",
+        "views/product.xml",
         "views/stock_request_views.xml",
         "views/stock_request_allocation_views.xml",
         "views/stock_move_views.xml",

--- a/stock_request/views/product.xml
+++ b/stock_request/views/product.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="action_variant_generate_stock_request_orders" model="ir.actions.server">
+        <field name="name">Request Stock</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="product.model_product_product"/>
+        <field name="binding_model_id" ref="product.model_product_product"/>
+        <field name="code">
+action = records.env['stock.request.order']._create_from_product_multiselect(records)
+        </field>
+    </record>
+
+    <record id="action_template_generate_stock_request_orders" model="ir.actions.server">
+        <field name="name">Request Stock</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="binding_model_id" ref="product.model_product_template"/>
+        <field name="code">
+action = records.env['stock.request.order']._create_from_product_multiselect(records)
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This commit allows the user to select multiple products from
a product list view and to create a Stock Request Order with
an action. If the user selects templates, all of those templates'
variants will be added to the order.

This is useful as it allows the user to filter products beforehand
based on their stocks, and to create a request order for all
those products whose stock is too low.