### PR TITLE
[11.0][FIX] stock_putaway_product: return the model.

### DIFF
--- a/stock_putaway_product/__manifest__.py
+++ b/stock_putaway_product/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Putaway strategy per product',
     'summary': 'Set a product location and put-away strategy per product',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Inventory',
     'website': 'http://www.apertoso.be',
     'author': 'Apertoso N.V., '

--- a/stock_putaway_product/models/product_putaway.py
+++ b/stock_putaway_product/models/product_putaway.py
@@ -39,11 +39,12 @@ class ProductPutaway(models.Model):
         return strategy
 
     def putaway_apply(self, product):
+        """:return a stock.location record or the model."""
         if self.method == 'per_product':
             strategies = self.get_product_putaway_strategies(product)
             strategy = strategies[:1]
             if strategy:
-                return strategy.fixed_location_id.id
+                return strategy.fixed_location_id
         return super().putaway_apply(product)
 
 

--- a/stock_putaway_product/tests/test_product_putaway.py
+++ b/stock_putaway_product/tests/test_product_putaway.py
@@ -41,7 +41,7 @@ class TestProductPutaway(SavepointCase):
     def test_02_putway_apply(self):
         self.assertEqual(
             self.putaway_per_product.putaway_apply(self.product_ipad),
-            self.location_shelf1.id)
+            self.location_shelf1)
 
     def test_03_stock_change_product_qty_default(self):
         wiz_obj = self.env['stock.change.product.qty']


### PR DESCRIPTION
The [putaway_apply method](https://github.com/odoo/odoo/blob/11.0/addons/stock/models/product_strategy.py#L24) should return a stock.location model or record not the id.