### PR TITLE
Wrong MTS source location when the warehouse has two or more Stock

### DIFF
--- a/stock_mts_mto_rule/__manifest__.py
+++ b/stock_mts_mto_rule/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {'name': 'Stock MTS+MTO Rule',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.1.0.1',
  'author': 'Akretion,Odoo Community Association (OCA)',
  'website': 'http://www.akretion.com',
  'license': 'AGPL-3',

--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -19,7 +19,7 @@ class ProcurementOrder(models.Model):
     @api.multi
     def get_mto_qty_to_order(self):
         self.ensure_one()
-        stock_location = self.warehouse_id.lot_stock_id.id
+        stock_location = self.rule_id.mts_rule_id.location_src_id.id
         proc_warehouse = self.with_context(location=stock_location)
         virtual_available = proc_warehouse.product_id.virtual_available
         qty_available = self.product_id.uom_id._compute_quantity(


### PR DESCRIPTION
**Impacted Versions:**
10.0

**Steps to Reproduce**
- Create 2 stock locations to have products stock. 
-  Create a route with 2 rules of  MTS - MTO rules.
-  Create a product with 2 units in one location and 3 units in another location.
-  Create a Sale Order with the product created with 10 of product quantity and confirm it 
  
**Current behavior before PR:**
- The stock location routes create wrong stock pickings because in the method "get_mto_qty_to_order" always takes the quantity available of the main stock location per warehouse (self.warehouse_id.lot_stock_id.id), so if I have many stock locations with products the method returns wrong quantities.

![captura realizada el 2018-04-19 08 46 58](https://user-images.githubusercontent.com/16998467/38995322-3ecd6d00-43ae-11e8-93b2-da0723c28915.png)


**Desired behavior after PR is merged:**
The method must return the available quantity of the source stock location configured on the MTS rule.


Hello @pedrobaeza, What can I do to have someone review this PR?
@alan196  Could you review this code?.

Best Regards!