### PR TITLE
[11.0][FIX] stock demand estimate: division by zero

### DIFF
--- a/stock_demand_estimate/__manifest__.py
+++ b/stock_demand_estimate/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Demand Estimate",
     "summary": "Allows to create demand estimates.",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",

--- a/stock_demand_estimate/models/stock_demand_estimate.py
+++ b/stock_demand_estimate/models/stock_demand_estimate.py
@@ -62,7 +62,10 @@ class StockDemandEstimate(models.Model):
     @api.depends('product_qty', 'date_range_id.days')
     def _compute_daily_qty(self):
         for rec in self:
-            rec.daily_qty = rec.product_qty / rec.date_range_id.days
+            if rec.date_range_id.days:
+                rec.daily_qty = rec.product_qty / rec.date_range_id.days
+            else:
+                rec.daily_qty = 0.0
 
     @api.multi
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
@@ -94,6 +97,7 @@ class StockDemandEstimate(models.Model):
 
     @api.model
     def get_quantity_by_date_range(self, date_start, date_end):
+        """To be used in other modules"""
         # Check if the dates overlap with the period
         period_date_start = fields.Date.from_string(
             self.date_range_id.date_start

--- a/stock_demand_estimate/views/stock_demand_estimate_view.xml
+++ b/stock_demand_estimate/views/stock_demand_estimate_view.xml
@@ -6,7 +6,7 @@
             <field name="name">stock.demand.estimate.tree</field>
             <field name="model">stock.demand.estimate</field>
             <field name="arch" type="xml">
-                <tree string="Stock Demand Estimate" editable="top">
+                <tree string="Stock Demand Estimate" editable="top" create="0">
                     <field name="date_range_id"/>
                     <field name="product_id"/>
                     <field name="location_id"/>


### PR DESCRIPTION
Testing on runbot I had the following traceback:

> ```python
> Error:
> Odoo Server Error
> 
> Traceback (most recent call last):
>   File "/.repo_requirements/odoo/odoo/fields.py", line 936, in __get__
>     value = record.env.cache.get(record, self)
>   File "/.repo_requirements/odoo/odoo/api.py", line 960, in get
>     value = self._data[field][record.id][key]
> KeyError: <odoo.api.Environment object at 0x7f9fb1200080>
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   File "/.repo_requirements/odoo/odoo/http.py", line 650, in _handle_exception
>     return super(JsonRequest, self)._handle_exception(exception)
>   File "/.repo_requirements/odoo/odoo/http.py", line 310, in _handle_exception
>     raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
>   File "/.repo_requirements/odoo/odoo/tools/pycompat.py", line 87, in reraise
>     raise value
>   File "/.repo_requirements/odoo/odoo/http.py", line 692, in dispatch
>     result = self._call_function(**self.params)
>   File "/.repo_requirements/odoo/odoo/http.py", line 342, in _call_function
>     return checked_call(self.db, *args, **kwargs)
>   File "/.repo_requirements/odoo/odoo/service/model.py", line 97, in wrapper
>     return f(dbname, *args, **kwargs)
>   File "/.repo_requirements/odoo/odoo/http.py", line 335, in checked_call
>     result = self.endpoint(*a, **kw)
>   File "/.repo_requirements/odoo/odoo/http.py", line 936, in __call__
>     return self.method(*args, **kw)
>   File "/.repo_requirements/odoo/odoo/http.py", line 515, in response_wrap
>     response = f(*args, **kw)
>   File "/home/odoo/OCB-11.0/addons/web/controllers/main.py", line 930, in call_kw
>     return self._call_kw(model, method, args, kwargs)
>   File "/home/odoo/OCB-11.0/addons/web/controllers/main.py", line 922, in _call_kw
>     return call_kw(request.env[model], method, args, kwargs)
>   File "/.repo_requirements/odoo/odoo/api.py", line 689, in call_kw
>     return call_kw_multi(method, model, args, kwargs)
>   File "/.repo_requirements/odoo/odoo/api.py", line 680, in call_kw_multi
>     result = method(recs, *args, **kwargs)
>   File "/.repo_requirements/odoo/odoo/models.py", line 5056, in onchange
>     value = record[name]
>   File "/.repo_requirements/odoo/odoo/models.py", line 4739, in __getitem__
>     return self._fields[key].__get__(self, type(self))
>   File "/.repo_requirements/odoo/odoo/fields.py", line 942, in __get__
>     self.determine_draft_value(record)
>   File "/.repo_requirements/odoo/odoo/fields.py", line 1062, in determine_draft_value
>     self._compute_value(record)
>   File "/.repo_requirements/odoo/odoo/fields.py", line 998, in _compute_value
>     getattr(records, self.compute)()
>   File "/home/odoo/build/OCA/stock-logistics-warehouse/stock_demand_estimate/models/stock_demand_estimate.py", line 65, in _compute_daily_qty
>     rec.daily_qty = rec.product_qty / rec.date_range_id.days
> ZeroDivisionError: float division by zero
> ```

This PR includes:

~- [x] A proper fix for that traceback to avoid the division by zero error.~
~- [x] A deletion of an unused method.~
Edited:
- [x] A fix for that traceback in case this error happens in any case.
- [x] Forbid the possibility to create a demand estimate directly from the <code>Create</code> in the tree view.
- [x] Put a docstring explaining that the unused method is used in other modules.

@jbeficent @lreficent @mpanarin
