### PR TITLE
[11.0][Fix] stock_orderpoint_manual_procurement : Convert date_planned string to datetime string

### DIFF
--- a/stock_orderpoint_manual_procurement/__manifest__.py
+++ b/stock_orderpoint_manual_procurement/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Stock Orderpoint Manual Procurement",
     "summary": "Allows to create procurement orders from orderpoints instead "
                "of relying only on the scheduler.",
-    "version": "11.0.1.1.0",
+    "version": "11.0.1.1.1",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",

--- a/stock_orderpoint_manual_procurement/wizards/make_procurement_orderpoint.py
+++ b/stock_orderpoint_manual_procurement/wizards/make_procurement_orderpoint.py
@@ -67,7 +67,8 @@ class MakeProcurementOrderpoint(models.TransientModel):
             if not item.orderpoint_id:
                 raise ValidationError(_("No reordering rule found!"))
             values = item.orderpoint_id._prepare_procurement_values(item.qty)
-            values['date_planned'] = item.date_planned
+            values['date_planned'] = fields.Datetime.to_string(
+                fields.Date.from_string(item.date_planned))
             # Run procurement
             try:
                 self.env['procurement.group'].run(


### PR DESCRIPTION
Fixes following error :
```
File "/opt/odoo/external-src/stock-logistics-warehouse/stock_orderpoint_manual_procurement/wizards/make_procurement_orderpoint.py", line 80, in make_procurement
values
File "/opt/odoo/external-src/stock-logistics-warehouse/stock_orderpoint_uom/models/procurement_group.py", line 23, in run
name, origin, values)
File "/opt/odoo/src/addons/stock/models/procurement.py", line 186, in run
getattr(rule, 'run%s' % rule.action)(product_id, product_qty, product_uom, location_id, name, origin, values)
File "/opt/odoo/src/addons/stock/models/procurement.py", line 78, in _run_move
data = self._get_stock_move_values(product_id, product_qty, product_uom, location_id, name, origin, values, group_id)
File "/opt/odoo/src/addons/sale_stock/models/stock.py", line 57, in _get_stock_move_values
result = super(ProcurementRule, self)._get_stock_move_values(product_id, product_qty, product_uom, location_id, name, origin, values, group_id)
File "/opt/odoo/external-src/stock-logistics-warehouse/stock_orderpoint_move_link/models/procurement_rule.py", line 14, in _get_stock_move_values
location_id, name, origin, values, group_id)
File "/opt/odoo/external-src/stock-rma/rma/models/procurement.py", line 23, in _get_stock_move_values
group_id)
File "/opt/odoo/src/addons/stock/models/procurement.py", line 91, in _get_stock_move_values
date_expected = (datetime.strptime(values['date_planned'], DEFAULT_SERVER_DATETIME_FORMAT) - relativedelta(days=self.delay or 0)).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
File "/usr/lib/python3.5/_strptime.py", line 510, in _strptime_datetime
tt, fraction = _strptime(data_string, format)
File "/usr/lib/python3.5/_strptime.py", line 343, in _strptime
(data_string, format))
ValueError: time data '2018-06-07' does not match format '%Y-%m-%d %H:%M:%S'
```