### PR TITLE
[10.0][FIX] purchase_packaging: Inverse method when no supplierinfo

### DIFF
--- a/purchase_packaging/__manifest__.py
+++ b/purchase_packaging/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Purchase Packaging",
-    "version": "10.0.1.0.6",
+    "version": "10.0.1.0.7",
     "author": 'ACSONE SA/NV, '
               'Odoo Community Association (OCA)',
     "category": "Warehouse",

--- a/purchase_packaging/models/purchase_order_line.py
+++ b/purchase_packaging/models/purchase_order_line.py
@@ -83,18 +83,18 @@ class PurchaseOrderLine(models.Model):
         uom_by_category = {
             from_uom.category_id: from_uom for from_uom in from_uoms}
         for line in self:
+            purchase_qty = line.product_qty
             if line.product_id:
                 supplier = line._get_product_seller()
                 if supplier:
                     product_purchase_uom = supplier.min_qty_uom_id
                     from_uom = uom_by_category.get(
                         line.product_purchase_uom_id.category_id)
-                    line.product_purchase_qty = from_uom._compute_quantity(
+                    purchase_qty = from_uom._compute_quantity(
                         line.product_qty,
                         product_purchase_uom)
                     line.product_purchase_uom_id = product_purchase_uom.id
-            else:
-                line.product_purchase_qty = line.product_qty
+            line.product_purchase_qty = purchase_qty
 
     @api.onchange("packaging_id")
     def _onchange_packaging_id(self):

--- a/purchase_packaging/tests/test_purchase_order_line.py
+++ b/purchase_packaging/tests/test_purchase_order_line.py
@@ -135,3 +135,31 @@ class TestPurchaseOrderLine(common.TransactionCase):
             po_line.product_uom,
             'The product uom is not well set'
         )
+
+    def test_po_line_inverse_no_supplier(self):
+        self.product_supplier_info.min_qty_uom_id = self.product_uom_8
+        self.product_supplier_info.min_qty = 2
+        self.product_supplier_info.packaging_id = self.product_packaging_dozen
+
+        po = self.env['purchase.order'].create(
+            {'partner_id': self.product_supplier_info.name.id})
+        po_line = po.order_line.new({
+            'product_id': self.product_tmpl_id.product_variant_id,
+            'product_purchase_qty': 1.0,
+            'product_purchase_uom_id':
+                po.order_line._default_product_purchase_uom_id(),
+            'order_id': po
+        })
+        po_line.onchange_product_id()
+        self.assertEquals(
+            16.0,
+            po_line.product_qty,
+        )
+        # Remove Supplierinfos
+        po_line.product_id.seller_ids = self.env[
+            'product.supplierinfo'].browse()
+        po_line.product_qty = 2.0
+        self.assertEquals(
+            2.0,
+            po_line.product_qty,
+        )


### PR DESCRIPTION
The inverse method does not take into account void supplierinfo, so product_purchase_qty is not well set.