### PR TITLE
[fix] stock_requet: add menu image for stock requests

### DIFF
--- a/stock_request/views/stock_request_menu.xml
+++ b/stock_request/views/stock_request_menu.xml
@@ -4,6 +4,7 @@
         id="menu_stock_request_root"
         name="Stock Requests"
         groups="stock_request.group_stock_request_user,stock_request.group_stock_request_manager"
+        web_icon="stock_request,static/description/icon.png"
         sequence="100"/>
 
     <menuitem


### PR DESCRIPTION
Fixes missing image in the menu for stock requests:
![image](https://user-images.githubusercontent.com/7683926/42768867-dfa4025e-8920-11e8-9072-77f714aba197.png)
