### PR TITLE
[FIX] 10.0 putaway_product : display variant on template

### DIFF
--- a/stock_putaway_product/views/product.xml
+++ b/stock_putaway_product/views/product.xml
@@ -21,8 +21,8 @@
                             <field name="putaway_id"/>
                             <field name="product_tmpl_id" invisible="1"/>
                             <field name="product_product_id"
-                                   invisible="context.get('default_product_product_id', False)"
-                                   domain="[('product_tmpl_id', '=', product_tmpl_id)]"/>
+                                domain="['|', ('product_tmpl_id', '=', product_tmpl_id),
+                                    ('id', '=', context.get('default_product_tmpl_id'))]"/>
                             <field name="fixed_location_id"/>
                         </tree>
                     </field>

--- a/stock_putaway_product/views/product.xml
+++ b/stock_putaway_product/views/product.xml
@@ -21,7 +21,7 @@
                             <field name="putaway_id"/>
                             <field name="product_tmpl_id" invisible="1"/>
                             <field name="product_product_id"
-                                   invisible="context.get('default_product_product_id', True)"
+                                   invisible="context.get('default_product_product_id', False)"
                                    domain="[('product_tmpl_id', '=', product_tmpl_id)]"/>
                             <field name="fixed_location_id"/>
                         </tree>


### PR DESCRIPTION
The variant name does not appear on the template's tree view, it's confusing. This PR fixes it.

From what I understand, the field should be invisible if there is not a default_product_product_id.