### PR TITLE
[10.0][FIX] stock_inventory_discrepancy: Launch wizard as current user

### DIFF
--- a/stock_inventory_discrepancy/tests/test_inventory_discrepancy.py
+++ b/stock_inventory_discrepancy/tests/test_inventory_discrepancy.py
@@ -163,11 +163,11 @@ class TestInventoryDiscrepancy(TransactionCase):
         """Test if a user error raises when a stock user tries to update the
         qty for a product and the correction is a discrepancy over the
         threshold."""
-        upd_qty = self.obj_upd_qty_wizard.create({
+        upd_qty = self.obj_upd_qty_wizard.sudo(self.user).create({
             'product_id': self.product1.id,
             'product_tmpl_id': self.product1.product_tmpl_id.id,
             'new_quantity': 10.0,
             'location_id': self.test_loc.id,
         })
         with self.assertRaises(UserError):
-            upd_qty.sudo(self.user).change_product_qty()
+            upd_qty.change_product_qty()


### PR DESCRIPTION
This has to be investigated but in test, user that haven't created wizard don't have access to it.

@lreficent @jbeficent 