### PR TITLE
[10.0] stock_quant_merge: add ability to disable it on some calls

### DIFF
--- a/stock_quant_merge/__manifest__.py
+++ b/stock_quant_merge/__manifest__.py
@@ -6,7 +6,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Stock - Quant merge",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "depends": [
         "stock",
     ],
@@ -14,8 +14,8 @@
               "AvanzOSC,"
               "Tecnativa,"
               "Odoo Community Association (OCA)",
-    "website": "http://www.odoomrp.com",
-    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "category": "Warehouse",
     'installable': True,
     "license": "AGPL-3",
 }

--- a/stock_quant_merge/models/stock_move.py
+++ b/stock_quant_merge/models/stock_move.py
@@ -12,5 +12,7 @@ class StockMove(models.Model):
         for move in self:
             quants = move.reserved_quant_ids
             super(StockMove, move).quants_unreserve()
-            if quants and not self._context.get('disable_stock_quant_merge'):
+            if (
+                    quants and
+                    not self.env.context.get('disable_stock_quant_merge')):
                 quants.merge_stock_quants()

--- a/stock_quant_merge/models/stock_move.py
+++ b/stock_quant_merge/models/stock_move.py
@@ -12,4 +12,5 @@ class StockMove(models.Model):
         for move in self:
             quants = move.reserved_quant_ids
             super(StockMove, move).quants_unreserve()
-            quants.merge_stock_quants()
+            if quants and not self._context.get('disable_stock_quant_merge'):
+                quants.merge_stock_quants()


### PR DESCRIPTION
Now possible to disable it on some particular calls via the context key 'disable_stock_quant_merge'

Used to fix a compatibility issue with the module "stock_quant_packages_moving_wizard".