### PR TITLE
[9.0] stock_cycle_count: fix issue with nan while doing the mean calculation

### DIFF
--- a/stock_cycle_count/models/stock_location.py
+++ b/stock_cycle_count/models/stock_location.py
@@ -32,7 +32,8 @@ class StockLocation(models.Model):
             if history:
                 wh_id = rec.get_warehouse(rec)
                 wh = self.env['stock.warehouse'].browse(wh_id)
-                if len(history) > wh.counts_for_accuracy_qty:
+                if wh.counts_for_accuracy_qty and \
+                        len(history) > wh.counts_for_accuracy_qty:
                     rec.loc_accuracy = mean(
                         history[:wh.counts_for_accuracy_qty].
                         mapped('inventory_accuracy'))


### PR DESCRIPTION
Fixes problem by which 'loc_accuracy' in stock.location was being set with value NaN when 'counts_for_accuracy_qty' value of the warehouse was 0. This produced that the form view of stock location could not be opened in those cases.

So, if you do not set the parameter 'Inventories for location accuracy calculation' the accuracy of the location should be 0 by default, as no inventory is going to be considered.