### PR TITLE
[11.0][FIX] stock_mts_mto_rule: fix view to show check for module use 

### DIFF
--- a/stock_mts_mto_rule/view/warehouse.xml
+++ b/stock_mts_mto_rule/view/warehouse.xml
@@ -6,7 +6,7 @@
         <field name="model">stock.warehouse</field>
         <field name="inherit_id" ref="stock.view_warehouse"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='delivery_steps']" position="after">
+            <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="mto_mts_management" />
             </xpath>
         </field>


### PR DESCRIPTION
This fix if due to the check is hidden because the field it's based their xpath is not in list, we are using a field that actually works out.

Without this change
![image](https://user-images.githubusercontent.com/4094256/47888469-409efa80-de0a-11e8-890a-28c478217e4d.png)

With this change
![image](https://user-images.githubusercontent.com/4094256/47888447-249b5900-de0a-11e8-9157-9999ea39f5fc.png)
