### PR TITLE
[10.0][FIX] stock_removal_by_priority: avoid pre-init-hook if reinstalled

### DIFF
--- a/stock_removal_location_by_priority/init_hook.py
+++ b/stock_removal_location_by_priority/init_hook.py
@@ -20,18 +20,30 @@ def pre_init_hook(cr):
 
 
 def set_stock_location_removal_priority_default(cr):
-    cr.execute(
-        """
-        ALTER TABLE stock_location
-        ADD COLUMN removal_priority integer
-        DEFAULT 10;
-        """)
+    cr.execute("""SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name='stock_location' AND
+    column_name='removal_priority'""")
+    if not cr.fetchone():
+        logger.info('Creating field removal_priority on stock_location')
+        cr.execute(
+            """
+            ALTER TABLE stock_location
+            ADD COLUMN removal_priority integer
+            DEFAULT 10;
+            """)
 
 
 def set_stock_quant_removal_priority_default(cr):
-    cr.execute(
-        """
-        ALTER TABLE stock_quant
-        ADD COLUMN removal_priority integer
-        DEFAULT 10;
-        """)
+    cr.execute("""SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name='stock_quant' AND
+    column_name='removal_priority'""")
+    if not cr.fetchone():
+        logger.info('Creating field removal_priority on stock_quant')
+        cr.execute(
+            """
+            ALTER TABLE stock_quant
+            ADD COLUMN removal_priority integer
+            DEFAULT 10;
+            """)


### PR DESCRIPTION
If you reinstall the module, the pre-init-hook breaks.