### PR TITLE
[11.0][stock_available_unreserved][FIX] change computation method to check for unreserved quantity and avoid useless long compute method.

### DIFF
--- a/stock_available_unreserved/models/product.py
+++ b/stock_available_unreserved/models/product.py
@@ -81,7 +81,8 @@ class ProductProduct(models.Model):
         res = {}
 
         domain_quant = self._prepare_domain_available_not_reserved()
-        quants = self.env['stock.quant'].with_context(lang=False).read_group(
+        ctx = {'lang': False, 'has_unreserved_quantity': True}
+        quants = self.env['stock.quant'].with_context(ctx).read_group(
             domain_quant,
             ['product_id', 'location_id', 'quantity', 'reserved_quantity'],
             ['product_id', 'location_id'],
@@ -111,12 +112,29 @@ class ProductProduct(models.Model):
             prod.qty_available_not_res = qty
         return res
 
+    def _get_domain_locations(self):
+        rec = super(ProductProduct, self)._get_domain_locations()
+        if self.env.context.get('has_unreserved_quantity', False):
+            domain_quant = [
+                ('unreserved_quantity', '>', 0.0),
+            ]
+            rec += (domain_quant,)
+        return rec
+
     def _search_quantity_unreserved(self, operator, value):
         if operator not in OPERATORS:
             raise UserError(_('Invalid domain operator %s') % operator)
         if not isinstance(value, (float, int)):
             raise UserError(_('Invalid domain right operand %s') % value)
-
+        if value and operator == '>' and not (
+                {'from_date', 'to_date'} & set(self.env.context.keys())):
+            product_ids = self.with_context(
+                has_unreserved_quantity=True)._search_qty_available_new(
+                operator, value, self.env.context.get('lot_id'),
+                self.env.context.get('owner_id'),
+                self.env.context.get('package_id')
+            )
+            return [('id', 'in', product_ids)]
         ids = []
         for product in self.search([]):
             if OPERATORS[operator](product.qty_available_not_res, value):

--- a/stock_available_unreserved/models/quant.py
+++ b/stock_available_unreserved/models/quant.py
@@ -7,17 +7,13 @@ from odoo import api, fields, models
 class StockQuant(models.Model):
     _inherit = "stock.quant"
 
-    contains_unreserved = fields.Boolean(
-        string="Contains unreserved products",
-        compute="_compute_contains_unreserved",
+    unreserved_quantity = fields.Float(
+        string="Unreserved quantity",
+        compute="_compute_unreserved_quantity",
         store=True,
     )
 
-    @api.depends('product_id', 'location_id', 'quantity', 'reserved_quantity')
-    def _compute_contains_unreserved(self):
-        for record in self:
-            available = record._get_available_quantity(
-                record.product_id,
-                record.location_id,
-            )
-            record.contains_unreserved = True if available > 0 else False
+    @api.depends('quantity', 'reserved_quantity')
+    def _compute_unreserved_quantity(self):
+        for rec in self:
+            rec.unreserved_quantity = rec.quantity - rec.reserved_quantity

--- a/stock_available_unreserved/tests/test_stock_available_unreserved.py
+++ b/stock_available_unreserved/tests/test_stock_available_unreserved.py
@@ -214,6 +214,7 @@ class TestStockLogisticsWarehouse(SavepointCase):
         no_template = self.env['product.template']
         # Start: one template with three variants.
         # All variants have zero unreserved stock
+
         self.check_variants_found_correctly('=', 0, all_variants)
         self.check_variants_found_correctly('>=', 0, all_variants)
         self.check_variants_found_correctly('<=', 0, all_variants)

--- a/stock_available_unreserved/views/stock_quant_view.xml
+++ b/stock_available_unreserved/views/stock_quant_view.xml
@@ -1,28 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="quant_search_view" model="ir.ui.view">
-        <field name="name">stock.quant.search</field>
-        <field name="model">stock.quant</field>
-        <field name="inherit_id" ref="stock.quant_search_view"/>
-        <field eval="10" name="priority"/>
-        <field name="arch" type="xml">
-            <field name="owner_id" position="after">
-                <field name="contains_unreserved"/>
-            </field>
-            <filter name="internal_loc" position="after">
-                <filter name='internal_unreserved'
-                        string="Internal Unreserved"
-                        domain="[('contains_unreserved','=', True), ('location_id.usage','=', 'internal')]"/>
-            </filter>
-        </field>
-    </record>
-
     <record model="ir.actions.act_window"
             id="product_open_quants_unreserved">
         <field name="name">Stock On Hand (Unreserved)</field>
         <field name="context">{'search_default_internal_loc': 1, 'search_default_locationgroup':1}</field>
-        <field name="domain">[('product_id', '=', active_id), ('contains_unreserved', '=', True)]</field>
+        <field name="domain">[('product_id', '=', active_id), ('unreserved_quantity', '>', 0)]</field>
         <field name="res_model">stock.quant</field>
     </record>
 


### PR DESCRIPTION
This fix implements a better mechanism to look for quants that have unreserved quantity.
The previous approach was unnecessarily defining a compute method in the quant that takes forever to compute during a migration from v10 to v11.