### PR TITLE
[11.0][IMP] stock_orderpoint_manual_procurement

### DIFF
--- a/stock_orderpoint_manual_procurement/wizards/make_procurement_orderpoint.py
+++ b/stock_orderpoint_manual_procurement/wizards/make_procurement_orderpoint.py
@@ -69,6 +69,7 @@ class MakeProcurementOrderpoint(models.TransientModel):
             values = item.orderpoint_id._prepare_procurement_values(item.qty)
             values['date_planned'] = fields.Datetime.to_string(
                 fields.Date.from_string(item.date_planned))
+            values['requested_uid'] = self.env.user
             # Run procurement
             try:
                 self.env['procurement.group'].run(


### PR DESCRIPTION
Improve module stock_orderpoint_manual_procurement in order to update Responsible field in a Manufacturing Order to show the user that has originated it and avoid displaying always the Administrator.