### PR TITLE
[11.0] [ADD] stock_request_non_internal

### DIFF
--- a/stock_request_non_internal/README.rst
+++ b/stock_request_non_internal/README.rst
@@ -6,20 +6,21 @@
 Stock Request Non Internal
 ==========================
 
-Allow to request stock for non internal locations
+Allow to request stock for internal locations and no company assigned.
+Constrains make sure to not create stock_request for the same location and
+different companies.
 
 
 Configuration
 =============
 
-There must be at least a route with a procurement rule for the wanted virtual
-location.
+There must be at least a route with a procurement rule for the wanted location
 
 
 Usage
 =====
 
-Create a stock request with no warehouse and the wanted virtual location
+Create a stock request for a location without company.
 
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas

--- a/stock_request_non_internal/README.rst
+++ b/stock_request_non_internal/README.rst
@@ -1,0 +1,61 @@
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+    :target: https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+    :alt: License: LGPL-3
+
+==========================
+Stock Request Non Internal
+==========================
+
+Allow to request stock for non internal locations
+
+
+Configuration
+=============
+
+There must be at least a route with a procurement rule for the wanted virtual
+location.
+
+
+Usage
+=====
+
+Create a stock request with no warehouse and the wanted virtual location
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/153/11.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-warehouse/issues>`_. In case of
+trouble, please check there if your issue has already been reported. If you
+spotted it first, help us smash it by providing detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester <jordi.ballester@eficent.com>.
+* Enric Tobella <etobella@creublanca.es>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_request_non_internal/__init__.py
+++ b/stock_request_non_internal/__init__.py
@@ -1,0 +1,2 @@
+
+from . import models

--- a/stock_request_non_internal/__manifest__.py
+++ b/stock_request_non_internal/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Stock Request Non internal",
+    "summary": "Stock request for non internal locations",
+    "version": "11.0.3.0.0",
+    "license": "LGPL-3",
+    "website": "https://github.com/stock-logistics-warehouse",
+    "author": "Eficent, "
+              "Odoo Community Association (OCA)",
+    "category": "Warehouse Management",
+    "depends": [
+        "stock_request",
+    ],
+    "installable": True,
+}

--- a/stock_request_non_internal/models/__init__.py
+++ b/stock_request_non_internal/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_request_abstract
+from . import stock_request_order

--- a/stock_request_non_internal/models/stock_request_abstract.py
+++ b/stock_request_non_internal/models/stock_request_abstract.py
@@ -1,0 +1,19 @@
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class StockRequest(models.Model):
+    _inherit = "stock.request"
+
+    @api.constrains('location_id', 'company_id')
+    def check_order_company(self):
+        if not self.location_id.company_id:
+            others = self.search([('location_id', '=', self.location_id.id),
+                                  ('company_id', '!=', self.company_id.id)])
+            if others:
+                raise ValidationError(_(
+                    'There are requests for the same location but other'
+                    ' company'))

--- a/stock_request_non_internal/models/stock_request_order.py
+++ b/stock_request_non_internal/models/stock_request_order.py
@@ -1,0 +1,19 @@
+# Copyright 2018 Creu Blanca
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class StockRequestOrder(models.Model):
+    _inherit = 'stock.request.order'
+
+    @api.constrains('location_id', 'company_id')
+    def check_order_company(self):
+        if not self.location_id.company_id:
+            others = self.search([('location_id', '=', self.location_id.id),
+                                  ('company_id', '!=', self.company_id.id)])
+            if others:
+                raise ValidationError(_(
+                    'There are requests for the same location but other'
+                    ' company'))

--- a/stock_request_non_internal/tests/__init__.py
+++ b/stock_request_non_internal/tests/__init__.py
@@ -1,0 +1,2 @@
+
+from . import test_stock_request_non_internal

--- a/stock_request_non_internal/tests/test_stock_request_non_internal.py
+++ b/stock_request_non_internal/tests/test_stock_request_non_internal.py
@@ -1,0 +1,41 @@
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+
+from odoo.addons.stock_request.tests import test_stock_request
+from odoo.exceptions import ValidationError
+
+
+class TestStockRequestNonInternal(test_stock_request.TestStockRequest):
+    def setUp(self):
+        super(TestStockRequestNonInternal, self).setUp()
+        self.out_location = self.env['stock.location'].create(
+            {'name': 'out_loc',
+             'location_id': self.warehouse.lot_stock_id.id,
+             'usage': 'internal',
+             'company_id': False}
+        )
+
+    def test_stock_non_internal(self):
+        vals = {
+            'product_id': self.product.id,
+            'product_uom_id': self.product.uom_id.id,
+            'product_uom_qty': 4.0,
+            'company_id': self.main_company.id,
+            'warehouse_id': self.warehouse.id,
+            'location_id': self.out_location.id,
+        }
+        self.product.route_ids = [(6, 0, self.route.ids)]
+        self.env['stock.request'].sudo(
+            self.stock_request_user).create(vals)
+
+        vals = {
+            'product_id': self.product.id,
+            'product_uom_id': self.product.uom_id.id,
+            'product_uom_qty': 4.0,
+            'company_id': self.company_2.id,
+            'warehouse_id': self.warehouse.id,
+            'location_id': self.out_location.id,
+        }
+        with self.assertRaises(ValidationError):
+            self.env['stock.request'].sudo(
+                self.stock_request_user).create(vals)


### PR DESCRIPTION
The idea of the module is to use effectively stock requests to consume products by transferring them to a location out of the company.

With the standard module we can create stock request for internal locations and no company assigned. Thus, we can use internal locations with no company assigned for consuming products using stock requests.

However, in this case. the company in the location is empty and it does not match with the company in the stock request. Thus, we can potentially create 2 stock_requests for different companies and same location. To solve this this module adds a constraint. 
