### PR TITLE
[11.0][stock_account_inventory_force_date]

### DIFF
--- a/stock_account_inventory_force_date/__init__.py
+++ b/stock_account_inventory_force_date/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_account_inventory_force_date/__manifest__.py
+++ b/stock_account_inventory_force_date/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Stock Account Inventory Force Date",
+    "summary": "Force the inventory adjustments to a date in the past.",
+    "version": "11.0.1.0.0",
+    "category": "Warehouse Management",
+    "license": "AGPL-3",
+    "author": "Eficent, "
+              "Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "depends": ["stock_account", "stock"],
+    "data": [
+        "security/stock_account_inventory_force_date_security.xml",
+        "views/stock_inventory_view.xml",
+        "views/res_company_view.xml",
+    ],
+    "installable": True,
+}

--- a/stock_account_inventory_force_date/models/__init__.py
+++ b/stock_account_inventory_force_date/models/__init__.py
@@ -1,4 +1,5 @@
 from . import res_company
 from . import stock_inventory
+from . import stock_inventory_line
 from . import stock_move
 from . import stock_move_line

--- a/stock_account_inventory_force_date/models/__init__.py
+++ b/stock_account_inventory_force_date/models/__init__.py
@@ -1,0 +1,4 @@
+from . import res_company
+from . import stock_inventory
+from . import stock_move
+from . import stock_move_line

--- a/stock_account_inventory_force_date/models/res_company.py
+++ b/stock_account_inventory_force_date/models/res_company.py
@@ -1,0 +1,16 @@
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019 Aleph Objects, Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    standard_cost_change_account_id = fields.Many2one(
+        'account.account', string='Standard Cost Change Offsetting Account')
+    force_inventory_lock_date = fields.Date(
+        string="Force Inventory Lock Date",
+        help="If set, it won't be possible for any user to force an inventory,"
+             "adjustment using a date earlier than this one.")

--- a/stock_account_inventory_force_date/models/stock_inventory.py
+++ b/stock_account_inventory_force_date/models/stock_inventory.py
@@ -1,0 +1,114 @@
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019 Aleph Objects, Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class StockInventory(models.Model):
+    _inherit = 'stock.inventory'
+
+    force_inventory_date = fields.Boolean(
+        help="Force the inventory moves and accounting entries to a given date"
+             "in the past.",
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+    )
+
+    @api.onchange('date')
+    def _onchange_force_inventory_date(self):
+        if self.force_inventory_date:
+            self.accounting_date = self.date
+
+    @api.multi
+    def write(self, vals):
+        """For inventories with `force_inventory_date` we only allow to
+        change `date` if they are in draft and not being confirmed."""
+        force_date = self.filtered(lambda l: l.force_inventory_date)
+        if not force_date or not vals.get('date'):
+            return super().write(vals)
+        res = super(StockInventory, self - force_date).write(vals)
+        if vals.get('state'):
+            vals.pop('date')
+            res &= super(StockInventory, force_date).write(vals)
+        else:
+            draft = force_date.filtered(lambda i: i.state == 'draft')
+            res &= super(StockInventory, draft).write(vals)
+            vals.pop('date')
+            res &= super(StockInventory, force_date - draft).write(vals)
+        return res
+
+    @api.multi
+    def _generate_lines_at_date(self, location, product_ids):
+        lines = []
+        products_at_date = self.env['product.product'].with_context({
+            'to_date': self.date,
+            'location': location.id,
+            'compute_child': False,
+        }).search([('id', 'in', product_ids)]).filtered(
+            lambda p: p.qty_available)
+        for p in products_at_date:
+            line = {
+                'product_id': p.id,
+                'product_qty': p.qty_available,
+                'location_id': location.id,
+            }
+            lines.append(line)
+        return lines
+
+    def _get_inventory_lines_values(self):
+        if not self.force_inventory_date:
+            return super()._get_inventory_lines_values()
+        locations = self.env['stock.location'].search(
+            [('id', 'child_of', [self.location_id.id])])
+        lines = []
+        if self.filter == 'none':
+            for loc in locations:
+                # To improve performance, we only considered product
+                # moved in/out of the location any time in history:
+                products = self.env['stock.move'].read_group([
+                    '|',
+                    ('location_id', '=', loc.id),
+                    ('location_dest_id', '=', loc.id),
+                    ('product_id.type', '=', 'product'),
+                    ('state', '=', 'done'),
+                ], ['product_id'], ['product_id'])
+                product_ids = [x['product_id'][0] for x in products]
+
+                if product_ids:
+                    lines.extend(self._generate_lines_at_date(loc,
+                                                              product_ids))
+
+        elif self.filter == 'product':
+            for loc in locations:
+                lines.extend(self._generate_lines_at_date(
+                    loc, self.product_id.ids))
+        elif self.filter == 'category':
+            product_ids = self.env['product.product'].search([
+                ('category_id', '=', self.category_id.id)]).ids
+            for loc in locations:
+                lines.extend(self._generate_lines_at_date(loc, product_ids))
+        else:
+            raise ValidationError(_(
+                'Option %s not available when forcing Inventory Date.',
+                self.filter))
+        return lines
+
+    @api.multi
+    def post_inventory(self):
+        forced_inventories = self.filtered(
+            lambda inventory: inventory.force_inventory_date)
+        for inventory in forced_inventories:
+            lock_date = fields.Date.from_string(
+                inventory.company_id.force_inventory_lock_date)
+            inventory_date = fields.Datetime.from_string(inventory.date).date()
+            if lock_date and inventory_date < lock_date:
+                raise ValidationError(_(
+                    'It is not possible to force an inventory adjustment to '
+                    'a date before %s') % lock_date)
+            super(StockInventory, inventory.with_context(
+                forced_inventory_date=inventory.date)).post_inventory()
+        other_inventories = self - forced_inventories
+        if other_inventories:
+            super(StockInventory, other_inventories).post_inventory()

--- a/stock_account_inventory_force_date/models/stock_inventory_line.py
+++ b/stock_account_inventory_force_date/models/stock_inventory_line.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019 Aleph Objects, Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class StockInventoryLine(models.Model):
+    _inherit = 'stock.inventory.line'
+
+    @api.one
+    @api.depends('location_id', 'product_id', 'package_id',
+                 'product_uom_id', 'company_id', 'prod_lot_id', 'partner_id',
+                 'inventory_id.force_inventory_date')
+    def _compute_theoretical_qty(self):
+        if not self.inventory_id.force_inventory_date:
+            return super()._compute_theoretical_qty()
+        if not self.product_id:
+            self.theoretical_qty = 0
+            return
+        product_at_date = self.env['product.product'].with_context({
+            'to_date': self.inventory_id.date,
+            'location': self.location_id.id,
+            'compute_child': False,
+        }).browse(self.product_id.id)
+        theoretical_qty = product_at_date.qty_available
+        if theoretical_qty and self.product_uom_id and \
+                self.product_id.uom_id != self.product_uom_id:
+            theoretical_qty = self.product_id.uom_id._compute_quantity(
+                theoretical_qty, self.product_uom_id)
+        self.theoretical_qty = theoretical_qty

--- a/stock_account_inventory_force_date/models/stock_move.py
+++ b/stock_account_inventory_force_date/models/stock_move.py
@@ -1,0 +1,130 @@
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019 Aleph Objects, Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+from odoo.tools import float_round
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _get_valued_quantity(self):
+        valued_move_lines = self.env['stock.move.line']
+        if self._is_in():
+            valued_move_lines = self.move_line_ids.filtered(
+                lambda ml: not ml.location_id._should_be_valued() and
+                ml.location_dest_id._should_be_valued() and
+                not ml.owner_id)
+        elif self._is_out():
+            valued_move_lines = self.move_line_ids.filtered(
+                lambda ml: ml.location_id._should_be_valued() and not
+                ml.location_dest_id._should_be_valued() and not ml.owner_id)
+        valued_quantity = 0
+        for valued_move_line in valued_move_lines:
+            valued_quantity += \
+                valued_move_line.product_uom_id._compute_quantity(
+                    valued_move_line.qty_done, self.product_id.uom_id)
+        return valued_quantity
+
+    def _prepare_move_price_history(self, history, diff):
+        valued_quantity = self._get_valued_quantity()
+        account_id = self.company_id.standard_cost_change_account_id.id
+        if not account_id:
+            raise ValidationError(_(
+                'Please define a Standard Cost Change Offsetting Account '
+                'in the company settings.'))
+        # Accounting Entries
+        product = self.product_id
+        product_accounts = product.product_tmpl_id.get_product_accounts()
+        if diff * valued_quantity < 0:
+            debit_account_id = account_id
+            credit_account_id = product_accounts['stock_valuation'].id
+        else:
+            debit_account_id = product_accounts['stock_valuation'].id
+            credit_account_id = account_id
+        description = _('Standard Price revalued for %s from %s') % (
+            self.product_id.display_name, self.inventory_id.name)
+        move_vals = {
+            'journal_id': product_accounts['stock_journal'].id,
+            'company_id': self.company_id.id,
+            'date': history.datetime,
+            'stock_move_id': self.id,
+            'line_ids': [(0, 0, {
+                'name': description,
+                'account_id': debit_account_id,
+                'debit': abs(diff * valued_quantity),
+                'credit': 0,
+                'product_id': self.product_id.id,
+            }), (0, 0, {
+                'name': description,
+                'account_id': credit_account_id,
+                'debit': 0,
+                'credit': abs(diff * valued_quantity),
+                'product_id': self.product_id.id,
+            })],
+        }
+        return move_vals
+
+    def _create_move_price_history(self, history, old_cost):
+        diff = history.cost - old_cost
+        if not diff:
+            return
+        move_vals = self._prepare_move_price_history(history, diff)
+        move = self.env['account.move'].create(move_vals)
+        move.post()
+
+    @api.multi
+    def _replay_product_price_history_moves(self, forced_inventory_date):
+        recs = self.env['product.price.history'].search([
+            ('product_id', '=', self.product_id.id),
+            ('company_id', '=', self.company_id.id),
+            ('datetime', '>', forced_inventory_date),
+        ], order="datetime asc")
+        old_cost = self.price_unit
+        for rec in recs:
+            self._create_move_price_history(rec, old_cost)
+            old_cost = rec.cost
+
+    def _run_valuation(self, quantity=None):
+        forced_inventory_date = self.env.context.get(
+            'forced_inventory_date', False)
+        super(StockMove, self)._run_valuation(quantity=quantity)
+        valued_quantity = self._get_valued_quantity()
+        if self.product_id.cost_method == 'standard' and forced_inventory_date:
+            price_used = self.product_id.get_history_price(
+                self.env.user.company_id.id,
+                date=forced_inventory_date,
+            )
+            curr_rounding = self.company_id.currency_id.rounding
+            value = float_round(price_used * (quantity or valued_quantity),
+                                precision_rounding=curr_rounding)
+            if valued_quantity:
+                price_unit = value / valued_quantity
+            elif quantity:
+                price_unit = value / quantity
+            else:
+                price_unit = 0.0
+            if self._is_out() or self._is_dropshipped_returned():
+                value *= -1
+                price_unit *= -1
+            self.write({
+                'value': value,
+                'price_unit': price_unit,
+            })
+
+    @api.multi
+    def _action_done(self):
+        moves = super(StockMove, self)._action_done()
+        forced_inventory_date = self.env.context.get(
+            'forced_inventory_date', False)
+        if forced_inventory_date:
+            moves.write({'date': forced_inventory_date})
+            for move in moves.filtered(
+                lambda m: m.product_id.valuation == 'real_time' and (
+                    m._is_in() or m._is_out() or m._is_dropshipped() or
+                    m._is_dropshipped_returned())):
+                move._replay_product_price_history_moves(
+                    forced_inventory_date)
+        return moves

--- a/stock_account_inventory_force_date/models/stock_move_line.py
+++ b/stock_account_inventory_force_date/models/stock_move_line.py
@@ -1,0 +1,25 @@
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019 Aleph Objects, Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class StockMoveLine(models.Model):
+    _inherit = 'stock.move.line'
+
+    @api.multi
+    def write(self, vals):
+        forced_inventory_date = self.env.context.get(
+            'forced_inventory_date', False)
+        if 'date' in vals and forced_inventory_date:
+            vals['date'] = forced_inventory_date
+        return super(StockMoveLine, self).write(vals)
+
+    @api.model
+    def create(self, vals):
+        forced_inventory_date = self.env.context.get(
+            'forced_inventory_date', False)
+        if 'date' in vals and forced_inventory_date:
+            vals['date'] = forced_inventory_date
+        return super(StockMoveLine, self).create(vals)

--- a/stock_account_inventory_force_date/security/stock_account_inventory_force_date_security.xml
+++ b/stock_account_inventory_force_date/security/stock_account_inventory_force_date_security.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Eficent Business and IT Consulting Services S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo noupdate="1">
+
+    <record id="group_stock_account_inventory_force_date" model="res.groups">
+        <field name="name">Force Inventory Adjustment Date</field>
+        <field name="category_id" ref="base.module_category_usability"/>
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
+    </record>
+
+</odoo>

--- a/stock_account_inventory_force_date/tests/__init__.py
+++ b/stock_account_inventory_force_date/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_inventory_force_date

--- a/stock_account_inventory_force_date/tests/test_stock_inventory_force_date.py
+++ b/stock_account_inventory_force_date/tests/test_stock_inventory_force_date.py
@@ -1,0 +1,328 @@
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.tools import float_round
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import ValidationError
+
+
+class TestStockInventoryForceDate(TransactionCase):
+
+    def setUp(self):
+        super(TestStockInventoryForceDate, self).setUp()
+        # Models
+        self.obj_wh = self.env['stock.warehouse']
+        self.obj_location = self.env['stock.location']
+        self.obj_inventory = self.env['stock.inventory']
+        self.obj_product = self.env['product.product']
+        self.obj_product_categ = self.env['product.category']
+        self.obj_warehouse = self.env['stock.warehouse']
+        self.obj_account = self.env['account.account']
+        self.obj_upd_qty_wizard = self.env['stock.change.product.qty']
+        # Refs
+        self.picking_type_id = self.env.ref('stock.picking_type_out')
+        self.loc_customer = self.env.ref('stock.stock_location_customers')
+        # Records
+        self.stock_input_account = self.obj_account.create({
+            'name': 'Stock Input',
+            'code': 'StockIn',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_current_liabilities').id,
+        })
+        self.stock_output_account = self.obj_account.create({
+            'name': 'COGS',
+            'code': 'cogs',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_expenses').id,
+        })
+        self.stock_valuation_account = self.obj_account.create({
+            'name': 'Stock Valuation',
+            'code': 'Stock Valuation',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_current_assets').id,
+        })
+        self.expense_account = self.env['account.account'].create({
+            'code': 'INVEXP',
+            'name': 'inventory adjustments',
+            'user_type_id':
+            self.env.ref('account.data_account_type_expenses').id,
+        })
+        self.cost_change_account = self.env['account.account'].create({
+            'code': 'COACC',
+            'name': 'cost change',
+            'user_type_id':
+                self.env.ref('account.data_account_type_expenses').id,
+        })
+        self.stock_journal = self.env['account.journal'].create({
+            'name': 'Stock Journal',
+            'code': 'STJTEST',
+            'type': 'general',
+        })
+        self.categ_standard = self.env['product.category'].create(
+            {'name': 'STANDARD',
+             'property_cost_method': 'standard',
+             'property_valuation': 'real_time',
+             'property_stock_account_input_categ_id':
+                 self.stock_input_account.id,
+             'property_stock_account_output_categ_id':
+                 self.stock_output_account.id,
+             'property_stock_valuation_account_id':
+                 self.stock_valuation_account.id,
+             'property_stock_journal': self.stock_journal.id,
+             },
+        )
+        self.env.ref('stock.location_inventory').write({
+            'valuation_in_account_id':
+                self.expense_account.id,
+            'valuation_out_account_id':
+                self.expense_account.id,
+
+        })
+        self.product1 = self.obj_product.create({
+            'name': 'Test Product 1',
+            'type': 'product',
+            'default_code': 'PROD1',
+            'standard_price': 1.0,
+            'categ_id': self.categ_standard.id,
+        })
+        self.product2 = self.obj_product.create({
+            'name': 'Test Product 2',
+            'type': 'product',
+            'default_code': 'PROD2',
+            'standard_price': 1.0,
+            'categ_id': self.categ_standard.id,
+        })
+        self.test_loc = self.obj_location.create({
+            'name': 'Test Location',
+            'usage': 'internal',
+        })
+        self.test_bin = self.obj_location.create({
+            'name': 'Test Bin Location',
+            'usage': 'internal',
+            'location_id': self.test_loc.id,
+        })
+        self.test_wh = self.obj_warehouse.create({
+            'name': 'Test WH',
+            'code': 'T',
+
+        })
+        self.obj_location._parent_store_compute()
+        group_stock_man = self.env.ref('stock.group_stock_manager')
+        self.manager = self.env['res.users'].create({
+            'name': 'Test Manager',
+            'login': 'manager',
+            'email': 'test.manager@example.com',
+            'groups_id': [(6, 0, [group_stock_man.id])]
+        })
+        group_stock_user = self.env.ref('stock.group_stock_user')
+        self.user = self.env['res.users'].create({
+            'name': 'Test User',
+            'login': 'user',
+            'email': 'test.user@example.com',
+            'groups_id': [(6, 0, [group_stock_user.id])]
+        })
+        self.env.user.company_id.standard_cost_change_account_id = \
+            self.cost_change_account
+
+    def test_01(self):
+        """Tests if creating inventory adjustments in the past produce correct
+        results forward in history.
+        """
+        # Create a fake history of changes to the standard price
+        self.env['product.price.history'].create({
+            'product_id': self.product1.id,
+            'datetime': '2013-01-01 00:00:00',
+            'cost': 100,
+            'company_id': self.env.user.company_id.id,
+        })
+        self.env['product.price.history'].create({
+            'product_id': self.product1.id,
+            'datetime': '2014-01-01 00:00:00',
+            'cost': 50,
+            'company_id': self.env.user.company_id.id,
+        })
+        self.env['product.price.history'].create({
+            'product_id': self.product1.id,
+            'datetime': '2015-01-01 00:00:00',
+            'cost': 25,
+            'company_id': self.env.user.company_id.id,
+        })
+        to_date = '2013-02-01 00:00:00'
+        inventory = self.obj_inventory.create({
+            'name': 'Test past date',
+            'location_id': self.test_loc.id,
+            'filter': 'none',
+            'force_inventory_date': True,
+            'date': to_date,
+            'accounting_date': to_date,
+            'line_ids': [
+                (0, 0, {
+                    'product_id': self.product1.id,
+                    'product_uom_id': self.env.ref(
+                        "product.product_uom_unit").id,
+                    'product_qty': 1.0,
+                    'location_id': self.test_loc.id,
+                }),
+            ],
+        })
+        inventory.action_done()
+        # Check that the stock valuation is correct
+        price_used = self.product1.get_history_price(
+            self.env.user.company_id.id,
+            date=to_date,
+        )
+        qty_available = self.product1.with_context(
+            company_owned=True, owner_id=False, to_date=to_date).qty_available
+        value = price_used * qty_available
+        round_curr = self.env.user.company_id.currency_id.rounding
+        inventory_valuation = float_round(value, precision_rounding=round_curr)
+        # Check that the accounting valuation for this product is correct
+        accounting_valuation = sum(self.env['account.move.line'].search([
+            ('account_id', '=', self.stock_valuation_account.id),
+            ('product_id', '=', self.product1.id),
+            ('date', '<=', '2013-04-01'),
+        ]).mapped('balance'))
+        self.assertEqual(inventory_valuation, accounting_valuation)
+        self.assertEqual(inventory_valuation, 100.00)
+        # Check in 2014
+        to_date = '2014-02-01 00:00:00'
+        # Check that the stock valuation is correct
+        price_used = self.product1.get_history_price(
+            self.env.user.company_id.id,
+            date=to_date,
+        )
+        qty_available = self.product1.with_context(
+            company_owned=True, owner_id=False, to_date=to_date).qty_available
+        value = price_used * qty_available
+        round_curr = self.env.user.company_id.currency_id.rounding
+        inventory_valuation = float_round(value, precision_rounding=round_curr)
+        # Check that the accounting valuation for this product is correct
+        accounting_valuation = sum(self.env['account.move.line'].search([
+            ('account_id', '=', self.stock_valuation_account.id),
+            ('product_id', '=', self.product1.id),
+            ('date', '<=', '2014-04-01'),
+        ]).mapped('balance'))
+        self.assertEqual(inventory_valuation, accounting_valuation)
+        self.assertEqual(inventory_valuation, 50.00)
+        # Check that the current quantity available is 1
+        qty_available = self.product1.with_context(
+            company_owned=True, owner_id=False).qty_available
+        self.assertEqual(qty_available, 1.00)
+        # Check in 2015
+        to_date = '2015-02-01 00:00:00'
+        # Check that the stock valuation is correct
+        price_used = self.product1.get_history_price(
+            self.env.user.company_id.id,
+            date=to_date,
+        )
+        qty_available = self.product1.with_context(
+            company_owned=True, owner_id=False, to_date=to_date).qty_available
+        value = price_used * qty_available
+        round_curr = self.env.user.company_id.currency_id.rounding
+        inventory_valuation = float_round(value, precision_rounding=round_curr)
+        # Check that the accounting valuation for this product is correct
+        accounting_valuation = sum(self.env['account.move.line'].search([
+            ('account_id', '=', self.stock_valuation_account.id),
+            ('product_id', '=', self.product1.id),
+            ('date', '<=', '2015-04-01'),
+        ]).mapped('balance'))
+        self.assertEqual(inventory_valuation, accounting_valuation)
+        self.assertEqual(inventory_valuation, 25.00)
+        # Check that the stock move line has the correct date
+        ml = self.env['stock.move.line'].search([
+            ('product_id', '=', self.product1.id),
+            ('date', '=', '2013-02-01 00:00:00')
+        ])
+        self.assertEqual(len(ml), 1)
+
+    def test_02(self):
+        """Test that we cannot post an inventory before the lock date.
+        """
+        self.env.user.company_id.force_inventory_lock_date = '2015-01-01'
+        to_date = '2013-02-01 00:00:00'
+        inventory = self.obj_inventory.create({
+            'name': 'Test past date',
+            'location_id': self.test_loc.id,
+            'filter': 'none',
+            'force_inventory_date': True,
+            'date': to_date,
+            'accounting_date': to_date,
+            'line_ids': [
+                (0, 0, {
+                    'product_id': self.product1.id,
+                    'product_uom_id': self.env.ref(
+                        "product.product_uom_unit").id,
+                    'product_qty': 1.0,
+                    'location_id': self.test_loc.id,
+                }),
+            ],
+        })
+        with self.assertRaises(ValidationError):
+            inventory.action_done()
+
+    def test_03(self):
+        inventory = self.obj_inventory.create({
+            'name': 'Test past date',
+            'location_id': self.test_loc.id,
+            'filter': 'none',
+            'line_ids': [
+                (0, 0, {
+                    'product_id': self.product1.id,
+                    'product_uom_id': self.env.ref(
+                        "product.product_uom_unit").id,
+                    'product_qty': 100.0,
+                    'location_id': self.test_loc.id,
+                }),
+            ],
+        })
+        inventory.action_done()
+        picking = self.env['stock.picking'].with_context(
+        ).create({
+            'picking_type_id': self.picking_type_id.id,
+            'location_id': self.test_loc.id,
+            'location_dest_id': self.loc_customer.id
+        })
+        move = self.env['stock.move'].create({
+            'name': 'Test Move',
+            'product_id': self.product1.id,
+            'product_uom_qty': 50.0,
+            'product_uom': self.product1.uom_id.id,
+            'picking_id': picking.id,
+            'state': 'draft',
+            'location_id': self.test_loc.id,
+            'location_dest_id': self.loc_customer.id,
+        })
+        picking.action_confirm()
+        picking.action_assign()
+        self.assertEqual(move.reserved_availability, 50.0)
+        self.env['product.price.history'].create({
+            'product_id': self.product1.id,
+            'datetime': '2013-01-01 00:00:00',
+            'cost': 100,
+            'company_id': self.env.user.company_id.id,
+        })
+        self.env['product.price.history'].create({
+            'product_id': self.product1.id,
+            'datetime': '2014-01-01 00:00:00',
+            'cost': 50,
+            'company_id': self.env.user.company_id.id,
+        })
+        to_date = '2013-02-01 00:00:00'
+        inventory = self.obj_inventory.create({
+            'name': 'Test past date',
+            'location_id': self.test_loc.id,
+            'filter': 'none',
+            'force_inventory_date': True,
+            'date': to_date,
+            'accounting_date': to_date,
+            'line_ids': [
+                (0, 0, {
+                    'product_id': self.product1.id,
+                    'product_uom_id': self.env.ref(
+                        "product.product_uom_unit").id,
+                    'product_qty': 0.0,
+                    'location_id': self.test_loc.id,
+                }),
+            ],
+        })
+        inventory.action_done()
+        self.assertEqual(move.reserved_availability, 0.0)

--- a/stock_account_inventory_force_date/views/res_company_view.xml
+++ b/stock_account_inventory_force_date/views/res_company_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_company_form" model="ir.ui.view">
+        <field name="name">res.company.form</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form"/>
+        <field name="arch" type="xml">
+            <group name="social_media" position="after">
+                <group name="inventory_force_date" string="Inventory">
+                    <field name="standard_cost_change_account_id"/>
+                    <field name="force_inventory_lock_date"/>
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/stock_account_inventory_force_date/views/stock_inventory_view.xml
+++ b/stock_account_inventory_force_date/views/stock_inventory_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Eficent Business and IT Consulting Services S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+
+    <record id="view_inventory_form" model="ir.ui.view">
+        <field name="name">stock.inventory.form - stock_inventory_force_date</field>
+        <field name="model">stock.inventory</field>
+        <field name="groups_id" eval="[(4, ref('stock_account_inventory_force_date.group_stock_account_inventory_force_date'))]"/>
+        <field name="inherit_id" ref="stock.view_inventory_form"/>
+        <field name="arch" type="xml">
+            <field name="date" position="after">
+                <field name="force_inventory_date"/>
+            </field>
+            <field name="date" position="attributes">
+                <attribute name="attrs">{'readonly': ['|', ('force_inventory_date', '!=', True), ('state', '!=', 'draft')]}</attribute>
+            </field>
+            <field name="accounting_date" position="attributes">
+                <attribute name="readonly">True</attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/stock_account_inventory_force_date/views/stock_inventory_view.xml
+++ b/stock_account_inventory_force_date/views/stock_inventory_view.xml
@@ -17,9 +17,6 @@
             <field name="date" position="attributes">
                 <attribute name="attrs">{'readonly': ['|', ('force_inventory_date', '!=', True), ('state', '!=', 'draft')]}</attribute>
             </field>
-            <field name="accounting_date" position="attributes">
-                <attribute name="readonly">True</attribute>
-            </field>
         </field>
     </record>
 


### PR DESCRIPTION
This module allows to post an inventory adjustment using a past date. 

If you use perpetual accounting, and standard cost method, the module will make sure that any future price changes are going to be revalued for the quantity that changed. The solution is not yet implemented for average or fifo costing.

