### PR TITLE
[11.0][FIX] stock_request: added readonly true on related company fields

### DIFF
--- a/stock_request/models/stock_request_abstract.py
+++ b/stock_request/models/stock_request_abstract.py
@@ -49,6 +49,7 @@ class StockRequest(models.AbstractModel):
     )
     allow_virtual_location = fields.Boolean(
         related='company_id.stock_request_allow_virtual_loc',
+        readonly=True,
     )
     product_uom_id = fields.Many2one(
         'product.uom', 'Product Unit of Measure',

--- a/stock_request/models/stock_request_order.py
+++ b/stock_request/models/stock_request_order.py
@@ -56,6 +56,7 @@ class StockRequestOrder(models.Model):
     )
     allow_virtual_location = fields.Boolean(
         related='company_id.stock_request_allow_virtual_loc',
+        readonly=True,
     )
     procurement_group_id = fields.Many2one(
         'procurement.group', 'Procurement Group', readonly=True,


### PR DESCRIPTION
This solver an issue when a non Administraator rights try to create a stock request order related company fields try to be mnodified promping next error:
![image](https://user-images.githubusercontent.com/32061121/51119797-0d1e1a80-1814-11e9-9d73-c76817cc7918.png)
