### PR TITLE
[FIX] stock_move_location: fix the 'group_lines()' method

### DIFF
--- a/stock_move_location/__manifest__.py
+++ b/stock_move_location/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Move Stock Location",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "author": "Julius Network Solutions, "
               "Odoo Community Association (OCA)",
     "summary": "This module allows to move all stock "

--- a/stock_move_location/tests/test_move_location.py
+++ b/stock_move_location/tests/test_move_location.py
@@ -30,10 +30,10 @@ class TestMoveLocation(TestsCommon):
             self.product_lots, self.internal_loc_1, 0, self.lot1,
         )
         self.check_product_amount(
-            self.product_lots, self.internal_loc_1, 0, self.lot1,
+            self.product_lots, self.internal_loc_1, 0, self.lot2,
         )
         self.check_product_amount(
-            self.product_lots, self.internal_loc_1, 0, self.lot1,
+            self.product_lots, self.internal_loc_1, 0, self.lot3,
         )
         self.check_product_amount(
             self.product_no_lots, self.internal_loc_2, 123,
@@ -42,10 +42,10 @@ class TestMoveLocation(TestsCommon):
             self.product_lots, self.internal_loc_2, 1, self.lot1,
         )
         self.check_product_amount(
-            self.product_lots, self.internal_loc_2, 1, self.lot1,
+            self.product_lots, self.internal_loc_2, 1, self.lot2,
         )
         self.check_product_amount(
-            self.product_lots, self.internal_loc_2, 1, self.lot1,
+            self.product_lots, self.internal_loc_2, 1, self.lot3,
         )
 
     def test_move_location_wizard_amount(self):


### PR DESCRIPTION
A recordset object is not reliable enough to use as a key for the built-in `sorted` and `itertools.groupby` functions (sometimes it works, sometimes not).
Using the ID of the record (here the product ID) can fix the problem, but the `group_lines()` has been totally rewritten for a simpler implementation without any use of `sorted` or `itertools.groupby` functions to group the wizard lines by product.

Fix #539
Ping @mpanarin @rousseldenis