### PR TITLE
[10.0] [FIX] purchase_packaging avoid conversion error when using uom not in units category

### DIFF
--- a/purchase_packaging/models/procurement_order.py
+++ b/purchase_packaging/models/procurement_order.py
@@ -21,6 +21,8 @@ class ProcurementOrder(models.Model):
             date=po.date_order and fields.Date.to_string(
                 fields.Date.from_string(po.date_order)) or None,
             uom_id=self.product_id.uom_po_id)
+        res['product_purchase_uom_id'] = seller.min_qty_uom_id.id \
+            or self.product_id.uom_po_id.id
         if seller.packaging_id:
             res['packaging_id'] = seller.packaging_id.id
             new_uom_id = seller.product_uom


### PR DESCRIPTION
Creating a po through a procurement for a product with a unit not in 'unit' category is impossible.
The method preparing the po line values does not take care of `product_purchase_uom_id` value and triggers the default: https://github.com/OCA/stock-logistics-warehouse/blob/10.0/purchase_packaging/models/purchase_order_line.py#L13
So it leads to a failing conversion error.

This PR intends to fix that.