### PR TITLE
[10.0] Fix mts+mto rules creation on warehouse creation

### DIFF
--- a/stock_mts_mto_rule/__manifest__.py
+++ b/stock_mts_mto_rule/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {'name': 'Stock MTS+MTO Rule',
- 'version': '10.0.1.0.1',
+ 'version': '10.0.1.0.2',
  'author': 'Akretion,Odoo Community Association (OCA)',
  'website': 'http://www.akretion.com',
  'license': 'AGPL-3',

--- a/stock_mts_mto_rule/model/warehouse.py
+++ b/stock_mts_mto_rule/model/warehouse.py
@@ -88,15 +88,15 @@ class Warehouse(models.Model):
                     })
         return res
 
-    @api.multi
-    def create_routes(self):
-        pull_model = self.env['procurement.rule']
-        res = super(Warehouse, self).create_routes()
-        if self.mto_mts_management:
-            mts_mto_pull_vals = self._get_mts_mto_rule()
+    @api.model
+    def create(self, vals):
+        wh = super(Warehouse, self).create(vals)
+        if wh.mto_mts_management:
+            pull_model = self.env['procurement.rule']
+            mts_mto_pull_vals = wh._get_mts_mto_rule()
             mts_mto_pull = pull_model.create(mts_mto_pull_vals)
-            res['mts_mto_rule_id'] = mts_mto_pull.id
-        return res
+            wh.mts_mto_rule_id = mts_mto_pull.id
+        return wh
 
     @api.multi
     def write(self, vals):

--- a/stock_mts_mto_rule/model/warehouse.py
+++ b/stock_mts_mto_rule/model/warehouse.py
@@ -88,14 +88,19 @@ class Warehouse(models.Model):
                     })
         return res
 
+    @api.multi
+    def _set_mts_mto_rule(self):
+        self.ensure_one()
+        if self.mto_mts_management:
+            pull_model = self.env['procurement.rule']
+            mts_mto_pull_vals = self._get_mts_mto_rule()
+            mts_mto_pull = pull_model.create(mts_mto_pull_vals)
+            self.mts_mto_rule_id = mts_mto_pull.id
+
     @api.model
     def create(self, vals):
         wh = super(Warehouse, self).create(vals)
-        if wh.mto_mts_management:
-            pull_model = self.env['procurement.rule']
-            mts_mto_pull_vals = wh._get_mts_mto_rule()
-            mts_mto_pull = pull_model.create(mts_mto_pull_vals)
-            wh.mts_mto_rule_id = mts_mto_pull.id
+        wh._set_mts_mto_rule()
         return wh
 
     @api.multi

--- a/stock_mts_mto_rule/tests/test_mto_mts_route.py
+++ b/stock_mts_mto_rule/tests/test_mto_mts_route.py
@@ -123,18 +123,21 @@ class TestMtoMtsRoute(TransactionCase):
         with self.assertRaises(exceptions.Warning):
             self.warehouse.mto_mts_management = True
 
-    def test_create_routes(self):
-        rule_obj = self.env['procurement.rule']
-        created_routes = self.warehouse.create_routes()
-        mts_mto_route = rule_obj.browse(created_routes['mts_mto_rule_id'])
-        self.assertEqual(mts_mto_route.warehouse_id, self.warehouse)
+    def test_create_routes_new_warehouse(self):
+        new_wh = self.env['stock.warehouse'].create({
+            'name': 'New TEST WH',
+            'code': 'TST',
+            'mto_mts_management': True
+        })
+        mts_mto_rule = new_wh.mts_mto_rule_id
+        self.assertEqual(mts_mto_rule.warehouse_id, new_wh)
         self.assertEqual(
-            mts_mto_route.location_id, self.warehouse.mto_pull_id.location_id)
+            mts_mto_rule.location_id, new_wh.mto_pull_id.location_id)
         self.assertEqual(
-            mts_mto_route.picking_type_id,
-            self.warehouse.mto_pull_id.picking_type_id)
+            mts_mto_rule.picking_type_id,
+            new_wh.mto_pull_id.picking_type_id)
         self.assertEqual(
-            mts_mto_route.route_id,
+            mts_mto_rule.route_id,
             self.env.ref('stock_mts_mto_rule.route_mto_mts'))
 
     def test_remove_mts_mto_management(self):


### PR DESCRIPTION
With the current version of the module, when you try to create a warehouse with the `mto_mts_management` flag, it fails.
Odoo raise an error here https://github.com/OCA/stock-logistics-warehouse/blob/10.0/stock_mts_mto_rule/model/warehouse.py#L35 because it did not yet write the data coming from `create_routes` mehod on the warehouse.
The same happens with mts_rules after.
I just move the logic from `create_routes` to `create` method in order to be sure the fields used in `_get_mts_mto_rule` are already filled.
