### PR TITLE
[11.0][IMP] stock_move_location: Allow move products from one location to another directly from selected quants

### DIFF
--- a/stock_move_location/README.rst
+++ b/stock_move_location/README.rst
@@ -25,7 +25,8 @@ Move Stock Location
 
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
-This module allows to move entire location of products from one place to another
+This module allows to move entire location of products from one place to
+another and move only selected quants.
 
 **Table of contents**
 
@@ -45,6 +46,14 @@ Usage
   it will move only the available quantity at the button press
 * Products will be moved and a form view of picking that did that will show up
 * If "PLANNED TRANSFER" is used - the picking won't be validated automatically
+
+If you want to transfer a full quant:
+
+*  Go to `Inventory > Master Data > Products` and click "On hand" smart button
+   or `Inventory > Reporting > Inventory`, the quants view will be
+   opened.
+
+*  Select the quants which you want move to another location
 
 Known issues / Roadmap
 ======================
@@ -79,6 +88,7 @@ Contributors
 
 * Mathieu Vatel <mathieu@julius.fr>
 * Mykhailo Panarin <m.panarin@mobilunity.com>
+* Sergio Teruel <sergio.teruel@tecnativa.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_move_location/__manifest__.py
+++ b/stock_move_location/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Move Stock Location",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.1.0",
     "author": "Julius Network Solutions, "
               "Odoo Community Association (OCA)",
     "summary": "This module allows to move all stock "
@@ -16,6 +16,7 @@
     ],
     "category": "Stock",
     "data": [
+        'data/stock_quant_view.xml',
         'wizard/stock_move_location.xml',
     ],
 }

--- a/stock_move_location/data/stock_quant_view.xml
+++ b/stock_move_location/data/stock_quant_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--  To move quants directly from qants views  -->
+    <act_window id="wiz_stock_quant_location_action"
+        name="Move to location..."
+        res_model="wiz.stock.move.location"
+        src_model="stock.quant"
+        view_mode="form"
+        context="{'origin_location_disable': True}"
+        target="new"
+        key2="client_action_multi"
+        groups="stock.group_stock_user"
+    />
+
+</odoo>

--- a/stock_move_location/i18n/stock_move_location.pot
+++ b/stock_move_location/i18n/stock_move_location.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-04-16 14:41+0000\n"
+"PO-Revision-Date: 2019-04-16 14:41+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -126,6 +128,11 @@ msgstr ""
 #: code:addons/stock_move_location/wizard/stock_move_location_line.py:70
 #, python-format
 msgid "Move quantity can not exceed max quantity or be negative"
+msgstr ""
+
+#. module: stock_move_location
+#: model:ir.actions.act_window,name:stock_move_location.wiz_stock_quant_location_action
+msgid "Move to location..."
 msgstr ""
 
 #. module: stock_move_location

--- a/stock_move_location/readme/CONTRIBUTORS.rst
+++ b/stock_move_location/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Mathieu Vatel <mathieu@julius.fr>
 * Mykhailo Panarin <m.panarin@mobilunity.com>
+* Sergio Teruel <sergio.teruel@tecnativa.com>

--- a/stock_move_location/readme/DESCRIPTION.rst
+++ b/stock_move_location/readme/DESCRIPTION.rst
@@ -1,1 +1,2 @@
-This module allows to move entire location of products from one place to another
+This module allows to move entire location of products from one place to
+another and move only selected quants.

--- a/stock_move_location/readme/USAGE.rst
+++ b/stock_move_location/readme/USAGE.rst
@@ -8,3 +8,11 @@
   it will move only the available quantity at the button press
 * Products will be moved and a form view of picking that did that will show up
 * If "PLANNED TRANSFER" is used - the picking won't be validated automatically
+
+If you want to transfer a full quant:
+
+*  Go to `Inventory > Master Data > Products` and click "On hand" smart button
+   or `Inventory > Reporting > Inventory`, the quants view will be
+   opened.
+
+*  Select the quants which you want move to another location

--- a/stock_move_location/static/description/index.html
+++ b/stock_move_location/static/description/index.html
@@ -368,7 +368,8 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/stock-logistics-warehouse/tree/11.0/stock_move_location"><img alt="OCA/stock-logistics-warehouse" src="https://img.shields.io/badge/github-OCA%2Fstock--logistics--warehouse-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/stock-logistics-warehouse-11-0/stock-logistics-warehouse-11-0-stock_move_location"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/153/11.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
-<p>This module allows to move entire location of products from one place to another</p>
+<p>This module allows to move entire location of products from one place to
+another and move only selected quants.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -396,6 +397,13 @@ where 2 location ca be specified.</li>
 it will move only the available quantity at the button press</li>
 <li>Products will be moved and a form view of picking that did that will show up</li>
 <li>If “PLANNED TRANSFER” is used - the picking won’t be validated automatically</li>
+</ul>
+<p>If you want to transfer a full quant:</p>
+<ul class="simple">
+<li>Go to <cite>Inventory &gt; Master Data &gt; Products</cite> and click “On hand” smart button
+or <cite>Inventory &gt; Reporting &gt; Inventory</cite>, the quants view will be
+opened.</li>
+<li>Select the quants which you want move to another location</li>
 </ul>
 </div>
 <div class="section" id="known-issues-roadmap">
@@ -429,6 +437,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li>Mathieu Vatel &lt;<a class="reference external" href="mailto:mathieu&#64;julius.fr">mathieu&#64;julius.fr</a>&gt;</li>
 <li>Mykhailo Panarin &lt;<a class="reference external" href="mailto:m.panarin&#64;mobilunity.com">m.panarin&#64;mobilunity.com</a>&gt;</li>
+<li>Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_move_location/wizard/stock_move_location.xml
+++ b/stock_move_location/wizard/stock_move_location.xml
@@ -8,10 +8,10 @@
       <form>
         <sheet>
           <group name="main">
-            <field name="origin_location_id"/>
+            <field name="origin_location_id" invisible="context.get('origin_location_disable', False)"/>
             <field name="destination_location_id"/>
           </group>
-          <group name="button">
+          <group name="button" invisible="context.get('origin_location_disable', False)">
             <button name="add_lines" string="Add all" type="object" class="btn-primary"/>
             <button name="clear_lines" string="Clear all" type="object" class="btn-primary"/>
           </group>
@@ -25,7 +25,7 @@
                   <field name="lot_id" domain="[('product_id', '=', product_id)]" context="{'default_product_id': product_id}"  groups="stock.group_production_lot" options="{'no_create': True}"/>
                   <field name="move_quantity"/>
                   <field name="custom" invisible="1" />
-                  <field name="max_quantity" attrs="{'readonly': [('custom', '!=', True)]}" />
+                  <field name="max_quantity" attrs="{'readonly': [('custom', '!=', True)]}" force_save="1"/>
               </tree>
             </field>
           </group>


### PR DESCRIPTION
cc @Tecnativa
This PR adds various improvements to this module:

1.  When in the wizard the user changes the location_destination_id all lines are erased, so the user loses the quantities to transfer to another location. With this PR only change the location_destination_id for all lines.

2. Add improvements that allow to do a transfer selecting quants directly from various origin locations. In this case you can not change origin location in the wizard. I try to no update the original behavior.

Thanks 

