### PR TITLE
[11.0][FIX] stock_orderpoint_manual_procurement_(uom)

### DIFF
--- a/stock_orderpoint_manual_procurement/__manifest__.py
+++ b/stock_orderpoint_manual_procurement/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Stock Orderpoint Manual Procurement",
     "summary": "Allows to create procurement orders from orderpoints instead "
                "of relying only on the scheduler.",
-    "version": "11.0.1.1.1",
+    "version": "11.0.2.0.0",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",

--- a/stock_orderpoint_manual_procurement_uom/__manifest__.py
+++ b/stock_orderpoint_manual_procurement_uom/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Stock Orderpoint Manual Procurement UoM",
     "summary": "Glue module for stock_orderpoint_uom and "
                "stock_orderpoint_manual_procurement",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",

--- a/stock_orderpoint_manual_procurement_uom/wizards/make_procurement_orderpoint.py
+++ b/stock_orderpoint_manual_procurement_uom/wizards/make_procurement_orderpoint.py
@@ -5,18 +5,6 @@
 from odoo import api, models
 
 
-class MakeProcurementOrderpoint(models.TransientModel):
-    _inherit = 'make.procurement.orderpoint'
-
-    @api.model
-    def _prepare_item(self, orderpoint):
-        vals = super(MakeProcurementOrderpoint, self)._prepare_item(orderpoint)
-        if orderpoint.procure_uom_id:
-            product_uom = orderpoint.procure_uom_id
-            vals['uom_id'] = product_uom.id
-        return vals
-
-
 class MakeProcurementOrderpointItem(models.TransientModel):
     _inherit = 'make.procurement.orderpoint.item'
 
@@ -29,3 +17,12 @@ class MakeProcurementOrderpointItem(models.TransientModel):
             rec.qty = uom._compute_quantity(
                 rec.orderpoint_id.procure_recommended_qty,
                 rec.uom_id)
+
+    @api.model
+    def _prepare_item(self, orderpoint):
+        vals = super(MakeProcurementOrderpointItem, self)._prepare_item(
+            orderpoint)
+        if orderpoint.procure_uom_id:
+            product_uom = orderpoint.procure_uom_id
+            vals['uom_id'] = product_uom.id
+        return vals


### PR DESCRIPTION
Before this PR once you made a procurement request and wizard was open all was right. But when you execute the procurement, `default_get` couldn't find `location_id, display_name, warehouse, product_id` for any item. 

That was solved using orderpoint location and product information when you run the procurement.

There was a lack of extendibility.

That PR tries to fix this issue across `stock_orderpoint_manual_procurement` and `stock_orderpoint_manual_procurement_uom` modules

@Eficent