### PR TITLE
[IMP] stock_available_mrp: Easier and faster BoM finding

### DIFF
--- a/stock_available_mrp/models/product_product.py
+++ b/stock_available_mrp/models/product_product.py
@@ -22,35 +22,10 @@ class ProductProduct(models.Model):
         super(ProductProduct, self)._compute_available_quantities()
 
     @api.multi
-    def _get_bom_id_domain(self):
-        """
-        Real multi domain
-        :return:
-        """
-        return [
-            '|',
-            ('product_id', 'in', self.ids),
-            '&',
-            ('product_id', '=', False),
-            ('product_tmpl_id', 'in', self.mapped('product_tmpl_id.id'))
-        ]
-
-    @api.multi
     @api.depends('product_tmpl_id')
     def _compute_bom_id(self):
-        bom_obj = self.env['mrp.bom']
-        boms = bom_obj.search(
-            self._get_bom_id_domain(),
-            order='sequence, product_id',
-        )
-        for product in self:
-            product_boms = boms.filtered(
-                lambda b: b.product_id == product or
-                (not b.product_id and
-                 b.product_tmpl_id == product.product_tmpl_id)
-            )
-            if product_boms:
-                product.bom_id = first(product_boms)
+        for one in self:
+            one.bom_id = self.env["mrp.bom"]._bom_find(product=one)
 
     @api.multi
     def _compute_available_quantities_dict(self):


### PR DESCRIPTION
Before this patch, the method was looping through found BoMs in each product, which produced an exponential double loop.

In a first attempt, I tried just avoiding the double loop, but then I noticed that with the inclusion of https://github.com/odoo/odoo/pull/33967, just calling upstream's method was easier, safer (takes more conditions into account, such as the company) and faster (due to cache, which also benefited further calls).

So here is the patch. See :fire: :chart_with_upwards_trend: here:

![Captura de pantalla de 2019-06-07 10-06-43](https://user-images.githubusercontent.com/973709/59093705-78c06b80-890c-11e9-9a06-22385a4a51a0.png)

This should be WIP until this one is merged, or possibly performance will be penalized:

- [ ] https://github.com/odoo/odoo/pull/33967


@Tecnativa