### PR TITLE
[11.0][IMP] procurement_auto_create_group: ensure that the procurement group is only created in the procurment process.

### DIFF
--- a/procurement_auto_create_group/models/procurement_group.py
+++ b/procurement_auto_create_group/models/procurement_group.py
@@ -12,7 +12,10 @@ class ProcurementGroup(models.Model):
     @api.model
     def _get_rule(self, product_id, location_id, values):
         result = super()._get_rule(product_id, location_id, values)
-        if result and not values.get('group_id') and result.auto_create_group:
+        # If there isn't a date planned in the values it means that this
+        # method has been called outside of a procurement process.
+        if result and not values.get('group_id') and result.auto_create_group \
+                and values.get("date_planned"):
             group_data = self._prepare_auto_procurement_group_data()
             group = self.env['procurement.group'].create(group_data)
             values['group_id'] = group


### PR DESCRIPTION
Add a context to be able to disable this moudule functionality on demand.

Sometimes the method _get_rule is just needed to obtain the information of the rule,
and it isn't followed by the run of the procurement.

@Eficent