### PR TITLE
[FIX] calculate the inventory value based on total cost

### DIFF
--- a/stock_quant_merge/models/stock_quant.py
+++ b/stock_quant_merge/models/stock_quant.py
@@ -30,14 +30,12 @@ class StockQuant(models.Model):
         for quant2merge in self.filtered(lambda x: not x.reservation_id):
             if quant2merge in pending_quants:
                 quants = self.search(quant2merge._mergeable_domain())
-                cont = 1
-                cost = quant2merge.cost
+                total_value = quant2merge.inventory_value
                 for quant in quants:
                     if (quant2merge._get_latest_move() ==
                             quant._get_latest_move()):
                         quant2merge.sudo().qty += quant.qty
-                        cost += quant.cost
-                        cont += 1
+                        total_value += quant.inventory_value
                         pending_quants -= quant
                         quant.with_context(force_unlink=True).sudo().unlink()
-                quant2merge.sudo().cost = cost / cont
+                quant2merge.sudo().cost = total_value / quant2merge.qty


### PR DESCRIPTION
When merging quants, the current behaviour was to calculate the
average cost for the merged quant's cost.

The problem with this that it does not keep the total inventory
value correct.  If we merge a quant with 100 units at a cost of 10
having a total value of 1000 with a quant with 2 units a a cost of 20
having a total value of 40, the old behaviour would generate a quant
with a cost of 15 resulting in a total value of 1530.

With this update the total value will stay at 1040.