### PR TITLE
[FIX] fix negative quant in blocked location

### DIFF
--- a/stock_location_lockdown/models/stock_quant.py
+++ b/stock_location_lockdown/models/stock_quant.py
@@ -9,18 +9,13 @@ from odoo.exceptions import UserError
 class StockQuant(models.Model):
     _inherit = 'stock.quant'
 
-    @api.model
-    def quants_move(
-            self, quants, move, location_to, location_from=False, lot_id=False,
-            owner_id=False, src_package_id=False, dest_package_id=False,
-            entire_pack=False):
-        if (
-                location_to.usage == 'internal' and
-                location_to.block_stock_entrance):
-            raise UserError(_(
-                "The location '%s' is not configured to receive stock.")
-                % location_to.display_name)
-        return super(StockQuant, self).quants_move(
-            quants, move, location_to, location_from=location_from,
-            lot_id=lot_id, owner_id=owner_id, src_package_id=src_package_id,
-            dest_package_id=dest_package_id, entire_pack=entire_pack)
+    @api.constrains('location_id')
+    def _check_location_blocked(self):
+        for record in self:
+            if record.location_id.block_stock_entrance:
+                raise UserError(
+                    _('The location %s is blocked and can '
+                      'not be used for moving the product %s')
+                    % (record.location_id.name, record.product_id.name)
+                    )
+        return True

--- a/stock_location_lockdown/models/stock_quant.py
+++ b/stock_location_lockdown/models/stock_quant.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 
 class StockQuant(models.Model):
@@ -13,7 +13,7 @@ class StockQuant(models.Model):
     def _check_location_blocked(self):
         for record in self:
             if record.location_id.block_stock_entrance:
-                raise UserError(
+                raise ValidationError(
                     _('The location %s is blocked and can '
                       'not be used for moving the product %s')
                     % (record.location_id.name, record.product_id.name)

--- a/stock_location_lockdown/tests/test_block_stock_location_entrance.py
+++ b/stock_location_lockdown/tests/test_block_stock_location_entrance.py
@@ -2,7 +2,7 @@
 # Copyright 2018 Akretion France
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -13,6 +13,7 @@ class TestStockLocationLockdown(TransactionCase):
         self.main_stock_location = self.env.ref('stock.stock_location_stock')
         self.main_stock_location.block_stock_entrance = True
         self.supplier_location = self.env.ref('stock.stock_location_suppliers')
+        self.customer_location = self.env.ref('stock.stock_location_customers')
         self.product = self.env.ref('product.product_product_27')
 
     def test_transfer_stock_in_locked_location(self):
@@ -29,5 +30,22 @@ class TestStockLocationLockdown(TransactionCase):
             'name': 'test',
         }
         stock_move = self.env['stock.move'].create(move_vals)
-        with self.assertRaises(UserError):
+        with self.assertRaises(ValidationError):
+            stock_move.action_done()
+
+    def test_transfer_stock_out_locked_location(self):
+        """
+            Test to move stock within a location that should not accept
+            Stock entrance.
+        """
+        move_vals = {
+            'location_id': self.main_stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': self.product.id,
+            'product_uom_qty': '2.0',
+            'product_uom': 1,
+            'name': 'test',
+        }
+        stock_move = self.env['stock.move'].create(move_vals)
+        with self.assertRaises(ValidationError):
             stock_move.action_done()

--- a/stock_location_lockdown/tests/test_block_stock_location_entrance.py
+++ b/stock_location_lockdown/tests/test_block_stock_location_entrance.py
@@ -25,7 +25,7 @@ class TestStockLocationLockdown(TransactionCase):
             'location_id': self.supplier_location.id,
             'location_dest_id': self.main_stock_location.id,
             'product_id': self.product.id,
-            'product_uom_qty': '2.0',
+            'product_uom_qty': self.product.qty_available + 1,
             'product_uom': 1,
             'name': 'test',
         }
@@ -42,7 +42,7 @@ class TestStockLocationLockdown(TransactionCase):
             'location_id': self.main_stock_location.id,
             'location_dest_id': self.customer_location.id,
             'product_id': self.product.id,
-            'product_uom_qty': '2.0',
+            'product_uom_qty': self.product.qty_available + 1,
             'product_uom': 1,
             'name': 'test',
         }


### PR DESCRIPTION
When forcing an outgoing move and then moving it. Odoo create a
negative quant. This quant should not be in the locked location
because no quand will go in it and so the negative quant will stay
here for ever

@florian-dacosta @alexis-via @bealdav 