### PR TITLE
[12.0][FIX] stock_request_kanban: group_uom is in uom module

### DIFF
--- a/stock_request_kanban/views/stock_request_kanban_views.xml
+++ b/stock_request_kanban/views/stock_request_kanban_views.xml
@@ -15,7 +15,7 @@
                 <field name="route_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                 <field name="product_id"/>
                 <field name="product_uom_id"
-                       options="{'no_open': True, 'no_create': True}" groups="product.group_uom"/>
+                       options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"/>
                 <field name="product_uom_qty"/>
                 <field name="active" invisible="1"/>
             </tree>
@@ -77,7 +77,7 @@
                                 <field name="product_uom_id"
                                        class="oe_inline"
                                        options="{'no_open': True, 'no_create': True}"
-                                       groups="product.group_uom"/>
+                                       groups="uom.group_uom"/>
                             </div>
                         </group>
                     </group>


### PR DESCRIPTION
Solves:

```yml
WARNING openerp_test odoo.addons.base.models.ir_ui_view: The group product.group_uom defined in view stock.request.kanban.tree does not exist!
WARNING openerp_test odoo.addons.base.models.ir_ui_view: The group product.group_uom defined in view stock.request.kanban.form does not exist!
```