### PR TITLE
[12.0][REW] stock_warehouse_calendar: add plan days helper method

### DIFF
--- a/stock_warehouse_calendar/README.rst
+++ b/stock_warehouse_calendar/README.rst
@@ -87,7 +87,8 @@ Authors
 Contributors
 ~~~~~~~~~~~~
 
-* Jordi Ballester (EFICENT) <jordi.ballester@eficent.com>.
+* Jordi Ballester <jordi.ballester@eficent.com>
+* Lois Rilo <lois.rilo@eficent>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_warehouse_calendar/models/stock_rule.py
+++ b/stock_warehouse_calendar/models/stock_rule.py
@@ -1,7 +1,7 @@
-# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2018-19 Eficent Business and IT Consulting Services, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
-from odoo import fields, models
+from odoo import models
 from datetime import datetime
 
 
@@ -13,11 +13,10 @@ class StockRule(models.Model):
         res = super(StockRule, self)._get_stock_move_values(
             product_id, product_qty, product_uom,
             location_id, name, origin, values, group_id)
-        dt_planned = fields.Datetime.to_datetime(values['date_planned'])
         warehouse = self.propagate_warehouse_id or self.warehouse_id
         if warehouse.calendar_id and self.delay:
-            date_expected = warehouse.calendar_id.plan_days(
-                -1 * self.delay - 1, dt_planned)
+            date_expected = warehouse.wh_plan_days(
+                values['date_planned'], -1 * self.delay)
             if date_expected > datetime.now():
                 res['date'] = date_expected
                 res['date_expected'] = date_expected

--- a/stock_warehouse_calendar/models/stock_warehouse.py
+++ b/stock_warehouse_calendar/models/stock_warehouse.py
@@ -1,5 +1,7 @@
-# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2018-19 Eficent Business and IT Consulting Services, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from datetime import datetime, timedelta
 
 from odoo import fields, models
 
@@ -11,3 +13,30 @@ class StockWarehouse(models.Model):
         comodel_name='resource.calendar',
         string='Working Hours',
     )
+
+    def wh_plan_days(self, date_from, delta):
+        """Helper method to schedule warehouse operations based on its
+        working days (if set).
+
+        :param datetime date_from: reference date.
+        :param integer delta: offset to apply.
+        :return: datetime: resulting date.
+        """
+        self.ensure_one()
+        if not isinstance(date_from, datetime):
+            date_from = fields.Datetime.to_datetime(date_from)
+        if delta == 0:
+            return date_from
+
+        if self.calendar_id:
+            if delta < 0:
+                # We force the date planned to be at the beginning of the day.
+                # So no work intervals are found in the reference date.
+                dt_planned = date_from.replace(hour=0)
+            else:
+                # We force the date planned at the end of the day.
+                dt_planned = date_from.replace(hour=23)
+            date_result = self.calendar_id.plan_days(delta, dt_planned)
+        else:
+            date_result = date_from + timedelta(days=delta)
+        return date_result

--- a/stock_warehouse_calendar/readme/CONTRIBUTORS.rst
+++ b/stock_warehouse_calendar/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
-* Jordi Ballester (EFICENT) <jordi.ballester@eficent.com>.
+* Jordi Ballester <jordi.ballester@eficent.com>
+* Lois Rilo <lois.rilo@eficent>

--- a/stock_warehouse_calendar/static/description/index.html
+++ b/stock_warehouse_calendar/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.15.2: http://docutils.sourceforge.net/" />
 <title>Stock Warehouse Calendar</title>
 <style type="text/css">
 
@@ -431,7 +431,8 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
-<li>Jordi Ballester (EFICENT) &lt;<a class="reference external" href="mailto:jordi.ballester&#64;eficent.com">jordi.ballester&#64;eficent.com</a>&gt;.</li>
+<li>Jordi Ballester &lt;<a class="reference external" href="mailto:jordi.ballester&#64;eficent.com">jordi.ballester&#64;eficent.com</a>&gt;</li>
+<li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;eficent">lois.rilo&#64;eficent</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_warehouse_calendar/tests/test_stock_warehouse_calendar.py
+++ b/stock_warehouse_calendar/tests/test_stock_warehouse_calendar.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2018-19 Eficent Business and IT Consulting Services, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import fields
@@ -9,6 +9,7 @@ class TestStockWarehouseCalendar(TransactionCase):
 
     def setUp(self):
         super(TestStockWarehouseCalendar, self).setUp()
+        self.wh_obj = self.env['stock.warehouse']
         self.move_obj = self.env['stock.move']
         self.company = self.env.ref('base.main_company')
         self.warehouse = self.env.ref('stock.warehouse0')
@@ -16,10 +17,14 @@ class TestStockWarehouseCalendar(TransactionCase):
         self.company_partner = self.env.ref('base.main_partner')
         self.calendar = self.env.ref('resource.resource_calendar_std')
         self.warehouse.calendar_id = self.calendar
-        self.warehouse_2 = self.env['stock.warehouse'].create({
+        self.warehouse_2 = self.wh_obj.create({
             'code': 'WH-T',
             'name': 'Warehouse Test',
             'calendar_id': self.calendar.id,
+        })
+        self.warehouse_3 = self.wh_obj.create({
+            'code': 'WH-no-calendar',
+            'name': 'Warehouse Test 2',
         })
 
         self.product = self.env['product.product'].create({
@@ -47,7 +52,7 @@ class TestStockWarehouseCalendar(TransactionCase):
         self.transfer_rule = self.env['stock.rule'].create(rule_vals)
         self.product.route_ids = [(6, 0, self.transfer_route.ids)]
 
-    def test_procurement_with_calendar(self):
+    def test_01_procurement_with_calendar(self):
         values = {
             'date_planned': '2097-01-07 09:00:00',  # Monday
             'warehouse_id': self.warehouse,
@@ -66,3 +71,37 @@ class TestStockWarehouseCalendar(TransactionCase):
         friday = fields.Date.to_date('2097-01-04 09:00:00')
 
         self.assertEquals(date_expected, friday)
+
+    def test_02_procurement_with_calendar_early(self):
+        """Test procuring at the beginning of the day, with no work intervals
+        before."""
+        values = {
+            'date_planned': '2097-01-07 01:00:00',  # Monday
+            'warehouse_id': self.warehouse,
+            'company_id': self.company,
+            'rule_id': self.transfer_rule,
+        }
+        self.env['procurement.group'].run(
+            self.product, 100,
+            self.product.uom_id,
+            self.warehouse.lot_stock_id, 'Test',
+            'Test', values)
+        move = self.env['stock.move'].search(
+            [('product_id', '=', self.product.id)], limit=1)
+        date_expected = fields.Date.to_date(move.date_expected)
+        # Friday 4th Jan 2017
+        friday = fields.Date.to_date('2097-01-04 09:00:00')
+
+        self.assertEquals(date_expected, friday)
+
+    def test_03_wh_plan_days_future(self):
+        """Test plan days helper in warehouse."""
+        reference = "2097-01-09 12:00:00"  # Wednesday
+        # With calendar
+        result = self.warehouse_2.wh_plan_days(reference, 3).date()
+        next_monday = fields.Date.to_date("2097-01-14")
+        self.assertEquals(result, next_monday)
+        # Without calendar
+        result = self.warehouse_3.wh_plan_days(reference, 3).date()
+        saturday = fields.Date.to_date("2097-01-12")
+        self.assertEquals(result, saturday)


### PR DESCRIPTION
the method `wh_plan_days` can be used in any place where planning
or scheduling needs to be done in a given warehouse context,
considering the working days if set.

@Eficent