### PR TITLE
[12.0][IMP] stock_orderpoint_move_link: View transfers on orderpoint

### DIFF
--- a/stock_orderpoint_move_link/README.rst
+++ b/stock_orderpoint_move_link/README.rst
@@ -56,6 +56,7 @@ Contributors
 
 * Jordi Ballester Alomar <jordi.ballester@eficent.com>
 * Kitti Upariphutthiphong <kittiu@ecosoft.co.th>
+* Héctor Villarreal Ortega <hector.villarreal@eficent.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_orderpoint_move_link/__init__.py
+++ b/stock_orderpoint_move_link/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import models

--- a/stock_orderpoint_move_link/__manifest__.py
+++ b/stock_orderpoint_move_link/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 {

--- a/stock_orderpoint_move_link/models/__init__.py
+++ b/stock_orderpoint_move_link/models/__init__.py
@@ -1,4 +1,5 @@
-# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import stock
 from . import stock_move
+from . import stock_warehouse_orderpoint

--- a/stock_orderpoint_move_link/models/stock.py
+++ b/stock_orderpoint_move_link/models/stock.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Eficent Business, IT Consulting Services, S.L., Ecosoft
+# Copyright 2019 Eficent Business, IT Consulting Services, S.L., Ecosoft
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from odoo import models
 

--- a/stock_orderpoint_move_link/models/stock_move.py
+++ b/stock_orderpoint_move_link/models/stock_move.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Eficent Business, IT Consulting Services, S.L.
+# Copyright 2019 Eficent Business, IT Consulting Services, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from odoo import fields, models
 

--- a/stock_orderpoint_move_link/models/stock_warehouse_orderpoint.py
+++ b/stock_orderpoint_move_link/models/stock_warehouse_orderpoint.py
@@ -1,0 +1,19 @@
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class StockWarehouseOrderpoint(models.Model):
+    _inherit = 'stock.warehouse.orderpoint'
+
+    @api.multi
+    def action_view_stock_picking(self):
+        action = self.env.ref('stock.action_picking_tree_all')
+        result = action.read()[0]
+        result['context'] = {}
+        picking_ids = self.env['stock.move'].search(
+            [('orderpoint_ids', 'in', self.id)]).mapped('picking_id')
+        result['domain'] = "[('id','in',%s)]" % picking_ids.ids
+        return result

--- a/stock_orderpoint_move_link/readme/CONTRIBUTORS.rst
+++ b/stock_orderpoint_move_link/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Jordi Ballester Alomar <jordi.ballester@eficent.com>
 * Kitti Upariphutthiphong <kittiu@ecosoft.co.th>
+* Héctor Villarreal Ortega <hector.villarreal@eficent.com>

--- a/stock_orderpoint_move_link/views/stock_move_views.xml
+++ b/stock_orderpoint_move_link/views/stock_move_views.xml
@@ -25,4 +25,20 @@
         </field>
     </record>
 
+    <record id="view_warehouse_orderpoint_move_form" model="ir.ui.view">
+        <field name="name">stock.warehouse.orderpoint.move.form</field>
+        <field name="model">stock.warehouse.orderpoint</field>
+        <field name="inherit_id" ref="stock.view_warehouse_orderpoint_form"/>
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button type="object"
+                    name="action_view_stock_picking"
+                    class="oe_stat_button"
+                    string="Transfers"
+                    icon="fa-arrows-h">
+                </button>
+            </div>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Allow to see Transfers from stock moves linked to the orderpoint.

Porting #579 to v12

Improve usability:
- [x] Add some test
- [x] Ensure orderpoint name on origin
- [x] Add Purchase like right-top button for stock pickings on Orderpoint views.

@Eficent 