### PR TITLE
[11.0][FIX] stock_request: sudoing internal stock_request engine _compute_qty

### DIFF
--- a/stock_request/security/stock_request_security.xml
+++ b/stock_request/security/stock_request_security.xml
@@ -62,6 +62,16 @@
             <field name="perm_unlink" eval="True"/>
             <field name="domain_force">[('requested_by','=',user.id)]</field>
         </record>
+
+        <record id="stock_request_user_inventory_user_rule" model="ir.rule">
+            <field name="name">Stock Request User Inventory User</field>
+            <field name="model_id" ref="model_stock_request"/>
+            <field name="groups" eval="[(6,0, [ref('stock.group_stock_user')])]"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
     
         <record id="stock_request_manager_rule" model="ir.rule">
             <field name="name">Stock Request Manager</field>


### PR DESCRIPTION
Inventory Users can't check availability on Transfers coming from a Stock Request.

Inventory Users have Stock request user role by default, but it also have a bunch of Record Rules that limit them to full edit other stock request that are not created by them.

You can do the test using demo data.
Steps to reproduce:
1. Log as admin create a SR, confirm it to generate an stock move.
2. Log with demo user go to that transfer and click check availability.

An error will be prompted when trying to compute allocation quantities with Stock Request User permissions.

Assuming this compute method is only used as an internal engine to keep allocations update, I'm proposing to sudo it.