### PR TITLE
[12.0][FIX] stock_request: add expected_date implicit on tests to avoid errors.

### DIFF
--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -166,10 +166,12 @@ class TestStockRequestBase(TestStockRequest):
             order.location_id, self.warehouse.lot_stock_id)
 
     def test_onchanges_order(self):
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
             'location_id': self.warehouse.lot_stock_id.id,
+            'expected_date': expected_date,
             'stock_request_ids': [(0, 0, {
                 'product_id': self.product.id,
                 'product_uom_id': self.product.uom_id.id,
@@ -177,6 +179,7 @@ class TestStockRequestBase(TestStockRequest):
                 'company_id': self.main_company.id,
                 'warehouse_id': self.warehouse.id,
                 'location_id': self.warehouse.lot_stock_id.id,
+                'expected_date': expected_date,
             })]
         }
         order = self.request_order.sudo(
@@ -295,7 +298,7 @@ class TestStockRequestBase(TestStockRequest):
     def test_stock_request_order_validations_01(self):
         """ Testing the discrepancy in warehouse_id between
         stock request and order"""
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.wh2.id,
@@ -318,7 +321,7 @@ class TestStockRequestBase(TestStockRequest):
     def test_stock_request_order_validations_02(self):
         """ Testing the discrepancy in location_id between
         stock request and order"""
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
@@ -341,7 +344,7 @@ class TestStockRequestBase(TestStockRequest):
     def test_stock_request_order_validations_03(self):
         """ Testing the discrepancy in requested_by between
         stock request and order"""
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
@@ -369,7 +372,7 @@ class TestStockRequestBase(TestStockRequest):
         procurement_group = self.env['procurement.group'].create({
             'name': 'Procurement',
         })
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
@@ -393,7 +396,7 @@ class TestStockRequestBase(TestStockRequest):
     def test_stock_request_order_validations_05(self):
         """ Testing the discrepancy in company between
         stock request and order"""
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.company_2.id,
             'warehouse_id': self.wh2.id,
@@ -416,7 +419,7 @@ class TestStockRequestBase(TestStockRequest):
     def test_stock_request_order_validations_06(self):
         """ Testing the discrepancy in expected dates between
         stock request and order"""
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         child_expected_date = '2015-01-01'
         vals = {
             'company_id': self.company_2.id,
@@ -439,7 +442,7 @@ class TestStockRequestBase(TestStockRequest):
     def test_stock_request_order_validations_07(self):
         """ Testing the discrepancy in picking policy between
         stock request and order"""
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
@@ -492,7 +495,7 @@ class TestStockRequestBase(TestStockRequest):
             stock_request.action_confirm()
 
     def test_create_request_01(self):
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
@@ -623,7 +626,7 @@ class TestStockRequestBase(TestStockRequest):
         picking.action_done()
 
     def test_cancel_request(self):
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
@@ -680,7 +683,7 @@ class TestStockRequestBase(TestStockRequest):
         self.assertEqual(len(stock_request.sudo().move_ids), 2)
 
     def test_view_actions(self):
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
@@ -856,10 +859,12 @@ class TestStockRequestBase(TestStockRequest):
         self.assertTrue(order.allow_virtual_location)
 
     def test_onchange_wh_no_effect_from_order(self):
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
             'location_id': self.virtual_loc.id,
+            'expected_date': expected_date,
             'stock_request_ids': [(0, 0, {
                 'product_id': self.product.id,
                 'product_uom_id': self.product.uom_id.id,
@@ -867,6 +872,7 @@ class TestStockRequestBase(TestStockRequest):
                 'company_id': self.main_company.id,
                 'warehouse_id': self.warehouse.id,
                 'location_id': self.virtual_loc.id,
+                'expected_date': expected_date,
             })]
         }
         order = self.request_order.sudo(

--- a/stock_request_analytic/tests/test_stock_request_analytic.py
+++ b/stock_request_analytic/tests/test_stock_request_analytic.py
@@ -43,7 +43,7 @@ class TestStockRequestAnalytic(test_stock_request.TestStockRequest):
         self.pizza.route_ids = [(6, 0, self.demand_route.ids)]
 
     def prepare_order_request_analytic(self, aa, company):
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': company.id,
             'warehouse_id': self.warehouse.id,

--- a/stock_request_purchase/tests/test_stock_request_purchase.py
+++ b/stock_request_purchase/tests/test_stock_request_purchase.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
 from odoo.tests import common
+from odoo import fields
 
 
 class TestStockRequestPurchase(common.TransactionCase):
@@ -73,10 +74,12 @@ class TestStockRequestPurchase(common.TransactionCase):
 
     def test_create_request_01(self):
         """Single Stock request with buy rule"""
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
             'location_id': self.warehouse.lot_stock_id.id,
+            'expected_date': expected_date,
             'stock_request_ids': [(0, 0, {
                 'product_id': self.product.id,
                 'product_uom_id': self.product.uom_id.id,
@@ -84,6 +87,7 @@ class TestStockRequestPurchase(common.TransactionCase):
                 'company_id': self.main_company.id,
                 'warehouse_id': self.warehouse.id,
                 'location_id': self.warehouse.lot_stock_id.id,
+                'expected_date': expected_date,
             })]
         }
 
@@ -187,10 +191,12 @@ class TestStockRequestPurchase(common.TransactionCase):
                          stock_request_2.product_uom_qty)
 
     def test_view_actions(self):
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,
             'location_id': self.warehouse.lot_stock_id.id,
+            'expected_date': expected_date,
             'stock_request_ids': [(0, 0, {
                 'product_id': self.product.id,
                 'product_uom_id': self.product.uom_id.id,
@@ -198,6 +204,7 @@ class TestStockRequestPurchase(common.TransactionCase):
                 'company_id': self.main_company.id,
                 'warehouse_id': self.warehouse.id,
                 'location_id': self.warehouse.lot_stock_id.id,
+                'expected_date': expected_date,
             })]
         }
 

--- a/stock_request_submit/tests/test_stock_request_submit.py
+++ b/stock_request_submit/tests/test_stock_request_submit.py
@@ -10,7 +10,7 @@ class TestStockRequestSubmit(test_stock_request.TestStockRequest):
         super(TestStockRequestSubmit, self).setUp()
 
     def test_stock_request_submit(self):
-        expected_date = fields.Date.today()
+        expected_date = fields.Datetime.now()
         vals = {
             'company_id': self.main_company.id,
             'warehouse_id': self.warehouse.id,


### PR DESCRIPTION
It should avoid intermittent errors when running stock_request test on CI.

@lreficent @jbeficent @max3903

https://github.com/OCA/stock-logistics-warehouse/pull/689