### PR TITLE
[WMS][12.0] Add stock_putaway_abc - alpha version

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -4,3 +4,4 @@ account-analytic
 product-attribute
 server-ux
 web
+stock-logistics-warehouse https://github.com/grindtildeath/stock-logistics-warehouse 12.0_add_stock_putaway_rule

--- a/stock_putaway_abc/__init__.py
+++ b/stock_putaway_abc/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_putaway_abc/__manifest__.py
+++ b/stock_putaway_abc/__manifest__.py
@@ -19,4 +19,8 @@
         "views/stock_location.xml",
         "views/product_strategy.xml",
     ],
+    "demo": [
+        "demo/stock_location.xml",
+        "demo/product_strategy.xml",
+    ],
 }

--- a/stock_putaway_abc/__manifest__.py
+++ b/stock_putaway_abc/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Putaway ABC",
+    "summary": "Manage ABC Chaotic storage putaway",
+    "version": "12.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "stock"
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/stock_location.xml",
+        "views/product_strategy.xml",
+    ],
+}

--- a/stock_putaway_abc/__manifest__.py
+++ b/stock_putaway_abc/__manifest__.py
@@ -12,7 +12,7 @@
     "application": False,
     "installable": True,
     "depends": [
-        "stock"
+        "stock_putaway_rule"
     ],
     "data": [
         "security/ir.model.access.csv",

--- a/stock_putaway_abc/__manifest__.py
+++ b/stock_putaway_abc/__manifest__.py
@@ -15,7 +15,6 @@
         "stock_putaway_rule"
     ],
     "data": [
-        "security/ir.model.access.csv",
         "views/stock_location.xml",
         "views/product_strategy.xml",
     ],

--- a/stock_putaway_abc/demo/product_strategy.xml
+++ b/stock_putaway_abc/demo/product_strategy.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_putaway_wh_stock" model="product.putaway">
+        <field name="name">Stock putaways</field>
+    </record>
+    <record id="abc_putaway_category_office" model="stock.abc.putaway.strat">
+        <field name="putaway_id" ref="product_putaway_wh_stock" />
+        <field name="category_id" ref="product.product_category_5" />
+        <field name="abc_priority">b</field>
+    </record>
+    <record id="abc_putaway_product_flipover" model="stock.abc.putaway.strat">
+        <field name="putaway_id" ref="product_putaway_wh_stock" />
+        <field name="product_id" ref="product.product_product_20" />
+        <field name="abc_priority">a</field>
+    </record>
+</odoo>

--- a/stock_putaway_abc/demo/product_strategy.xml
+++ b/stock_putaway_abc/demo/product_strategy.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <record id="product_putaway_wh_stock" model="product.putaway">
-        <field name="name">Stock putaways</field>
-    </record>
-    <record id="abc_putaway_category_office" model="stock.abc.putaway.strat">
-        <field name="putaway_id" ref="product_putaway_wh_stock" />
+    <record id="abc_putaway_category_office" model="stock.putaway.rule.abc">
+        <field name="location_in_id" ref="stock.stock_location_stock" />
         <field name="category_id" ref="product.product_category_5" />
         <field name="abc_priority">b</field>
     </record>
-    <record id="abc_putaway_product_flipover" model="stock.abc.putaway.strat">
-        <field name="putaway_id" ref="product_putaway_wh_stock" />
+    <record id="abc_putaway_product_flipover" model="stock.putaway.rule.abc">
+        <field name="location_in_id" ref="stock.stock_location_stock" />
         <field name="product_id" ref="product.product_product_20" />
         <field name="abc_priority">a</field>
     </record>

--- a/stock_putaway_abc/demo/product_strategy.xml
+++ b/stock_putaway_abc/demo/product_strategy.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <record id="abc_putaway_category_office" model="stock.putaway.rule.abc">
+    <record id="abc_putaway_category_office" model="stock.putaway.rule">
         <field name="location_in_id" ref="stock.stock_location_stock" />
         <field name="category_id" ref="product.product_category_5" />
+        <field name="method">abc</field>
         <field name="abc_priority">b</field>
     </record>
-    <record id="abc_putaway_product_flipover" model="stock.putaway.rule.abc">
+    <record id="abc_putaway_product_flipover" model="stock.putaway.rule">
         <field name="location_in_id" ref="stock.stock_location_stock" />
         <field name="product_id" ref="product.product_product_20" />
+        <field name="method">abc</field>
         <field name="abc_priority">a</field>
     </record>
 </odoo>

--- a/stock_putaway_abc/demo/stock_location.xml
+++ b/stock_putaway_abc/demo/stock_location.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="location_bin_a" model="stock.location">
+        <field name="name">Bin A</field>
+        <field name="usage">internal</field>
+        <field name="location_id" ref="stock.stock_location_components"/>
+        <field name="abc_classification">a</field>
+    </record>
+    <record id="location_bin_b" model="stock.location">
+        <field name="name">Bin B</field>
+        <field name="usage">internal</field>
+        <field name="location_id" ref="stock.stock_location_components"/>
+        <field name="abc_classification">b</field>
+    </record>
+    <record id="location_bin_c" model="stock.location">
+        <field name="name">Bin C</field>
+        <field name="usage">internal</field>
+        <field name="location_id" ref="stock.stock_location_14"/>
+        <field name="abc_classification">c</field>
+    </record>
+</odoo>

--- a/stock_putaway_abc/models/__init__.py
+++ b/stock_putaway_abc/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_strategy
+from . import stock_location

--- a/stock_putaway_abc/models/product_strategy.py
+++ b/stock_putaway_abc/models/product_strategy.py
@@ -1,0 +1,119 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, models, fields
+
+
+class PutAwayStrategy(models.Model):
+    _inherit = 'product.putaway'
+
+    # TODO PR to add this field to odoo core ?
+    location_ids = fields.One2many('stock.location', 'putaway_strategy_id')
+    product_abc_strategy_ids = fields.One2many(
+        'stock.abc.putaway.strat',
+        'putaway_id',
+        domain=[('product_id', '!=', False)],
+        copy=True,
+    )
+    category_abc_strategy_ids = fields.One2many(
+        'stock.abc.putaway.strat',
+        'putaway_id',
+        domain=[('category_id', '!=', False)],
+        copy=True,
+    )
+
+    def putaway_apply(self, product):
+        location = super().putaway_apply(product)
+        if location:
+            return location
+        abc_putaway = self._get_abc_putaway_rule(product)
+        if abc_putaway:
+            return abc_putaway.find_abc_location()
+        return self.env['stock.location']
+
+    def _get_abc_putaway_rule(self, product):
+        if self.product_abc_strategy_ids:
+            put_away = self.product_abc_strategy_ids.filtered(
+                lambda x: x.product_id == product
+            )
+            if put_away:
+                return put_away[0]
+        if self.category_abc_strategy_ids:
+            categ = product.categ_id
+            while categ:
+                put_away = self.category_abc_strategy_ids.filtered(
+                    lambda x: x.category_id == categ
+                )
+                if put_away:
+                    return put_away[0]
+                categ = categ.parent_id
+        return self.env['stock.location']
+
+
+class ABCPutAwayStrategy(models.Model):
+
+    _name = 'stock.abc.putaway.strat'
+
+    @api.model
+    def _get_abc_priority_selection(self):
+        return [('a', 'A'), ('b', 'B'), ('c', 'C')]
+
+    product_id = fields.Many2one('product.product', 'Product')
+    putaway_id = fields.Many2one(
+        'product.putaway',
+        'Put Away Method',
+        required=True
+    )
+    category_id = fields.Many2one('product.category', 'Product Category')
+    abc_priority = fields.Selection(
+        _get_abc_priority_selection(),
+        required=True,
+    )
+    sequence = fields.Integer(
+        'Priority',
+        help="Give to the more specialized category, a higher priority to have"
+             " them in top of the list."
+    )
+
+    @api.model
+    def _next_abc_priority(self, priority):
+        if priority == 'a':
+            return 'b'
+        elif priority == 'b':
+            return 'c'
+        elif priority == 'c':
+            return 'a'
+        return False
+
+    @api.multi
+    def validate_abc_location(self, locations):
+        """Return locations without children or locations, to be inherited to
+        add validation rules"""
+        self.ensure_one()
+        no_children_locations = locations.filtered(lambda l: not l.child_ids)
+        return no_children_locations or locations
+
+    @api.mutli
+    def find_abc_location(self):
+        self.ensure_one()
+        validated_location = self.env['stock.location']
+        parent_locations = self.putaway_id.location_ids
+        actual_priority = first_priority = self.abc_priority
+        while not validated_location:
+            children_locations = self.env['stock.location'].search(
+                [
+                    ('abc_classification', '=', actual_priority),
+                    ('id', 'childof', parent_locations.ids)
+                ]
+            )
+            if not children_locations:
+                actual_priority = self._next_abc_priority(actual_priority)
+                # Quit the loop if we went through the 3 priorities without
+                # success
+                if actual_priority == first_priority:
+                    validated_location = self.env['stock.location']
+                    break
+            else:
+                validated_location = self.validate_abc_locations(
+                    children_locations
+                )[0]
+        return validated_location

--- a/stock_putaway_abc/models/product_strategy.py
+++ b/stock_putaway_abc/models/product_strategy.py
@@ -1,59 +1,38 @@
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import api, models, fields, _
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 
 ABC_SELECTION = [('a', 'A'), ('b', 'B'), ('c', 'C')]
 
 
-class StockPutawayRuleAbc(models.Model):
+class StockPutawayRule(models.Model):
 
-    _name = 'stock.putaway.rule.abc'
-    _description = 'ABC Chaotic putaway'
+    _inherit = 'stock.putaway.rule'
 
-    def _default_location_id(self):
-        if self.env.context.get('active_model') == 'stock.location':
-            return self.env.context.get('active_id')
-
-    product_id = fields.Many2one('product.product', 'Product')
-    location_in_id = fields.Many2one(
-        'stock.location', 'When product arrives in', check_company=True,
-        domain="[('child_ids', '!=', False), '|', ('company_id', '=', False), ('company_id', '=', company_id)]",
-        default=_default_location_id, required=True, ondelete='cascade')
-    category_id = fields.Many2one('product.category', 'Product Category')
+    method = fields.Selection(
+        [('fixed', 'Fixed location'), ('abc', 'ABC Priority')],
+        required=True,
+        default='fixed',
+    )
     abc_priority = fields.Selection(
         ABC_SELECTION,
         string='ABC Priority',
-        required=True,
     )
-    sequence = fields.Integer(
-        'Priority',
-        help="Give to the more specialized category, a higher priority to have"
-             " them in top of the list."
-    )
-    company_id = fields.Many2one(
-        'res.company', 'Company', required=True,
-        default=lambda s: s.env.company.id, index=True
-    )
+    location_out_id = fields.Many2one(required=False)
 
-    @api.onchange('location_in_id')
-    def _onchange_location_in(self):
-        if self.location_out_id:
-            child_location_count = self.env['stock.location'].search_count([
-                ('id', '=', self.location_out_id.id),
-                ('id', 'child_of', self.location_in_id.id),
-                ('id', '!=', self.location_in_id.id),
-            ])
-            if not child_location_count:
-                self.location_out_id = None
-
-    def write(self, vals):
-        if 'company_id' in vals:
-            for rule in self:
-                if rule.company_id.id != vals['company_id']:
-                    raise UserError(_("Changing the company of this record is forbidden at this point, you should rather archive it and create a new one."))
-        return super().write(vals)
+    @api.constrains('method', 'location_out_id', 'abc_priority')
+    def _check_method(self):
+        for rule in self:
+            if rule.method == 'fixed' and not rule.location_out_id:
+                raise ValidationError(_(
+                    "Fixed putaways require a 'Store to' location."
+                ))
+            elif rule.method == 'abc' and not rule.abc_priority:
+                raise ValidationError(_(
+                    "ABC putaways require an ABC priority."
+                ))
 
     @api.model
     def _next_abc_priority(self, priority):
@@ -98,3 +77,13 @@ class StockPutawayRuleAbc(models.Model):
                     children_locations
                 )[0]
         return validated_location
+
+    def filtered(self, func):
+        """Filter putaway strats according to method"""
+        putaway_rules = super().filtered(func)
+        if self.env.context.get('_putaway_method') == 'fixed':
+            filtered_putaways = super(
+                StockPutawayRule, putaway_rules
+            ).filtered(lambda p: p.method == 'fixed')
+            return filtered_putaways
+        return putaway_rules

--- a/stock_putaway_abc/models/product_strategy.py
+++ b/stock_putaway_abc/models/product_strategy.py
@@ -29,9 +29,18 @@ class StockPutawayRule(models.Model):
                 raise ValidationError(_(
                     "Fixed putaways require a 'Store to' location."
                 ))
+            elif rule.method == 'fixed' and rule.abc_priority:
+                raise ValidationError(_(
+                    "Fixed putaways are not allowed to have an ABC priority."
+                ))
             elif rule.method == 'abc' and not rule.abc_priority:
                 raise ValidationError(_(
                     "ABC putaways require an ABC priority."
+                ))
+            elif rule.method == 'abc' and rule.location_out_id:
+                raise ValidationError(_(
+                    "ABC putaways are not allowed to have a 'Store to' "
+                    "location."
                 ))
 
     @api.model

--- a/stock_putaway_abc/models/product_strategy.py
+++ b/stock_putaway_abc/models/product_strategy.py
@@ -3,7 +3,11 @@
 from odoo import api, models, fields
 
 
+ABC_SELECTION = [('a', 'A'), ('b', 'B'), ('c', 'C')]
+
+
 class PutAwayStrategy(models.Model):
+
     _inherit = 'product.putaway'
 
     # TODO PR to add this field to odoo core ?
@@ -52,10 +56,7 @@ class PutAwayStrategy(models.Model):
 class ABCPutAwayStrategy(models.Model):
 
     _name = 'stock.abc.putaway.strat'
-
-    @api.model
-    def _get_abc_priority_selection(self):
-        return [('a', 'A'), ('b', 'B'), ('c', 'C')]
+    _description = 'ABC Chaotic putaway'
 
     product_id = fields.Many2one('product.product', 'Product')
     putaway_id = fields.Many2one(
@@ -65,7 +66,7 @@ class ABCPutAwayStrategy(models.Model):
     )
     category_id = fields.Many2one('product.category', 'Product Category')
     abc_priority = fields.Selection(
-        _get_abc_priority_selection(),
+        ABC_SELECTION,
         required=True,
     )
     sequence = fields.Integer(
@@ -85,14 +86,14 @@ class ABCPutAwayStrategy(models.Model):
         return False
 
     @api.multi
-    def validate_abc_location(self, locations):
+    def validate_abc_locations(self, locations):
         """Return locations without children or locations, to be inherited to
         add validation rules"""
         self.ensure_one()
         no_children_locations = locations.filtered(lambda l: not l.child_ids)
         return no_children_locations or locations
 
-    @api.mutli
+    @api.multi
     def find_abc_location(self):
         self.ensure_one()
         validated_location = self.env['stock.location']
@@ -102,7 +103,7 @@ class ABCPutAwayStrategy(models.Model):
             children_locations = self.env['stock.location'].search(
                 [
                     ('abc_classification', '=', actual_priority),
-                    ('id', 'childof', parent_locations.ids)
+                    ('id', 'child_of', parent_locations.ids),
                 ]
             )
             if not children_locations:

--- a/stock_putaway_abc/models/product_strategy.py
+++ b/stock_putaway_abc/models/product_strategy.py
@@ -56,13 +56,13 @@ class StockPutawayRule(models.Model):
     def find_abc_location(self):
         self.ensure_one()
         validated_location = self.env['stock.location']
-        parent_locations = self.putaway_id.location_ids
+        parent_location = self.location_in_id
         actual_priority = first_priority = self.abc_priority
         while not validated_location:
             children_locations = self.env['stock.location'].search(
                 [
                     ('abc_classification', '=', actual_priority),
-                    ('id', 'child_of', parent_locations.ids),
+                    ('id', 'child_of', parent_location.id),
                 ]
             )
             if not children_locations:

--- a/stock_putaway_abc/models/product_strategy.py
+++ b/stock_putaway_abc/models/product_strategy.py
@@ -67,6 +67,7 @@ class ABCPutAwayStrategy(models.Model):
     category_id = fields.Many2one('product.category', 'Product Category')
     abc_priority = fields.Selection(
         ABC_SELECTION,
+        string='ABC Priority',
         required=True,
     )
     sequence = fields.Integer(

--- a/stock_putaway_abc/models/stock_location.py
+++ b/stock_putaway_abc/models/stock_location.py
@@ -10,5 +10,5 @@ class StockLocation(models.Model):
     # TODO Check if we want to define this only on locations without children
     #  or if filtering those in validate_abc_location is enough
     abc_classification = fields.Selection(
-        ABC_SELECTION,
+        ABC_SELECTION, strinng='ABC Classification'
     )

--- a/stock_putaway_abc/models/stock_location.py
+++ b/stock_putaway_abc/models/stock_location.py
@@ -3,6 +3,7 @@
 from odoo import models, fields
 from .product_strategy import ABC_SELECTION
 
+
 class StockLocation(models.Model):
 
     _inherit = 'stock.location'
@@ -12,3 +13,37 @@ class StockLocation(models.Model):
     abc_classification = fields.Selection(
         ABC_SELECTION, strinng='ABC Classification'
     )
+    putaway_rule_abc_ids = fields.One2many(
+        'stock.putaway.rule.abc', 'location_in_id', 'Putaway Rules'
+    )
+
+    def _get_putaway_strategy(self, product):
+        location = super()._get_putaway_strategy(product)
+        if location:
+            return location
+        abc_putaway = self._get_putaway_strategy_abc(product)
+        if abc_putaway:
+            return abc_putaway.find_abc_location()
+        return self.env['stock.location']
+
+    def _get_putaway_strategy_abc(self, product):
+        current_location = self
+        putaway_location = self.env['stock.location']
+        while current_location and not putaway_location:
+            # Looking for a putaway about the product.
+            putaway_rules = self.putaway_rule_abc_ids.filtered(
+                lambda x: x.product_id == product)
+            if putaway_rules:
+                putaway_location = putaway_rules[0].find_abc_location()
+            # If not product putaway found, we're looking with category so.
+            else:
+                categ = product.categ_id
+                while categ:
+                    putaway_rules = self.putaway_rule_abc_ids.filtered(
+                        lambda x: x.category_id == categ)
+                    if putaway_rules:
+                        putaway_location = putaway_rules[0].find_abc_location()
+                        break
+                    categ = categ.parent_id
+            current_location = current_location.location_id
+        return putaway_location

--- a/stock_putaway_abc/models/stock_location.py
+++ b/stock_putaway_abc/models/stock_location.py
@@ -34,7 +34,10 @@ class StockLocation(models.Model):
                 lambda x: x.product_id == product and x.method == 'abc'
             )
             if putaway_rules:
-                putaway_location = putaway_rules[0].find_abc_location()
+                for put_rule in putaway_rules:
+                    putaway_location = put_rule.find_abc_location()
+                    if putaway_location:
+                        break
             # If not product putaway found, we're looking with category so.
             else:
                 categ = product.categ_id
@@ -43,8 +46,10 @@ class StockLocation(models.Model):
                         lambda x: x.category_id == categ and x.method == 'abc'
                     )
                     if putaway_rules:
-                        putaway_location = putaway_rules[0].find_abc_location()
-                        break
+                        for put_rule in putaway_rules:
+                            putaway_location = put_rule.find_abc_location()
+                            if putaway_location:
+                                break
                     categ = categ.parent_id
             current_location = current_location.location_id
         return putaway_location

--- a/stock_putaway_abc/models/stock_location.py
+++ b/stock_putaway_abc/models/stock_location.py
@@ -1,0 +1,17 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, fields
+
+
+class StockLocation(models.Model):
+
+    _inherit = 'stock.location'
+
+    def _get_abc_classification_selection(self):
+        return self.env['stock.abc.putaway.strat']._get_abc_priority_selection()
+
+    # TODO Check if we want to define this only on locations without children
+    #  or if filtering those in validate_abc_location is enough
+    abc_classification = fields.Selection(
+        _get_abc_classification_selection(),
+    )

--- a/stock_putaway_abc/models/stock_location.py
+++ b/stock_putaway_abc/models/stock_location.py
@@ -20,9 +20,9 @@ class StockLocation(models.Model):
         ).get_putaway_strategy(product)
         if location:
             return location
-        abc_putaway = self._get_putaway_strategy_abc(product)
-        if abc_putaway:
-            return abc_putaway.find_abc_location()
+        abc_putaway_location = self._get_putaway_strategy_abc(product)
+        if abc_putaway_location:
+            return abc_putaway_location
         return self.env['stock.location']
 
     def _get_putaway_strategy_abc(self, product):

--- a/stock_putaway_abc/models/stock_location.py
+++ b/stock_putaway_abc/models/stock_location.py
@@ -30,9 +30,10 @@ class StockLocation(models.Model):
         putaway_location = self.env['stock.location']
         while current_location and not putaway_location:
             # Looking for a putaway about the product.
-            putaway_rules = self.putaway_rule_ids.filtered(
-                lambda x: x.product_id == product and x.method == 'abc'
-            )
+            putaway_rules = self.putaway_rule_ids.with_context(
+                _putaway_method='abc').filtered(
+                    lambda x: x.product_id == product and x.method == 'abc'
+                )
             if putaway_rules:
                 for put_rule in putaway_rules:
                     putaway_location = put_rule.find_abc_location()
@@ -42,9 +43,11 @@ class StockLocation(models.Model):
             else:
                 categ = product.categ_id
                 while categ:
-                    putaway_rules = self.putaway_rule_ids.filtered(
-                        lambda x: x.category_id == categ and x.method == 'abc'
-                    )
+                    putaway_rules = self.putaway_rule_ids.with_context(
+                        _putaway_method='abc').filtered(
+                            lambda x: x.category_id == categ
+                                      and x.method == 'abc'
+                        )
                     if putaway_rules:
                         for put_rule in putaway_rules:
                             putaway_location = put_rule.find_abc_location()

--- a/stock_putaway_abc/models/stock_location.py
+++ b/stock_putaway_abc/models/stock_location.py
@@ -1,17 +1,14 @@
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import models, fields
-
+from .product_strategy import ABC_SELECTION
 
 class StockLocation(models.Model):
 
     _inherit = 'stock.location'
 
-    def _get_abc_classification_selection(self):
-        return self.env['stock.abc.putaway.strat']._get_abc_priority_selection()
-
     # TODO Check if we want to define this only on locations without children
     #  or if filtering those in validate_abc_location is enough
     abc_classification = fields.Selection(
-        _get_abc_classification_selection(),
+        ABC_SELECTION,
     )

--- a/stock_putaway_abc/models/stock_location.py
+++ b/stock_putaway_abc/models/stock_location.py
@@ -11,7 +11,7 @@ class StockLocation(models.Model):
     # TODO Check if we want to define this only on locations without children
     #  or if filtering those in validate_abc_location is enough
     abc_classification = fields.Selection(
-        ABC_SELECTION, strinng='ABC Classification'
+        ABC_SELECTION, string='ABC Classification'
     )
 
     def get_putaway_strategy(self, product):
@@ -39,7 +39,7 @@ class StockLocation(models.Model):
             else:
                 categ = product.categ_id
                 while categ:
-                    putaway_rules = self.putaway_rule_abc_ids.filtered(
+                    putaway_rules = self.putaway_rule_ids.filtered(
                         lambda x: x.category_id == categ and x.method == 'abc'
                     )
                     if putaway_rules:

--- a/stock_putaway_abc/models/stock_location.py
+++ b/stock_putaway_abc/models/stock_location.py
@@ -14,10 +14,10 @@ class StockLocation(models.Model):
         ABC_SELECTION, strinng='ABC Classification'
     )
 
-    def _get_putaway_strategy(self, product):
+    def get_putaway_strategy(self, product):
         location = super(
             StockLocation, self.with_context(_putaway_method='fixed')
-        )._get_putaway_strategy(product)
+        ).get_putaway_strategy(product)
         if location:
             return location
         abc_putaway = self._get_putaway_strategy_abc(product)

--- a/stock_putaway_abc/readme/CONTRIBUTORS.rst
+++ b/stock_putaway_abc/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/stock_putaway_abc/readme/DESCRIPTION.rst
+++ b/stock_putaway_abc/readme/DESCRIPTION.rst
@@ -1,0 +1,14 @@
+This module implements ABC chaotic storage putaways.
+
+Instead of defining putaway with a fixed location for product or product
+category, this module allows to define an ABC preference for product or product
+category on the product putaway form.
+
+When such a putaway is applied, it will look recursively for a stock location
+without children whose ABC classification matches the ABC priority of the
+putaway.
+
+e.g. for a putaway with B priority, it will look on children locations
+for a B location. If no B location is found, it will look for a C. If no C
+location is found, it will look for an A. Finally, if no location matches, it
+will return the stock location where the putaway is applied.

--- a/stock_putaway_abc/security/ir.model.access.csv
+++ b/stock_putaway_abc/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_abc_putaway_strat,stock_abc_putaway_strat managers,model_stock_abc_putaway_strat,stock.group_stock_manager,1,1,1,1
+access_stock_abc_putaway_user,stock_abc_putaway_strat user,model_stock_abc_putaway_strat,stock.group_stock_user,1,0,0,0

--- a/stock_putaway_abc/security/ir.model.access.csv
+++ b/stock_putaway_abc/security/ir.model.access.csv
@@ -1,3 +1,0 @@
-id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_stock_putaway_rule_abc_strat,stock_putaway_rule_abc managers,model_stock_putaway_rule_abc,stock.group_stock_manager,1,1,1,1
-access_stock_putaway_rule_abc_user,stock_putaway_rule_abc user,model_stock_putaway_rule_abc,stock.group_stock_user,1,0,0,0

--- a/stock_putaway_abc/security/ir.model.access.csv
+++ b/stock_putaway_abc/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_stock_abc_putaway_strat,stock_abc_putaway_strat managers,model_stock_abc_putaway_strat,stock.group_stock_manager,1,1,1,1
-access_stock_abc_putaway_user,stock_abc_putaway_strat user,model_stock_abc_putaway_strat,stock.group_stock_user,1,0,0,0
+access_stock_putaway_rule_abc_strat,stock_putaway_rule_abc managers,model_stock_putaway_rule_abc,stock.group_stock_manager,1,1,1,1
+access_stock_putaway_rule_abc_user,stock_putaway_rule_abc user,model_stock_putaway_rule_abc,stock.group_stock_user,1,0,0,0

--- a/stock_putaway_abc/tests/__init__.py
+++ b/stock_putaway_abc/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)

--- a/stock_putaway_abc/tests/__init__.py
+++ b/stock_putaway_abc/tests/__init__.py
@@ -1,2 +1,1 @@
-# Copyright 2019 Camptocamp SA
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from . import test_putaway_abc

--- a/stock_putaway_abc/tests/test_putaway_abc.py
+++ b/stock_putaway_abc/tests/test_putaway_abc.py
@@ -129,7 +129,9 @@ class TestStockMovePutawayABC(SavepointCase):
         # Sofa product is office category
         # office category has an ABC putaway strategy to B
         # Bin B is set as inactive so it must go into Bin C
+        # Bin C is set as inactive so it must go into Bin A
         self.bin_b_location.active = False
+        self.bin_c_location.active = False
         replenish_wiz = self.env['product.replenish'].create({
             'product_id': self.product_sofa.id,
             'product_tmpl_id': self.product_sofa.product_tmpl_id.id,
@@ -149,5 +151,5 @@ class TestStockMovePutawayABC(SavepointCase):
         self.assertEqual(generated_move.state, 'assigned')
         self.assertEqual(
             generated_move.move_line_ids.location_dest_id,
-            self.bin_c_location
+            self.bin_a_location
         )

--- a/stock_putaway_abc/tests/test_putaway_abc.py
+++ b/stock_putaway_abc/tests/test_putaway_abc.py
@@ -1,4 +1,153 @@
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import SavepointCase
 
-# TODO
+
+class TestStockMovePutawayABC(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product_flipover = cls.env.ref('product.product_product_20')
+        cls.product_sofa = cls.env.ref('product.consu_delivery_01')
+        cls.product_category_office = cls.env.ref('product.product_category_5')
+
+        cls.warehouse = cls.env.ref('stock.warehouse0')
+
+        cls.vendors_location = cls.env.ref('stock.stock_location_suppliers')
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+
+        cls.stock_putaway = cls.env.ref(
+            'stock_putaway_abc.product_putaway_wh_stock'
+        )
+        cls.stock_location.write({'putaway_strategy_id': cls.stock_putaway.id})
+
+        cls.bin_a_location = cls.env.ref('stock_putaway_abc.location_bin_a')
+        cls.bin_b_location = cls.env.ref('stock_putaway_abc.location_bin_b')
+        cls.bin_c_location = cls.env.ref('stock_putaway_abc.location_bin_c')
+
+        cls.picking_type_receipts = cls.env.ref('stock.picking_type_in')
+
+        cls.reception_route = cls.env['stock.location.route'].search([
+            ('warehouse_ids', '=', cls.warehouse.id),
+            ('name', 'ilike', 'Receive'),
+        ])
+
+        # Add reception route to product category
+        cls.product_category_office.write({
+            'route_ids': [(4, cls.reception_route.id)]
+        })
+
+        # Create route to pull from suppliers location
+        cls.suppliers_to_stock_rule = cls.env['stock.rule'].create({
+            'route_id': cls.reception_route.id,
+            'name': 'WH: Suppliers → Stock',
+            'action': 'pull',
+            'picking_type_id': cls.picking_type_receipts.id,
+            'location_src_id': cls.vendors_location.id,
+            'location_id': cls.stock_location.id,
+            'procure_method': 'make_to_stock',
+        })
+
+    def test_reception_into_product_abc_bin(self):
+        # Flipover product has an ABC putaway strategy to A
+        replenish_wiz = self.env['product.replenish'].create({
+            'product_id': self.product_flipover.id,
+            'product_tmpl_id': self.product_flipover.product_tmpl_id.id,
+            'product_uom_id': self.product_flipover.uom_id.id,
+            'quantity': 10.0,
+        })
+        replenish_wiz.launch_replenishment()
+        generated_move = self.env['stock.move'].search(
+            [
+                ('product_id', '=', self.product_flipover.id),
+                ('location_id', '=', self.vendors_location.id),
+                ('location_dest_id', '=', self.stock_location.id),
+            ]
+        )
+        self.assertEqual(generated_move.state, 'confirmed')
+        generated_move.picking_id.action_assign()
+        self.assertEqual(generated_move.state, 'assigned')
+        self.assertEqual(
+            generated_move.move_line_ids.location_dest_id,
+            self.bin_a_location
+        )
+
+    def test_reception_into_product_next_abc_bin(self):
+        # Flipover product has an ABC putaway strategy to A
+        # Bin A is set as inactive so it must go into Bin B
+        self.bin_a_location.active = False
+        replenish_wiz = self.env['product.replenish'].create({
+            'product_id': self.product_flipover.id,
+            'product_tmpl_id': self.product_flipover.product_tmpl_id.id,
+            'product_uom_id': self.product_flipover.uom_id.id,
+            'quantity': 10.0,
+        })
+        replenish_wiz.launch_replenishment()
+        generated_move = self.env['stock.move'].search(
+            [
+                ('product_id', '=', self.product_flipover.id),
+                ('location_id', '=', self.vendors_location.id),
+                ('location_dest_id', '=', self.stock_location.id),
+            ]
+        )
+        self.assertEqual(generated_move.state, 'confirmed')
+        generated_move.picking_id.action_assign()
+        self.assertEqual(generated_move.state, 'assigned')
+        self.assertEqual(
+            generated_move.move_line_ids.location_dest_id,
+            self.bin_b_location
+        )
+
+    def test_reception_into_product_category_abc_bin(self):
+        # Sofa product is office category
+        # office category has an ABC putaway strategy to B
+        replenish_wiz = self.env['product.replenish'].create({
+            'product_id': self.product_sofa.id,
+            'product_tmpl_id': self.product_sofa.product_tmpl_id.id,
+            'product_uom_id': self.product_sofa.uom_id.id,
+            'quantity': 10.0,
+        })
+        replenish_wiz.launch_replenishment()
+        generated_move = self.env['stock.move'].search(
+            [
+                ('product_id', '=', self.product_sofa.id),
+                ('location_id', '=', self.vendors_location.id),
+                ('location_dest_id', '=', self.stock_location.id),
+            ]
+        )
+        self.assertEqual(generated_move.state, 'confirmed')
+        generated_move.picking_id.action_assign()
+        self.assertEqual(generated_move.state, 'assigned')
+        self.assertEqual(
+            generated_move.move_line_ids.location_dest_id,
+            self.bin_b_location
+        )
+
+    def test_reception_into_product_category_next_abc_bin(self):
+        # Sofa product is office category
+        # office category has an ABC putaway strategy to B
+        # Bin B is set as inactive so it must go into Bin C
+        self.bin_b_location.active = False
+        replenish_wiz = self.env['product.replenish'].create({
+            'product_id': self.product_sofa.id,
+            'product_tmpl_id': self.product_sofa.product_tmpl_id.id,
+            'product_uom_id': self.product_sofa.uom_id.id,
+            'quantity': 10.0,
+        })
+        replenish_wiz.launch_replenishment()
+        generated_move = self.env['stock.move'].search(
+            [
+                ('product_id', '=', self.product_sofa.id),
+                ('location_id', '=', self.vendors_location.id),
+                ('location_dest_id', '=', self.stock_location.id),
+            ]
+        )
+        self.assertEqual(generated_move.state, 'confirmed')
+        generated_move.picking_id.action_assign()
+        self.assertEqual(generated_move.state, 'assigned')
+        self.assertEqual(
+            generated_move.move_line_ids.location_dest_id,
+            self.bin_c_location
+        )

--- a/stock_putaway_abc/tests/test_putaway_abc.py
+++ b/stock_putaway_abc/tests/test_putaway_abc.py
@@ -18,11 +18,6 @@ class TestStockMovePutawayABC(SavepointCase):
         cls.vendors_location = cls.env.ref('stock.stock_location_suppliers')
         cls.stock_location = cls.env.ref('stock.stock_location_stock')
 
-        cls.stock_putaway = cls.env.ref(
-            'stock_putaway_abc.product_putaway_wh_stock'
-        )
-        cls.stock_location.write({'putaway_strategy_id': cls.stock_putaway.id})
-
         cls.bin_a_location = cls.env.ref('stock_putaway_abc.location_bin_a')
         cls.bin_b_location = cls.env.ref('stock_putaway_abc.location_bin_b')
         cls.bin_c_location = cls.env.ref('stock_putaway_abc.location_bin_c')

--- a/stock_putaway_abc/tests/test_putaway_abc.py
+++ b/stock_putaway_abc/tests/test_putaway_abc.py
@@ -1,0 +1,4 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+# TODO

--- a/stock_putaway_abc/views/product_strategy.xml
+++ b/stock_putaway_abc/views/product_strategy.xml
@@ -6,6 +6,9 @@
         <field name="model">product.putaway</field>
         <field name="arch" type="xml">
             <field name="fixed_location_ids" position="after">
+                <p class="oe_grey">
+                    The rules defined by fixed location will be applied before the rules defined by ABC classification.
+                </p>
                 <field name="product_abc_strategy_ids" colspan="4" nolabel="1">
                     <tree editable="bottom">
                         <field name="sequence" widget='handle'/>

--- a/stock_putaway_abc/views/product_strategy.xml
+++ b/stock_putaway_abc/views/product_strategy.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_putaway" model="ir.ui.view">
+        <field name="name">product.putaway.form.inherit</field>
+        <field name="inherit_id" ref="stock.view_putaway" />
+        <field name="model">product.putaway</field>
+        <field name="arch" type="xml">
+            <field name="fixed_location_ids" position="after">
+                <field name="product_abc_strategy_ids" colspan="4" nolabel="1">
+                    <tree editable="bottom">
+                        <field name="sequence" widget='handle'/>
+                        <field name="product_id" required="1"/>
+                        <field name="abc_priority" />
+                    </tree>
+                </field>
+                <field name="category_abc_strategy_ids" colspan="4" nolabel="1">
+                    <tree editable="bottom">
+                        <field name="sequence" widget='handle'/>
+                        <field name="category_id" required="1"/>
+                        <field name="abc_priority" />
+                    </tree>
+                </field>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/stock_putaway_abc/views/product_strategy.xml
+++ b/stock_putaway_abc/views/product_strategy.xml
@@ -1,29 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <record id="view_putaway" model="ir.ui.view">
-        <field name="name">product.putaway.form.inherit</field>
-        <field name="inherit_id" ref="stock.view_putaway" />
-        <field name="model">product.putaway</field>
+    <record id="stock_putaway_list_inherit" model="ir.ui.view">
+        <field name="name">stock.putaway.rule.tree.inherit</field>
+        <field name="model">stock.putaway.rule</field>
+        <field name="inherit_id" ref="stock_putaway_rule.stock_putaway_list" />
         <field name="arch" type="xml">
-            <field name="fixed_location_ids" position="after">
-                <p class="oe_grey">
-                    The rules defined by fixed location will be applied before the rules defined by ABC classification.
-                </p>
-                <field name="product_abc_strategy_ids" colspan="4" nolabel="1">
-                    <tree editable="bottom">
-                        <field name="sequence" widget='handle'/>
-                        <field name="product_id" required="1"/>
-                        <field name="abc_priority" />
-                    </tree>
-                </field>
-                <field name="category_abc_strategy_ids" colspan="4" nolabel="1">
-                    <tree editable="bottom">
-                        <field name="sequence" widget='handle'/>
-                        <field name="category_id" required="1"/>
-                        <field name="abc_priority" />
-                    </tree>
-                </field>
+            <field name="location_in_id" position="after">
+                <field name="method" />
+            </field>
+            <field name="location_out_id" position="after">
+                <field name="abc_priority" />
             </field>
         </field>
     </record>
+
+    <record id="view_putaway_search_inherit" model="ir.ui.view">
+        <field name="name">stock.putaway.rule.search.inherit</field>
+        <field name="model">stock.putaway.rule</field>
+        <field name="inherit_id" ref="stock_putaway_rule.view_putaway_search" />
+        <field name="arch" type="xml">
+            <field name="location_in_id" position="after">
+                <field name="method" />
+            </field>
+            <field name="location_out_id" position="after">
+                <field name="abc_priority" />
+            </field>
+            <filter name="location_in" position="after">
+                <filter string="Method" name="method" context="{'group_by':'method'}"/>
+            </filter>
+            <filter name="location_out" position="after">
+                <filter string="ABC Priority" name="abc_priority" context="{'group_by':'abc_priority'}"/>
+            </filter>
+        </field>
+    </record>
+
 </odoo>

--- a/stock_putaway_abc/views/stock_location.xml
+++ b/stock_putaway_abc/views/stock_location.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_location_form_inherit" model="ir.ui.view">
+        <field name="name">stock.location.form.inherit</field>
+        <field name="inherit_id" ref="stock.view_location_form" />
+        <field name="model">stock.location</field>
+        <field name="arch" type="xml">
+            <field name="putaway_strategy_id" position="after">
+                <field name="abc_classification" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module implements ABC chaotic storage putaways.

Instead of defining putaway with a fixed location for product or product
category, this module allows to define an ABC preference for product or product
category on the product putaway form.

When such a putaway is applied, it will look recursively for a stock location
without children whose ABC classification matches the ABC priority of the
putaway.

e.g. for a putaway with B priority, it will look on children locations
for a B location. If no B location is found, it will look for a C. If no C
location is found, it will look for an A. Finally, if no location matches, it
will return the stock location where the putaway is applied.

Related to #691 