### PR TITLE
[WMS][12.0] Add stock_putaway_abc_move_location_dest_constraint - alpha version

### DIFF
--- a/stock_putaway_abc_move_location_dest_constraint/__init__.py
+++ b/stock_putaway_abc_move_location_dest_constraint/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_putaway_abc_move_location_dest_constraint/__manifest__.py
+++ b/stock_putaway_abc_move_location_dest_constraint/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Move Location Dest Constraint ABC",
+    "summary": "Constrain location dest matching ABC classification",
+    "version": "12.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "depends": [
+        "stock_move_location_dest_constraint_base",
+        "stock_putaway_abc"
+    ],
+}

--- a/stock_putaway_abc_move_location_dest_constraint/models/__init__.py
+++ b/stock_putaway_abc_move_location_dest_constraint/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_strategy

--- a/stock_putaway_abc_move_location_dest_constraint/models/__init__.py
+++ b/stock_putaway_abc_move_location_dest_constraint/models/__init__.py
@@ -1,1 +1,2 @@
 from . import product_strategy
+from . import stock_location

--- a/stock_putaway_abc_move_location_dest_constraint/models/product_strategy.py
+++ b/stock_putaway_abc_move_location_dest_constraint/models/product_strategy.py
@@ -9,8 +9,8 @@ class ABCPutAwayStrategy(models.Model):
     _inherit = 'stock.abc.putaway.strat'
 
     @api.multi
-    def validate_abc_location(self, locations):
-        res = super().validate_abc_location(locations)
+    def validate_abc_locations(self, locations):
+        res = super().validate_abc_locations(locations)
         product = None
         if self.product_id:
             product = self.product_id

--- a/stock_putaway_abc_move_location_dest_constraint/models/product_strategy.py
+++ b/stock_putaway_abc_move_location_dest_constraint/models/product_strategy.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, models
+from odoo.exceptions import ValidationError
+
+
+class ABCPutAwayStrategy(models.Model):
+
+    _inherit = 'stock.abc.putaway.strat'
+
+    @api.multi
+    def validate_abc_location(self, locations):
+        res = super().validate_abc_location(locations)
+        product = None
+        if self.product_id:
+            product = self.product_id
+        checked_locations = self.env['stock.location']
+        for loc in res:
+            try:
+                loc.check_move_dest_constraint(product=product)
+            except ValidationError:
+                continue
+            checked_locations |= loc
+        return checked_locations

--- a/stock_putaway_abc_move_location_dest_constraint/models/product_strategy.py
+++ b/stock_putaway_abc_move_location_dest_constraint/models/product_strategy.py
@@ -4,9 +4,9 @@ from odoo import api, models
 from odoo.exceptions import ValidationError
 
 
-class ABCPutAwayStrategy(models.Model):
+class StockPutawayRule(models.Model):
 
-    _inherit = 'stock.abc.putaway.strat'
+    _inherit = 'stock.putaway.rule'
 
     @api.multi
     def validate_abc_locations(self, locations):

--- a/stock_putaway_abc_move_location_dest_constraint/models/stock_location.py
+++ b/stock_putaway_abc_move_location_dest_constraint/models/stock_location.py
@@ -1,0 +1,15 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockLocation(models.Model):
+
+    def check_move_dest_constraint(self, line=None, product=None):
+        # As stock.putaway.rule.location_out_id is not required when
+        # stock_putaway_abc is installed, we check here that this method
+        # is called on an existing stock.location to avoid error on ensure_one
+        # in stock_move_location_dest_constraint_base
+        if not self:
+            return False
+        return super().check_move_dest_constraint(line=line, product=product)

--- a/stock_putaway_abc_move_location_dest_constraint/models/stock_location.py
+++ b/stock_putaway_abc_move_location_dest_constraint/models/stock_location.py
@@ -5,6 +5,8 @@ from odoo import models
 
 class StockLocation(models.Model):
 
+    _inherit = 'stock.location'
+
     def check_move_dest_constraint(self, line=None, product=None):
         # As stock.putaway.rule.location_out_id is not required when
         # stock_putaway_abc is installed, we check here that this method

--- a/stock_putaway_abc_move_location_dest_constraint/readme/CONTRIBUTORS.rst
+++ b/stock_putaway_abc_move_location_dest_constraint/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/stock_putaway_abc_move_location_dest_constraint/readme/DESCRIPTION.rst
+++ b/stock_putaway_abc_move_location_dest_constraint/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module allows to validate ABC locations according to constraints installed
+by modules restricting location destination on stock move lines.


### PR DESCRIPTION
This module allows to validate ABC locations according to constraints installed
by modules restricting location destination on stock move lines.

Requires
 - [ ] #699 
 - [ ] #696 

Related to #691 
