### PR TITLE
[WMS][12.0] Add stock_putaway_abc_product_form - alpha version

### DIFF
--- a/stock_putaway_abc_product_form/__init__.py
+++ b/stock_putaway_abc_product_form/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_putaway_abc_product_form/__manifest__.py
+++ b/stock_putaway_abc_product_form/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Putaway Product From",
+    "summary": "Manage putaway from product form",
+    "version": "12.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "depends": [
+        "stock_putaway_abc",
+        "stock_putaway_product_form",
+    ],
+    "data": [
+        "views/product.xml",
+        "views/product_category.xml",
+    ],
+}

--- a/stock_putaway_abc_product_form/models/__init__.py
+++ b/stock_putaway_abc_product_form/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product
+from . import product_category

--- a/stock_putaway_abc_product_form/models/product.py
+++ b/stock_putaway_abc_product_form/models/product.py
@@ -1,0 +1,18 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, fields
+
+
+class ProductProduct(models.Model):
+
+    _inherit = 'product.product'
+
+    abc_putaway_strategy_ids = fields.One2many(
+        'stock.abc.putaway.strat',
+        'product_id',
+        string="Product ABC Put-aways",
+    )
+    category_abc_putaway_ids = fields.One2many(
+        related='categ_id.abc_putaway_strategy_ids',
+        string="Category ABC Put-aways",
+    )

--- a/stock_putaway_abc_product_form/models/product_category.py
+++ b/stock_putaway_abc_product_form/models/product_category.py
@@ -1,0 +1,12 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, fields
+
+
+class ProductCategory(models.Model):
+
+    _inherit = 'product.category'
+
+    abc_putaway_strategy_ids = fields.One2many(
+        'stock.abc.putaway.strat', 'category_id', string='ABC Put-Aways'
+    )

--- a/stock_putaway_abc_product_form/models/product_template.py
+++ b/stock_putaway_abc_product_form/models/product_template.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, fields
+
+
+class ProductTemplate(models.Model):
+
+    _inherit = 'product.template'
+
+    # TODO Display putaway from product.product ?
+    #  we probably want to display these if there are no more than one variant
+
+    # TODO Display putaway from product.category

--- a/stock_putaway_abc_product_form/readme/CONTRIBUTORS.rst
+++ b/stock_putaway_abc_product_form/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/stock_putaway_abc_product_form/readme/DESCRIPTION.rst
+++ b/stock_putaway_abc_product_form/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module adds embedded tree views on product and product category form view
+to view and manage ABC put-aways more efficiently.

--- a/stock_putaway_abc_product_form/views/product.xml
+++ b/stock_putaway_abc_product_form/views/product.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_normal_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.product.form.inherit</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="stock_putaway_product_form.product_normal_form_view_inherit"/>
+        <field name="arch" type="xml">
+            <group name="product_putaways" position="after">
+                <group string="ABC Put-aways">
+                    <field name="abc_putaway_strategy_ids" context="{'default_category_id': False, 'default_product_id': active_id}">
+                        <tree>
+                            <field name="putaway_id" />
+                            <field name="abc_priority" />
+                        </tree>
+                        <form>
+                            <group>
+                                <field name="putaway_id" />
+                                <field name="abc_priority" />
+                                <field name="product_id" readonly="1"/>
+                            </group>
+                        </form>
+                    </field>
+                    <field name="category_abc_putaway_ids">
+                        <tree>
+                            <field name="putaway_id" />
+                            <field name="abc_priority" />
+                        </tree>
+                    </field>
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/stock_putaway_abc_product_form/views/product_category.xml
+++ b/stock_putaway_abc_product_form/views/product_category.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_category_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.category.form.inherit</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="stock_putaway_product_form.product_category_form_view_inherit" />
+        <field name="arch" type="xml">
+            <field name="fixed_putaway_strategy_ids" position="after">
+                <field name="abc_putaway_strategy_ids" context="{'default_category_id': active_id, 'default_product_id': False}">
+                    <tree>
+                        <field name="putaway_id" />
+                        <field name="abc_priority" />
+                    </tree>
+                    <form>
+                        <group>
+                            <field name="putaway_id" />
+                            <field name="abc_priority" />
+                            <field name="category_id" readonly="1" />
+                        </group>
+                    </form>
+                </field>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module adds embedded tree views on product and product category form view
to view and manage ABC put-aways more efficiently.

Requires:
 - [ ] #699  
 - [ ] #702 

Related to #691 