### PR TITLE
[WMS][12.0] Add stock_putaway_recursive - alpha version

### DIFF
--- a/stock_putaway_recursive/__init__.py
+++ b/stock_putaway_recursive/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_putaway_recursive/__manifest__.py
+++ b/stock_putaway_recursive/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Putaway Recursive",
+    "summary": "Apply putaway strategies recursively",
+    "version": "12.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "stock"
+    ],
+}

--- a/stock_putaway_recursive/__manifest__.py
+++ b/stock_putaway_recursive/__manifest__.py
@@ -12,6 +12,10 @@
     "application": False,
     "installable": True,
     "depends": [
-        "stock"
+        # FIXME should depend on stock, however, stock_putaway_rule
+        # overrides StockLocation.get_putaway_strategy without calling
+        # super(), so until we have an alternative, add a dependency
+        # there.
+        "stock_putaway_rule",
     ],
 }

--- a/stock_putaway_recursive/models/__init__.py
+++ b/stock_putaway_recursive/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_location

--- a/stock_putaway_recursive/models/stock_location.py
+++ b/stock_putaway_recursive/models/stock_location.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockLocation(models.Model):
+
+    _inherit = 'stock.location'
+
+    def get_putaway_strategy(self, product):
+        loc = super().get_putaway_strategy(product)
+        if loc != self:
+            recursive_locations = self.env.context.get(
+                '_recursive_locations', []
+            )
+            # avoid infinite recursion if putaway was already applied on loc
+            if loc.id in recursive_locations:
+                return self
+            recursive_locations.append(loc.id)
+            # apply putaway recursively
+            return loc.with_context(
+                _recursive_locations=recursive_locations
+            ).get_putaway_strategy(product)
+        return loc

--- a/stock_putaway_recursive/models/stock_location.py
+++ b/stock_putaway_recursive/models/stock_location.py
@@ -8,17 +8,9 @@ class StockLocation(models.Model):
     _inherit = 'stock.location'
 
     def get_putaway_strategy(self, product):
-        loc = super().get_putaway_strategy(product)
-        if loc != self:
-            recursive_locations = self.env.context.get(
-                '_recursive_locations', []
-            )
-            # avoid infinite recursion if putaway was already applied on loc
-            if loc.id in recursive_locations:
-                return self
-            recursive_locations.append(loc.id)
-            # apply putaway recursively
-            return loc.with_context(
-                _recursive_locations=recursive_locations
-            ).get_putaway_strategy(product)
-        return loc
+        if not self:
+            # stop recursion
+            return self
+        current_location = super().get_putaway_strategy(product)
+        next_location = current_location.get_putaway_strategy(product)
+        return next_location or current_location

--- a/stock_putaway_recursive/readme/CONTRIBUTORS.rst
+++ b/stock_putaway_recursive/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/stock_putaway_recursive/readme/DESCRIPTION.rst
+++ b/stock_putaway_recursive/readme/DESCRIPTION.rst
@@ -1,0 +1,9 @@
+This module applies putaway strategies recursively.
+
+By default Odoo applies a putaway strategy on the destination location of a
+stock move and returns the first fixed location it finds on the destination
+location of the move.
+
+With this module, if another putaway is defined on the returned fixed location,
+it will be applied as well, as will be any other putaway strategy that is
+defined on the next destination location that is found.

--- a/stock_putaway_recursive/tests/__init__.py
+++ b/stock_putaway_recursive/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_putaway_recursive

--- a/stock_putaway_recursive/tests/test_stock_putaway_recursive.py
+++ b/stock_putaway_recursive/tests/test_stock_putaway_recursive.py
@@ -16,7 +16,7 @@ class TestStockPutawayRecursive(SavepointCase):
         cls.shelf2_location = cls.env.ref('stock.stock_location_14')
         cls.refri_location = cls.env.ref('stock.location_refrigerator_small')
 
-        # Define putaway from Stock to Stock/Shelf 1
+        # Define putaway from Stock to Stock/Shelf 2
         stock_putaway = cls.env['product.putaway'].create({
             'name': 'stock putaway',
         })
@@ -24,19 +24,6 @@ class TestStockPutawayRecursive(SavepointCase):
             'putaway_strategy_id': stock_putaway.id
         })
         stock_putaway.write({
-            'product_location_ids': [(0, 0, {
-                'product_id': cls.product_flipover.id,
-                'fixed_location_id': cls.shelf1_location.id,
-            })]
-        })
-        # Define putaway from Stock/Shelf 1 to Stock/Shelf 2
-        shelf1_putaway = cls.env['product.putaway'].create({
-            'name': 'shelf1 putaway',
-        })
-        cls.shelf1_location.write({
-            'putaway_strategy_id': shelf1_putaway.id
-        })
-        shelf1_putaway.write({
             'product_location_ids': [(0, 0, {
                 'product_id': cls.product_flipover.id,
                 'fixed_location_id': cls.shelf2_location.id,

--- a/stock_putaway_recursive/tests/test_stock_putaway_recursive.py
+++ b/stock_putaway_recursive/tests/test_stock_putaway_recursive.py
@@ -1,0 +1,87 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import SavepointCase
+
+
+class TestStockPutawayRecursive(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product_flipover = cls.env.ref('product.product_product_20')
+        cls.order_location = cls.env.ref('stock.location_order')
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.shelf1_location = cls.env.ref('stock.stock_location_components')
+        cls.shelf2_location = cls.env.ref('stock.stock_location_14')
+        cls.refri_location = cls.env.ref('stock.location_refrigerator_small')
+
+        # Define putaway from Stock to Stock/Shelf 1
+        stock_putaway = cls.env['product.putaway'].create({
+            'name': 'stock putaway',
+        })
+        cls.stock_location.write({
+            'putaway_strategy_id': stock_putaway.id
+        })
+        stock_putaway.write({
+            'product_location_ids': [(0, 0, {
+                'product_id': cls.product_flipover.id,
+                'fixed_location_id': cls.shelf1_location.id,
+            })]
+        })
+        # Define putaway from Stock/Shelf 1 to Stock/Shelf 2
+        shelf1_putaway = cls.env['product.putaway'].create({
+            'name': 'shelf1 putaway',
+        })
+        cls.shelf1_location.write({
+            'putaway_strategy_id': shelf1_putaway.id
+        })
+        shelf1_putaway.write({
+            'product_location_ids': [(0, 0, {
+                'product_id': cls.product_flipover.id,
+                'fixed_location_id': cls.shelf2_location.id,
+            })]
+        })
+        # Define putaway from Stock/Shelf 2 to Stock/Shelf 2/Small refrigerator
+        shelf2_putaway = cls.env['product.putaway'].create({
+            'name': 'shelf2 putaway',
+        })
+        cls.shelf2_location.write({
+            'putaway_strategy_id': shelf2_putaway.id
+        })
+        shelf2_putaway.write({
+            'product_location_ids': [(0, 0, {
+                'product_id': cls.product_flipover.id,
+                'fixed_location_id': cls.refri_location.id,
+            })]
+        })
+
+    @classmethod
+    def _update_qty_in_location(cls, location, product, quantity):
+        cls.env['stock.quant']._update_available_quantity(
+            product, location, quantity
+        )
+
+    def _create_and_assign_move(self, product, location, location_dest):
+        move = self.env['stock.move'].create({
+            'name': 'Test move',
+            'product_id': product.id,
+            'product_uom_qty': 1.0,
+            'product_uom': product.uom_id.id,
+            'location_id': location.id,
+            'location_dest_id': location_dest.id,
+        })
+        move._action_confirm()
+        move._action_assign()
+        return move
+
+    def test_putaway_recursive(self):
+        self._update_qty_in_location(
+            self.order_location, self.product_flipover, 10.0
+        )
+        move = self._create_and_assign_move(
+            self.product_flipover, self.order_location, self.stock_location
+        )
+        self.assertEqual(
+            move.move_line_ids.location_dest_id, self.refri_location
+        )


### PR DESCRIPTION
This module applies putaway strategies recursively.

By default Odoo applies a putaway strategy on the destination location of a
stock move and returns the first fixed location it finds on the destination
location of the move.

With this module, if another putaway is defined on the returned fixed location,
it will be applied as well, as will be any other putaway strategy that is
defined on the next destination location that is found.

Related to #691