### PR TITLE
[WMS][12.0] Add stock_putaway_rule - alpha version

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -4,4 +4,3 @@ account-analytic
 product-attribute
 server-ux
 web
-stock-logistics-warehouse https://github.com/grindtildeath/stock-logistics-warehouse 12.0_add_stock_putaway_rule

--- a/stock_putaway_rule/__init__.py
+++ b/stock_putaway_rule/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_putaway_rule/__manifest__.py
+++ b/stock_putaway_rule/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Putaway Rule",
+    "summary": "Manage putaway with rules as in odoo v13.0",
+    "version": "12.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "stock"
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/product_strategy.xml",
+        "views/product.xml",
+        "views/stock_location.xml",
+    ],
+}

--- a/stock_putaway_rule/models/__init__.py
+++ b/stock_putaway_rule/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product
+from . import product_strategy
+from . import stock_location

--- a/stock_putaway_rule/models/product.py
+++ b/stock_putaway_rule/models/product.py
@@ -1,0 +1,52 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models, _
+
+
+class ProductCategory(models.Model):
+
+    _inherit = 'product.category'
+
+    putaway_rule_ids = fields.One2many('stock.putaway.rule', 'category_id',
+                                       'Putaway Rules')
+
+
+class ProductProduct(models.Model):
+
+    _inherit = 'product.product'
+
+    putaway_rule_ids = fields.One2many('stock.putaway.rule', 'product_id',
+                                       'Putaway Rules')
+
+    def action_view_related_putaway_rules(self):
+        self.ensure_one()
+        domain = [
+            '|',
+                ('product_id', '=', self.id),
+                ('category_id', '=', self.product_tmpl_id.categ_id.id),
+        ]
+        return self.env['product.template']._get_action_view_related_putaway_rules(domain)
+
+
+class ProductTemplate(models.Model):
+
+    _inherit = 'product.template'
+
+    @api.model
+    def _get_action_view_related_putaway_rules(self, domain):
+        return {
+            'name': _('Putaway Rules'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'stock.putaway.rule',
+            'view_mode': 'list',
+            'domain': domain,
+        }
+
+    def action_view_related_putaway_rules(self):
+        self.ensure_one()
+        domain = [
+            '|',
+                ('product_id.product_tmpl_id', '=', self.id),
+                ('category_id', '=', self.categ_id.id),
+        ]
+        return self._get_action_view_related_putaway_rules(domain)

--- a/stock_putaway_rule/models/product.py
+++ b/stock_putaway_rule/models/product.py
@@ -22,10 +22,12 @@ class ProductProduct(models.Model):
         self.ensure_one()
         domain = [
             '|',
-                ('product_id', '=', self.id),
-                ('category_id', '=', self.product_tmpl_id.categ_id.id),
+            ('product_id', '=', self.id),
+            ('category_id', '=', self.product_tmpl_id.categ_id.id),
         ]
-        return self.env['product.template']._get_action_view_related_putaway_rules(domain)
+        return self.env[
+            'product.template'
+        ]._get_action_view_related_putaway_rules(domain)
 
 
 class ProductTemplate(models.Model):
@@ -46,7 +48,7 @@ class ProductTemplate(models.Model):
         self.ensure_one()
         domain = [
             '|',
-                ('product_id.product_tmpl_id', '=', self.id),
-                ('category_id', '=', self.categ_id.id),
+            ('product_id.product_tmpl_id', '=', self.id),
+            ('category_id', '=', self.categ_id.id),
         ]
         return self._get_action_view_related_putaway_rules(domain)

--- a/stock_putaway_rule/models/product_strategy.py
+++ b/stock_putaway_rule/models/product_strategy.py
@@ -1,0 +1,78 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class StockPutawayRule(models.Model):
+    _name = 'stock.putaway.rule'
+    _order = 'sequence,product_id'
+    _description = 'Putaway Rule'
+
+    def _default_category_id(self):
+        if self.env.context.get('active_model') == 'product.category':
+            return self.env.context.get('active_id')
+
+    def _default_location_id(self):
+        if self.env.context.get('active_model') == 'stock.location':
+            return self.env.context.get('active_id')
+
+    def _default_product_id(self):
+        if self.env.context.get('active_model') == 'product.template' and self.env.context.get('active_id'):
+            product_template = self.env['product.template'].browse(self.env.context.get('active_id'))
+            product_template = product_template.exists()
+            if product_template.product_variant_count == 1:
+                return product_template.product_variant_id
+        elif self.env.context.get('active_model') == 'product.product':
+            return self.env.context.get('active_id')
+
+    def _domain_category_id(self):
+        active_model = self.env.context.get('active_model')
+        if active_model in ('product.template', 'product.product') and self.env.context.get('active_id'):
+            product = self.env[active_model].browse(self.env.context.get('active_id'))
+            product = product.exists()
+            if product:
+                return [('id', '=', product.categ_id.id)]
+        return []
+
+    def _domain_product_id(self):
+        domain = "[('type', '!=', 'service'), '|', ('company_id', '=', False), ('company_id', '=', company_id)]"
+        if self.env.context.get('active_model') == 'product.template':
+            return [('product_tmpl_id', '=', self.env.context.get('active_id'))]
+        return domain
+
+    product_id = fields.Many2one(
+        'product.product', 'Product',
+        default=_default_product_id, domain=_domain_product_id, ondelete='cascade')
+    category_id = fields.Many2one('product.category', 'Product Category',
+        default=_default_category_id, domain=_domain_category_id, ondelete='cascade')
+    location_in_id = fields.Many2one(
+        'stock.location', 'When product arrives in',
+        domain="[('child_ids', '!=', False), '|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        default=_default_location_id, required=True, ondelete='cascade')
+    location_out_id = fields.Many2one(
+        'stock.location', 'Store to',
+        domain="[('id', 'child_of', location_in_id), ('id', '!=', location_in_id), '|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        required=True, ondelete='cascade')
+    sequence = fields.Integer('Priority', help="Give to the more specialized category, a higher priority to have them in top of the list.")
+    company_id = fields.Many2one(
+        'res.company', 'Company', required=True,
+        default=lambda s: s.env.user.company_id, index=True)
+
+    @api.onchange('location_in_id')
+    def _onchange_location_in(self):
+        if self.location_out_id:
+            child_location_count = self.env['stock.location'].search_count([
+                ('id', '=', self.location_out_id.id),
+                ('id', 'child_of', self.location_in_id.id),
+                ('id', '!=', self.location_in_id.id),
+            ])
+            if not child_location_count:
+                self.location_out_id = None
+
+    def write(self, vals):
+        if 'company_id' in vals:
+            for rule in self:
+                if rule.company_id.id != vals['company_id']:
+                    raise UserError(_("Changing the company of this record is forbidden at this point, you should rather archive it and create a new one."))
+        return super(StockPutawayRule, self).write(vals)

--- a/stock_putaway_rule/models/stock_location.py
+++ b/stock_putaway_rule/models/stock_location.py
@@ -1,0 +1,32 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class StockLocation(models.Model):
+
+    _inherit = 'stock.location'
+
+    putaway_rule_ids = fields.One2many('stock.putaway.rule', 'location_in_id',
+                                       'Putaway Rules')
+
+    def _get_putaway_strategy(self, product):
+        ''' Returns the location where the product has to be put, if any compliant putaway strategy is found. Otherwise returns None.'''
+        current_location = self
+        putaway_location = self.env['stock.location']
+        while current_location and not putaway_location:
+            # Looking for a putaway about the product.
+            putaway_rules = self.putaway_rule_ids.filtered(lambda x: x.product_id == product)
+            if putaway_rules:
+                putaway_location = putaway_rules[0].location_out_id
+            # If not product putaway found, we're looking with category so.
+            else:
+                categ = product.categ_id
+                while categ:
+                    putaway_rules = self.putaway_rule_ids.filtered(lambda x: x.category_id == categ)
+                    if putaway_rules:
+                        putaway_location = putaway_rules[0].location_out_id
+                        break
+                    categ = categ.parent_id
+            current_location = current_location.location_id
+        return putaway_location

--- a/stock_putaway_rule/models/stock_location.py
+++ b/stock_putaway_rule/models/stock_location.py
@@ -10,7 +10,7 @@ class StockLocation(models.Model):
     putaway_rule_ids = fields.One2many('stock.putaway.rule', 'location_in_id',
                                        'Putaway Rules')
 
-    def _get_putaway_strategy(self, product):
+    def get_putaway_strategy(self, product):
         ''' Returns the location where the product has to be put, if any compliant putaway strategy is found. Otherwise returns None.'''
         current_location = self
         putaway_location = self.env['stock.location']

--- a/stock_putaway_rule/readme/CONTRIBUTORS.rst
+++ b/stock_putaway_rule/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/stock_putaway_rule/readme/DESCRIPTION.rst
+++ b/stock_putaway_rule/readme/DESCRIPTION.rst
@@ -1,0 +1,8 @@
+This module backports the new implementation of putaways as in Odoo v.13.
+
+Models `product.putaway` and `stock.fixed.putaway.strat` are not used anymore
+and are replaced by `product.putaway.rule` which has a direct relation to
+`stock.location`, instead of having a useless intermediate model.
+
+Usability is therefore improved as putaway rules are accessible from Stock
+locations, Products or the dedicated menu entry.

--- a/stock_putaway_rule/security/ir.model.access.csv
+++ b/stock_putaway_rule/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_putaway_all,stock.putaway.rule all users,model_stock_putaway_rule,base.group_user,1,0,0,0
+access_stock_putaway_manager,stock.putaway.rule all managers,model_stock_putaway_rule,stock.group_stock_manager,1,1,1,1

--- a/stock_putaway_rule/views/product.xml
+++ b/stock_putaway_rule/views/product.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_category_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.category.form.inherit</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="product.product_category_form_view" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button string="Putaway Rules"
+                        class="oe_stat_button"
+                        icon="fa-random" name="%(category_open_putaway)d" type="action"
+                        groups="stock.group_stock_multi_locations"/>
+            </div>
+        </field>
+    </record>
+
+    <record id="product_variant_easy_edit_view_inherit" model="ir.ui.view">
+        <field name="name">product.product.view.form.easy.inherit</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_variant_easy_edit_view" />
+        <field name="arch" type="xml">
+            <field name="id" position="after">
+                <div class="oe_button_box" name="button_box">
+                    <button string="Putaway Rules" type="object"
+                        name="action_view_related_putaway_rules"
+                        class="oe_stat_button" icon="fa-random" groups="stock.group_stock_multi_locations"
+                        attrs="{'invisible': [('type', '=', 'service')]}"
+                        context="{'invisible_handle': True, 'single_product': True}"/>
+                </div>
+            </field>
+        </field>
+    </record>
+
+    <record id="product_normal_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.product.form.inherit</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+            <button name="toggle_active" position="before">
+                <button string="Putaway Rules" type="object"
+                    name="action_view_related_putaway_rules"
+                    class="oe_stat_button" icon="fa-random" groups="stock.group_stock_multi_locations"
+                    attrs="{'invisible': [('type', '=', 'service')]}"
+                    context="{'invisible_handle': True, 'single_product': True}"/>
+            </button>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="product_template_only_form_view_inherit">
+        <field name="name">product.template.product.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view"/>
+        <field name="arch" type="xml">
+            <button name="toggle_active" position="before">
+                <button string="Putaway Rules" type="object"
+                    name="action_view_related_putaway_rules"
+                    class="oe_stat_button" icon="fa-random" groups="stock.group_stock_multi_locations"
+                    attrs="{'invisible': [('type', '=', 'service')]}"
+                    context="{
+                        'invisible_handle': True,
+                        'single_product': product_variant_count == 1,
+                    }"/>
+            </button>
+        </field>
+    </record>
+</odoo>

--- a/stock_putaway_rule/views/product_strategy.xml
+++ b/stock_putaway_rule/views/product_strategy.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_putaway_list" model="ir.ui.view">
+        <field name="name">stock.putaway.rule.tree</field>
+        <field name="model">stock.putaway.rule</field>
+        <field name="arch" type="xml">
+            <tree string="Putaway Rules" editable="bottom">
+                <field name="sequence" widget="handle"
+                       invisible="context.get('invisible_handle', False)"/>
+                <field name="product_id"
+                       attrs="{'readonly': [('category_id', '!=', False)], 'required': [('category_id', '=', False)]}"
+                       options="{'no_create': True, 'no_open': True}"
+                       readonly="context.get('single_product', False)"
+                       force_save="1"/>
+                <field name="category_id"
+                       attrs="{'readonly': [('product_id', '!=', False)], 'required': [('product_id', '=', False)]}"
+                       options="{'no_create': True, 'no_open': True}"
+                       readonly="context.get('fixed_category', False)"
+                       force_save="1"/>
+                <field name="location_in_id"
+                       options="{'no_create': True}"
+                       readonly="context.get('fixed_location', False)"/>
+                <field name="location_out_id" attrs="{'readonly': [('location_in_id', '=', False)]}"
+                       options="{'no_create': True}"/>
+                <field name="company_id" groups="stock.group_stock_multi_locations" force_save="1" readonly="context.get('fixed_location', False)"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_putaway_tree" model="ir.actions.act_window">
+        <field name="name">Putaways Rules</field>
+        <field name="res_model">stock.putaway.rule</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="stock_putaway_list"/>
+    </record>
+
+    <record id="view_putaway_search" model="ir.ui.view">
+        <field name="name">stock.putaway.rule.search</field>
+        <field name="model">stock.putaway.rule</field>
+        <field name="arch" type="xml">
+            <search string="Putaway Rules">
+                <field name="product_id"/>
+                <field name="category_id"/>
+                <field name="location_in_id"/>
+                <field name="location_out_id"/>
+                <group expand='0' string='Filters'>
+                    <filter name="filter_to_rules_on_product"
+                            string="Rules on Products"
+                            domain="[('product_id', '!=', False)]"/>
+                    <filter name="filter_to_rules_on_category"
+                            string="Rules on Categories"
+                            domain="[('category_id' ,'!=', False)]"/>
+                </group>
+                <group expand="0" string="Group By">
+                        <filter string="Location: When arrives to" name="location_in" context="{'group_by':'location_in_id'}"/>
+                        <filter string="Location: Store to" name="location_out" context="{'group_by':'location_out_id'}"/>
+                    </group>
+            </search>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="category_open_putaway"> <!-- Putaway rules from category -->
+        <field name="name">Putaway Rules</field>
+        <field name="res_model">stock.putaway.rule</field>
+        <field name="context">{
+            'search_default_category_id': [active_id],
+            'fixed_category': True,
+        }</field>
+    </record>
+    <record model="ir.actions.act_window" id="location_open_putaway"> <!-- Putaway rules from location -->
+        <field name="name">Putaway Rules</field>
+        <field name="res_model">stock.putaway.rule</field>
+        <field name="context">{'fixed_location': True}</field>
+        <field name="domain">[('location_in_id', '=', active_id)]</field>
+    </record>
+
+    <menuitem id="menu_putaway" name="Putaway Rules" parent="stock.menu_warehouse_config"
+        action="action_putaway_tree" sequence="5" groups="stock.group_stock_multi_locations"/>
+</odoo>

--- a/stock_putaway_rule/views/stock_location.xml
+++ b/stock_putaway_rule/views/stock_location.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_location_form_inherit" model="ir.ui.view">
+        <field name="name">stock.location.form.inherit</field>
+        <field name="model">stock.location</field>
+        <field name="inherit_id" ref="stock.view_location_form" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button string="Putaway Rules"
+                    class="oe_stat_button"
+                    icon="fa-random" name="%(location_open_putaway)d" type="action"
+                    groups="stock.group_stock_multi_locations" context="{'default_company_id': company_id}"/>
+            </div>
+            <field name="putaway_strategy_id" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module backports the new implementation of putaways as in Odoo v.13.

Models `product.putaway` and `stock.fixed.putaway.strat` are not used anymore
and are replaced by `product.putaway.rule` which has a direct relation to
`stock.location`, instead of having a useless intermediate model.

Usability is therefore improved as putaway rules are accessible from Stock
locations, Products or the dedicated menu entry.
Refers to #621 and #691
