### PR TITLE
[Fix] use the same view id for differnt view using in product and pro…

### DIFF
--- a/stock_available/views/product_product_view.xml
+++ b/stock_available/views/product_product_view.xml
@@ -36,7 +36,7 @@
             </xpath>
         </field>
     </record>
-    <record model="ir.ui.view" id="view_stock_available_tree">
+    <record model="ir.ui.view" id="view_stock_available_product_tree">
         <field name="name">Quantity available to promise (variant tree)</field>
         <field name="model">product.product</field>
         <field name="inherit_id" ref="stock.view_stock_product_tree"/>

--- a/stock_available/views/product_template_view.xml
+++ b/stock_available/views/product_template_view.xml
@@ -36,7 +36,7 @@
             </xpath>
         </field>
     </record>
-    <record model="ir.ui.view" id="view_stock_available_tree">
+    <record model="ir.ui.view" id="view_stock_available_product_template_tree">
         <field name="name">Quantity available to promise (tree)</field>
         <field name="model">product.template</field>
         <field name="inherit_id" ref="stock.view_stock_product_template_tree"/>


### PR DESCRIPTION
the inherited tree view for `product.product` and `product.template` is using the same view id. This patch fixes it.