### PR TITLE
[11.0][FIX] stock_orderpoint_generator singleton

### DIFF
--- a/stock_orderpoint_generator/models/orderpoint_template.py
+++ b/stock_orderpoint_generator/models/orderpoint_template.py
@@ -54,14 +54,15 @@ class OrderpointTemplate(models.Model):
         """ Create instances of model using template inherited model
         """
         orderpoint_model = self.env['stock.warehouse.orderpoint']
-        for data in self.copy_data():
-            data.pop('auto_generate', None)
-            data.pop('auto_product_ids', None)
-            data.pop('auto_last_generation', None)
-            for product_id in product_ids:
-                vals = data.copy()
-                vals['product_id'] = product_id
-                orderpoint_model.create(vals)
+        for record in self:
+            for data in record.copy_data():
+                data.pop('auto_generate')
+                data.pop('auto_product_ids')
+                data.pop('auto_last_generation')
+                for product_id in product_ids:
+                    vals = data.copy()
+                    vals['product_id'] = product_id
+                    orderpoint_model.create(vals)
 
     @api.multi
     def create_orderpoints(self, product_ids):


### PR DESCRIPTION
Fixes singleton:

```
  File "/odoo/vitamineenzo.nl/community/stock_orderpoint_generator/wizard/orderpoint_generator.py", line 44, in action_configure
    self.orderpoint_template_id.create_orderpoints(product_ids)
  File "/odoo/vitamineenzo.nl/community/stock_orderpoint_generator/models/orderpoint_template.py", line 73, in create_orderpoints
    self._create_instances(product_ids)
  File "/odoo/vitamineenzo.nl/community/stock_orderpoint_generator/models/orderpoint_template.py", line 57, in _create_instances
    for data in self.copy_data():
  File "/odoo/vitamineenzo.nl/odoo/odoo/models.py", line 3857, in copy_data
    self.ensure_one()
  File "/odoo/vitamineenzo.nl/odoo/odoo/models.py", line 4417, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: stock.warehouse.orderpoint.template(6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)

```
