### PR TITLE
[9.0] [FIX] Purchase Packaging: purchase line product qty should be stored

### DIFF
--- a/purchase_packaging/__openerp__.py
+++ b/purchase_packaging/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Purchase Packaging",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "author": 'ACSONE SA/NV, '
               'Odoo Community Association (OCA)',
     "category": "Warehouse",

--- a/purchase_packaging/migrations/9.0.1.0.1/post-migrate.py
+++ b/purchase_packaging/migrations/9.0.1.0.1/post-migrate.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    # We recompute possible void values
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    void_purchase_lines = env['purchase.order.line'].search([
+        ('product_qty', '=', False)])
+    void_purchase_lines._compute_product_qty()

--- a/purchase_packaging/models/purchase_order_line.py
+++ b/purchase_packaging/models/purchase_order_line.py
@@ -35,7 +35,8 @@ class PurchaseOrderLine(models.Model):
     product_qty = fields.Float(
         compute="_compute_product_qty",
         string='Quantity',
-        inverse='_inverse_product_qty'
+        inverse='_inverse_product_qty',
+        store=True,
     )
 
     @api.multi


### PR DESCRIPTION
Backport of https://github.com/OCA/stock-logistics-warehouse/pull/493

It fixes a bug with order line prices computation.