### PR TITLE
[12.0] [IMP] stock_inventory_preparation_filter

### DIFF
--- a/stock_inventory_preparation_filter/tests/test_stock_inventory_preparation_filter.py
+++ b/stock_inventory_preparation_filter/tests/test_stock_inventory_preparation_filter.py
@@ -121,6 +121,20 @@ class TestStockInventoryPreparationFilterCategories(common.TransactionCase):
         self.assertEqual(line2.theoretical_qty, 4.0)
         self.assertEqual(line2.location_id, self.location)
 
+    def test_inventory_domain_filter(self):
+        inventory = self.inventory_model.create({
+            'name': 'Domain inventory',
+            'filter': 'domain',
+            'location_id': self.location.id,
+            'product_domain': [('id', '=', self.product1.id)],
+        })
+        inventory.action_start()
+        self.assertEqual(len(inventory.line_ids), 1)
+        line1 = inventory.line_ids[0]
+        self.assertEqual(line1.product_id, self.product1)
+        self.assertEqual(line1.theoretical_qty, 2.0)
+        self.assertEqual(line1.location_id, self.location)
+
     def test_inventory_lots_filter(self):
         inventory = self.inventory_model.create(
             {

--- a/stock_inventory_preparation_filter/views/stock_inventory_view.xml
+++ b/stock_inventory_preparation_filter/views/stock_inventory_view.xml
@@ -27,6 +27,9 @@
                         <field name="lot_ids"
                                 attrs="{'invisible':[('filter','!=','lots')]}" />
                     </field>
+                    <notebook position="before">
+                        <field name="product_domain" widget="domain" attrs="{'invisible': [('filter', '!=', 'domain')]}" options="{'model': 'product.product'}"/>
+                    </notebook>
                     <notebook position="inside">
                         <page string="Capture Lines"
                             attrs="{'invisible':[('filter','!=','empty')]}">

--- a/stock_inventory_preparation_filter/views/stock_inventory_view.xml
+++ b/stock_inventory_preparation_filter/views/stock_inventory_view.xml
@@ -19,9 +19,13 @@
                             attrs="{'invisible':[('filter','!=','categories')]}" />
                     </field>
                     <field name="product_id" position="after">
-                        <field name="product_ids"
-                            widget="many2many_tags"
-                            attrs="{'invisible':[('filter','!=','products')]}" />
+                        <field name="product_ids" attrs="{'invisible':[('filter','!=','products')]}">
+                            <tree>
+                                <field name="default_code"/>
+                                <field name="name"/>
+                                <field name="barcode"/>
+                            </tree>
+                        </field>
                     </field>
                     <field name="lot_id" position="after">
                         <field name="lot_ids"


### PR DESCRIPTION
This PR improves the stock_inventory_preparation_filter module by making it easier to filter on products.

**Replace the many2many_tags in product_ids**
Using the standard many2many widget allows the user to easily search and select a list of products
Without this PR the user is expected to search one by one

![Screen record from 2019-11-08 10 48 43](https://user-images.githubusercontent.com/1914185/68481434-f10dbe80-0215-11ea-8977-4289e4d51f3f.gif)


**Added a new filter type: domain**
This enables more complex searches, like searching based on a related field's field.
![Screen record from 2019-11-08 10 43 54](https://user-images.githubusercontent.com/1914185/68481596-65486200-0216-11ea-914c-bd529a008d54.gif)
