### PR TITLE
[12.0][IMP] Use many2many_tags widgets for lots on inventory adjustment

### DIFF
--- a/stock_inventory_preparation_filter/README.rst
+++ b/stock_inventory_preparation_filter/README.rst
@@ -34,6 +34,8 @@ Includes more options for making an inventory out of:
 It also allows to make an inventory based on scanned products, adding a line
 with product code and quantity.
 
+To add several products, lots or categories by selecting all of them, install the module web_widget_many2many_tags_multi_selection.
+
 **Table of contents**
 
 .. contents::

--- a/stock_inventory_preparation_filter/readme/DESCRIPTION.rst
+++ b/stock_inventory_preparation_filter/readme/DESCRIPTION.rst
@@ -6,3 +6,5 @@ Includes more options for making an inventory out of:
 
 It also allows to make an inventory based on scanned products, adding a line
 with product code and quantity.
+
+To add several products, lots or categories by selecting all of them, install the module web_widget_many2many_tags_multi_selection.

--- a/stock_inventory_preparation_filter/views/stock_inventory_view.xml
+++ b/stock_inventory_preparation_filter/views/stock_inventory_view.xml
@@ -25,7 +25,8 @@
                     </field>
                     <field name="lot_id" position="after">
                         <field name="lot_ids"
-                                attrs="{'invisible':[('filter','!=','lots')]}" />
+                            widget="many2many_tags"
+                            attrs="{'invisible':[('filter','!=','lots')]}" />
                     </field>
                     <notebook position="inside">
                         <page string="Capture Lines"


### PR DESCRIPTION
~This PR improves the stock_inventory_preparation_filter module by making it easier to filter on products.~

~Replace the many2many_tags in product_ids~
~Using the standard many2many widget allows the user to easily search and select a list of products~

Use many2many_tags widgets on lots