### PR TITLE
[11.0][stock_move_location] Start wizard from inventory dashboard

### DIFF
--- a/stock_move_location/__manifest__.py
+++ b/stock_move_location/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Move Stock Location",
-    "version": "11.0.1.1.1",
+    "version": "11.0.2.0.0",
     "author": "Julius Network Solutions, "
               "Odoo Community Association (OCA)",
     "summary": "This module allows to move all stock "
@@ -17,6 +17,7 @@
     "category": "Stock",
     "data": [
         'data/stock_quant_view.xml',
+        'views/stock_picking_type_views.xml',
         'wizard/stock_move_location.xml',
     ],
 }

--- a/stock_move_location/models/__init__.py
+++ b/stock_move_location/models/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from . import stock_move
+from . import stock_picking_type

--- a/stock_move_location/models/stock_picking_type.py
+++ b/stock_move_location/models/stock_picking_type.py
@@ -1,0 +1,25 @@
+# Copyright 2019 Sergio Teruel <sergio.teruel@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    show_move_onhand = fields.Boolean(
+        string='Show Move On hand stock',
+        help="Show a button 'Move On Hand' in the Inventory Dashboard "
+             "to initiate the process to move the products in stock "
+             "at the origin location.")
+
+    def action_move_location(self):
+        action = self.env.ref(
+            'stock_move_location.wiz_stock_move_location_action').read()[0]
+        action['context'] = {
+            'default_origin_location_id': self.default_location_src_id.id,
+            'default_destination_location_id':
+                self.default_location_dest_id.id,
+            'default_picking_type_id': self.id,
+            'default_edit_locations': False,
+        }
+        return action

--- a/stock_move_location/readme/CONTRIBUTORS.rst
+++ b/stock_move_location/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Mykhailo Panarin <m.panarin@mobilunity.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com>
 * Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* Lois Rilo <lois.rilo@eficent.com>

--- a/stock_move_location/readme/CONTRIBUTORS.rst
+++ b/stock_move_location/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Mathieu Vatel <mathieu@julius.fr>
 * Mykhailo Panarin <m.panarin@mobilunity.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com>
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>

--- a/stock_move_location/readme/USAGE.rst
+++ b/stock_move_location/readme/USAGE.rst
@@ -1,5 +1,5 @@
-* A new menuitem Stock > Move from location... opens a wizard
-  where 2 location ca be specified.
+* A new menu item Stock > Move from location... opens a wizard
+  where 2 location can be specified.
 * Select origin and destination locations and press "IMMEDIATE TRANSFER" or "PLANNED TRANSFER"
 * Press `ADD ALL` button to add all products available
 * Those lines can be edited. Move quantity can't be more than a max available quantity
@@ -16,3 +16,7 @@ If you want to transfer a full quant:
    opened.
 
 *  Select the quants which you want move to another location
+
+If you go to the Inventory Dashboard you can see the button "Move from location"
+in each of the picking types (only applicable to internal transfers). Press it
+and you will be directed to the wizard.

--- a/stock_move_location/tests/test_common.py
+++ b/stock_move_location/tests/test_common.py
@@ -16,6 +16,12 @@ class TestsCommon(common.SavepointCase):
         cls.wizard_obj = cls.env["wiz.stock.move.location"]
         cls.quant_obj = cls.env["stock.quant"]
 
+        # Enable multi-locations:
+        wizard = cls.env['res.config.settings'].create({
+            'group_stock_multi_locations': True,
+        })
+        wizard.execute()
+
         cls.internal_loc_1 = cls.location_obj.create({
             "name": "INT_1",
             "usage": "internal",

--- a/stock_move_location/tests/test_move_location.py
+++ b/stock_move_location/tests/test_move_location.py
@@ -102,10 +102,10 @@ class TestMoveLocation(TestsCommon):
         wizard.add_lines()
         wizard.with_context({'planned': True}).action_move_location()
         picking = wizard.picking_id
-        self.assertEqual(picking.state, 'draft')
+        self.assertEqual(picking.state, 'assigned')
         self.assertEqual(len(picking.move_line_ids), 4)
         self.assertEqual(
-            sorted(picking.move_line_ids.mapped("qty_done")),
+            sorted(picking.move_line_ids.mapped("product_uom_qty")),
             [1, 1, 1, 123],
         )
 

--- a/stock_move_location/tests/test_move_location.py
+++ b/stock_move_location/tests/test_move_location.py
@@ -100,7 +100,8 @@ class TestMoveLocation(TestsCommon):
         """Test planned transfer."""
         wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
         wizard.add_lines()
-        wizard.with_context({'planned': True}).action_move_location()
+        wizard = wizard.with_context({'planned': True})
+        wizard.action_move_location()
         picking = wizard.picking_id
         self.assertEqual(picking.state, 'assigned')
         self.assertEqual(len(picking.move_line_ids), 4)
@@ -129,3 +130,20 @@ class TestMoveLocation(TestsCommon):
         wizard.origin_location_id = self.internal_loc_2
         wizard._onchange_destination_location_id()
         self.assertEqual(len(lines), 3)
+
+    def test_readonly_location_computation(self):
+        """Test that origin_location_disable and destination_location_disable
+        are computed correctly."""
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        # locations are editable.
+        self.assertFalse(wizard.origin_location_disable)
+        self.assertFalse(wizard.destination_location_disable)
+        # Disable edit mode:
+        wizard.edit_locations = False
+        self.assertTrue(wizard.origin_location_disable)
+        self.assertTrue(wizard.destination_location_disable)
+
+    def test_picking_type_action_dummy(self):
+        """Test that no error is raised from actions."""
+        pick_type = self.env.ref("stock.picking_type_internal")
+        pick_type.action_move_location()

--- a/stock_move_location/views/stock_picking_type_views.xml
+++ b/stock_move_location/views/stock_picking_type_views.xml
@@ -21,7 +21,7 @@
             </field>
             <xpath expr="//div[hasclass('o_kanban_primary_left')]" position="inside">
                 <div t-if="record.show_move_onhand.raw_value">
-                    <button name="action_move_location" type="object" class="btn btn-info">
+                    <button name="action_move_location" type="object" class="btn btn-info" style="margin-top: 5px;">
                         Move On Hand
                     </button>
                 </div>

--- a/stock_move_location/views/stock_picking_type_views.xml
+++ b/stock_move_location/views/stock_picking_type_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_picking_type_form">
+        <field name="name">Operation Types</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="arch" type="xml">
+            <field name="show_operations" position="after">
+                <field name="show_move_onhand" attrs='{"invisible": [("code", "not in", ["internal"])]}'/>
+            </field>
+        </field>
+    </record>
+
+    <record id="stock_picking_type_kanban" model="ir.ui.view">
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
+        <field name="arch" type="xml">
+            <field name="code" position="after">
+                <field name="show_move_onhand"/>
+            </field>
+            <xpath expr="//div[hasclass('o_kanban_primary_left')]" position="inside">
+                <div t-if="record.show_move_onhand.raw_value">
+                    <button name="action_move_location" type="object" class="btn btn-info">
+                        Move On Hand
+                    </button>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -150,6 +150,9 @@ class StockMoveLocationWizard(models.TransientModel):
         self._create_moves(picking)
         if not self.env.context.get("planned"):
             picking.button_validate()
+        else:
+            picking.action_confirm()
+            picking.action_assign()
         self.picking_id = picking
         return self._get_picking_action(picking.id)
 

--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -19,7 +19,9 @@ class StockMoveLocationWizard(models.TransientModel):
              ('warehouse_id.company_id', '=', company_id)], limit=1).id
 
     origin_location_disable = fields.Boolean(
-        compute='_compute_readonly_locations')
+        compute="_compute_readonly_locations",
+        help="technical field to disable the edition of origin location."
+    )
     origin_location_id = fields.Many2one(
         string='Origin Location',
         comodel_name='stock.location',
@@ -27,7 +29,9 @@ class StockMoveLocationWizard(models.TransientModel):
         domain=lambda self: self._get_locations_domain(),
     )
     destination_location_disable = fields.Boolean(
-        compute='_compute_readonly_locations')
+        compute="_compute_readonly_locations",
+        help="technical field to disable the edition of destination location."
+    )
     destination_location_id = fields.Many2one(
         string='Destination Location',
         comodel_name='stock.location',

--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -10,17 +10,24 @@ from odoo.fields import first
 class StockMoveLocationWizard(models.TransientModel):
     _name = "wiz.stock.move.location"
 
+    origin_location_disable = fields.Boolean(
+        compute='_compute_readonly_locations')
     origin_location_id = fields.Many2one(
         string='Origin Location',
         comodel_name='stock.location',
         required=True,
         domain=lambda self: self._get_locations_domain(),
     )
+    destination_location_disable = fields.Boolean(
+        compute='_compute_readonly_locations')
     destination_location_id = fields.Many2one(
         string='Destination Location',
         comodel_name='stock.location',
         required=True,
         domain=lambda self: self._get_locations_domain(),
+    )
+    picking_type_id = fields.Many2one(
+        comodel_name='stock.picking.type'
     )
     stock_move_location_line_ids = fields.One2many(
         string="Move Location lines",
@@ -31,6 +38,17 @@ class StockMoveLocationWizard(models.TransientModel):
         string="Connected Picking",
         comodel_name="stock.picking",
     )
+    edit_locations = fields.Boolean(string='Edit Locations',
+                                    default=True)
+
+    @api.depends('edit_locations')
+    def _compute_readonly_locations(self):
+        for rec in self:
+            rec.origin_location_disable = self.env.context.get(
+                'origin_location_disable', False)
+            if not rec.edit_locations:
+                rec.origin_location_disable = True
+                rec.destination_location_disable = True
 
     @api.model
     def default_get(self, fields):
@@ -70,7 +88,8 @@ class StockMoveLocationWizard(models.TransientModel):
 
     def _create_picking(self):
         return self.env['stock.picking'].create({
-            'picking_type_id': self.env.ref('stock.picking_type_internal').id,
+            'picking_type_id': self.picking_type_id.id or
+            self.env.ref('stock.picking_type_internal').id,
             'location_id': self.origin_location_id.id,
             'location_dest_id': self.destination_location_id.id,
         })
@@ -166,12 +185,16 @@ class StockMoveLocationWizard(models.TransientModel):
         product_data = []
         for group in self._get_group_quants():
             product = product_obj.browse(group.get("product_id")).exists()
+            # Apply the putaway strategy
+            location_dest_id = \
+                self.destination_location_id.get_putaway_strategy(
+                    product).id or self.destination_location_id.id
             product_data.append({
                 'product_id': product.id,
                 'move_quantity': group.get("sum"),
                 'max_quantity': group.get("sum"),
                 'origin_location_id': self.origin_location_id.id,
-                'destination_location_id': self.destination_location_id.id,
+                'destination_location_id': location_dest_id,
                 # cursor returns None instead of False
                 'lot_id': group.get("lot_id") or False,
                 'product_uom_id': product.uom_id.id,

--- a/stock_move_location/wizard/stock_move_location.xml
+++ b/stock_move_location/wizard/stock_move_location.xml
@@ -14,6 +14,9 @@
               </label>
               <field name="edit_locations" widget="boolean_toggle"/>
           </div>
+          <group name="picking_type">
+              <field name="picking_type_id"/>
+          </group>
           <group name="main">
               <field name="origin_location_disable" invisible="True"/>
               <field name="origin_location_id" attrs="{'readonly': [('origin_location_disable', '=', True)]}"/>

--- a/stock_move_location/wizard/stock_move_location.xml
+++ b/stock_move_location/wizard/stock_move_location.xml
@@ -7,16 +7,25 @@
     <field name="arch" type="xml">
       <form>
         <sheet>
+          <div class="oe_button_box" name="button_box"/>
+           <div>
+              <label for="edit_locations">
+                Edit Locations
+              </label>
+              <field name="edit_locations" widget="boolean_toggle"/>
+          </div>
           <group name="main">
-            <field name="origin_location_id" invisible="context.get('origin_location_disable', False)"/>
-            <field name="destination_location_id"/>
+              <field name="origin_location_disable" invisible="True"/>
+              <field name="origin_location_id" attrs="{'readonly': [('origin_location_disable', '=', True)]}"/>
+              <field name="destination_location_disable" invisible="True"/>
+              <field name="destination_location_id" attrs="{'readonly': [('destination_location_disable', '=', True)]}"/>
           </group>
           <group name="button" invisible="context.get('origin_location_disable', False)">
             <button name="add_lines" string="Add all" type="object" class="btn-primary"/>
             <button name="clear_lines" string="Clear all" type="object" class="btn-primary"/>
           </group>
           <group name="lines">
-            <field name="stock_move_location_line_ids" nolabel="1" >
+            <field name="stock_move_location_line_ids" nolabel="1" widget="one2many_list" mode="tree,kanban">
               <tree string="Inventory Details" editable="bottom" decoration-info="move_quantity != max_quantity" decoration-danger="(move_quantity &lt; 0) or (move_quantity > max_quantity)">
                   <field name="product_id"  domain="[('type','=','product')]"/>
                   <field name="product_uom_id" string="UoM" groups="product.group_uom"/>
@@ -27,6 +36,26 @@
                   <field name="custom" invisible="1" />
                   <field name="max_quantity" attrs="{'readonly': [('custom', '!=', True)]}" force_save="1"/>
               </tree>
+              <kanban class="o_kanban_mobile">
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div t-attf-class="oe_kanban_global_click">
+                                <div class="o_kanban_record_body">
+                                    <field name="product_id"/>
+                                    <field name="product_uom_id"/>
+                                    <field name="lot_id" groups="stock.group_production_lot"/>
+                                    <field name="origin_location_id"/>
+                                    <field name="destination_location_id"/>
+                                </div>
+                                <div class="o_kanban_record_bottom">
+                                    <div class="oe_kanban_bottom_right">
+                                        <span><field name="move_quantity"/></span>
+                                    </div>
+                                </div>
+                            </div>
+                        </t>
+                    </templates>
+              </kanban>
             </field>
           </group>
           <footer>

--- a/stock_move_location/wizard/stock_move_location_line.py
+++ b/stock_move_location/wizard/stock_move_location_line.py
@@ -102,12 +102,14 @@ class StockMoveLocationWizardLine(models.TransientModel):
     @api.multi
     def _get_move_line_values(self, picking, move):
         self.ensure_one()
+        qty_todo, qty_done = self._get_available_quantity()
         return {
             "product_id": self.product_id.id,
             "lot_id": self.lot_id.id,
             "location_id": self.origin_location_id.id,
             "location_dest_id": self.destination_location_id.id,
-            "qty_done": self._get_available_quantity(),
+            "product_uom_qty": qty_todo,
+            "qty_done": qty_done,
             "product_uom_id": self.product_uom_id.id,
             "picking_id": picking.id,
             "move_id": move.id,
@@ -123,7 +125,7 @@ class StockMoveLocationWizardLine(models.TransientModel):
             return 0
         if self.env.context.get("planned"):
             # for planned transfer we don't care about the amounts at all
-            return self.move_quantity
+            return self.move_quantity, 0
         search_args = [
             ('location_id', '=', self.origin_location_id.id),
             ('product_id', '=', self.product_id.id),
@@ -143,4 +145,4 @@ class StockMoveLocationWizardLine(models.TransientModel):
             available_qty, self.move_quantity, rounding) == -1
         if available_qty_lt_move_qty:
             return available_qty
-        return self.move_quantity
+        return 0, self.move_quantity


### PR DESCRIPTION
This PR introduces:
- The ability to start the wizard from a picking type in the inventory dashboard. A button "Move On Hand"

![image](https://user-images.githubusercontent.com/7683926/68722542-156eef80-05b6-11ea-95f1-1c51694b932d.png)


- You can define in the settings of the picking type if you want the button to appear for each picking type.
![image](https://user-images.githubusercontent.com/7683926/68722593-38999f00-05b6-11ea-80b8-8869f9857ea2.png)

- Pickings created using this button will adopt the corresponding picking type.

- Added toggle to edit the origin and destination locations. By default one cannot edit the origin and destination locations when they press the button from the picking type in the inventory dashboard.
![image](https://user-images.githubusercontent.com/7683926/68722661-74ccff80-05b6-11ea-9690-88d74e905ae6.png)

This last setting will be important in https://github.com/OCA/stock-logistics-barcode/pull/227




