### PR TITLE
[11.0][FIX] stock_secondary_unit: move line create round

### DIFF
--- a/stock_secondary_unit/models/stock_move.py
+++ b/stock_secondary_unit/models/stock_move.py
@@ -42,7 +42,7 @@ class StockMoveLine(models.Model):
                 'product_uom_qty', vals.get('qty_done', 0.0))
             qty = float_round(
                 move_line_qty / (factor or 1.0),
-                precision_rounding=move.secondary_uom_id.uom_id.factor
+                precision_rounding=move.secondary_uom_id.uom_id.rounding
             )
             vals.update({
                 'secondary_uom_qty': qty,


### PR DESCRIPTION
On move line creation, the precision of secondary qty rounding is wrong; the unit of measure factor is being used instead of rounding.