### PR TITLE
[11.0][FIX] Stock Request Order purchase button fix

### DIFF
--- a/stock_request_purchase/models/stock_request_order.py
+++ b/stock_request_purchase/models/stock_request_order.py
@@ -33,6 +33,10 @@ class StockRequestOrder(models.Model):
         purchases = self.mapped('purchase_ids')
         if len(purchases) > 1:
             action['domain'] = [('id', 'in', purchases.ids)]
+            action['views'] = [
+                (self.env.ref('purchase.purchase_order_tree').id, 'tree'),
+                (self.env.ref('purchase.purchase_order_form').id, 'form'),
+            ]
         elif purchases:
             action['views'] = [
                 (self.env.ref('purchase.purchase_order_form').id, 'form')]


### PR DESCRIPTION
When clicking on the purchase smart button with more than one purchase_id, it was opening a new form instead of a tree showing all the purchases.