### PR TITLE
[10.0][IMP] stock_lot_sale_tracking: Add tracking details

### DIFF
--- a/stock_lot_sale_tracking/__manifest__.py
+++ b/stock_lot_sale_tracking/__manifest__.py
@@ -19,6 +19,8 @@
     'data': [
         "security/security.xml",
         "report/stock_lot_sale_report.xml",
+        "views/sale_order.xml",
+        "views/stock_lot_sale_detail.xml",
     ],
     'installable': True,
 }

--- a/stock_lot_sale_tracking/models/__init__.py
+++ b/stock_lot_sale_tracking/models/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import stock_production_lot
+from . import sale_order

--- a/stock_lot_sale_tracking/models/sale_order.py
+++ b/stock_lot_sale_tracking/models/sale_order.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+
+    _inherit = 'sale.order'
+
+    sale_lot_tracking_ids = fields.One2many(
+        comodel_name='stock.lot.sale.tracking.detail',
+        string="Lot Tracking Detail",
+        inverse_name='order_id'
+    )
+    sale_lot_tracking_count = fields.Integer(
+        compute='_compute_sale_lot_tracking_count',
+    )
+
+    @api.multi
+    def action_view_lot_tracking_detail(self):
+        self.ensure_one()
+        ref = 'stock_lot_sale_tracking.action_stock_lot_sale_detail_from_sale'
+        sale_id = self.id
+        action_dict = self.env.ref(ref).read()[0]
+        action_dict['domain'] = [('order_id', '=', sale_id)]
+        return action_dict
+
+    @api.multi
+    @api.depends('sale_lot_tracking_ids')
+    def _compute_sale_lot_tracking_count(self):
+        for sale in self:
+            sale.sale_lot_tracking_count = len(sale.sale_lot_tracking_ids)

--- a/stock_lot_sale_tracking/report/__init__.py
+++ b/stock_lot_sale_tracking/report/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import stock_lot_sale_report
+from . import stock_lot_sale_tracking_detail

--- a/stock_lot_sale_tracking/report/stock_lot_sale_report.xml
+++ b/stock_lot_sale_tracking/report/stock_lot_sale_report.xml
@@ -61,6 +61,71 @@
         </t>
     </template>
 
+    <template id="report_lot_sale_tracking_detail_document">
+        <t t-call="report.internal_layout">
+            <div class="page">
+                <div class="oe_structure"/>
+                <h1>
+                    Lot Tracking Details
+                </h1>
+                <h2>
+                    <span t-field="doc.name"/>
+                </h2>
+                <table class="table table-condensed">
+                    <thead>
+                        <tr>
+                            <th name="so_title">Sale Order</th>
+                            <th name="ship_title">Shipped to</th>
+                            <th name="product_title">Product</th>
+                            <th name="internal_ref_title">Internal Reference</th>
+                            <th name="lot_title">Lot</th>
+                            <th name="picking_type_title">Operation Type</th>
+                            <th name="date_title">Shipment Date</th>
+                            <th class="text-right" name="qty_title">Quantity</th>
+                            <th class="text-right" name="value_title">Inventory Value</th>
+                        </tr>
+                   </thead>
+                   <tbody>
+                        <t t-foreach="doc.sale_lot_tracking_ids" t-as="l">
+                            <tr>
+                                <td name="so"><span t-field="l.order_id"/></td>
+                                <td name="ship"><span t-field="l.order_id.partner_shipping_id"/></td>
+                                <td name="product"><span t-field="l.product_id"/></td>
+                                <td name="internal_ref"><span t-field="l.default_code"/></td>
+                                <td name="lot"><span t-field="l.lot_id"/></td>
+                                <td name="picking_type"><span t-field="l.picking_type_id"/></td>
+                                <td name="date"><span t-field="l.date"/></td>
+                                <td name="qty" class="text-right">
+                                    <span t-field="l.product_uom_qty"/>
+                                    <span t-field="l.product_uom" groups="product.group_uom"/>
+                                </td>
+                                <td name="value">
+                                     <span t-field="l.inventory_value"/>
+                                </td>
+                            </tr>
+                        </t>
+                   </tbody>
+                </table>
+            </div>
+        </t>
+    </template>
+
+    <template id="report_lot_sale_tracking_detail">
+        <t t-call="report.html_container">
+            <t t-foreach="docs" t-as="doc">
+                <t t-call="stock_lot_sale_tracking.report_lot_sale_tracking_detail_document"/>
+            </t>
+        </t>
+    </template>
+
+    <report
+            id="report_stock_lot_sale_tracking_detail"
+            string="Deliveries Tracking Detail"
+            model="sale.order"
+            report_type="qweb-html"
+            file="stock_lot_sale_tracking.report_lot_sale_tracking_detail"
+            name="stock_lot_sale_tracking.report_lot_sale_tracking_detail"/>
+
     <report
             id="report_stock_lot_sale_tracking"
             string="Deliveries Tracking"
@@ -70,6 +135,10 @@
             name="stock_lot_sale_tracking.report_lot_sale_tracking"/>
 
     <record model="ir.actions.report.xml" id="report_stock_lot_sale_tracking">
+        <field name="paperformat_id"
+               ref="stock_lot_sale_tracking.paperformat_a4_landscape"/>
+    </record>
+    <record model="ir.actions.report.xml" id="report_stock_lot_sale_tracking_detail">
         <field name="paperformat_id"
                ref="stock_lot_sale_tracking.paperformat_a4_landscape"/>
     </record>

--- a/stock_lot_sale_tracking/report/stock_lot_sale_tracking_detail.py
+++ b/stock_lot_sale_tracking/report/stock_lot_sale_tracking_detail.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from odoo import tools
+from odoo import api, fields, models
+from odoo.addons import decimal_precision as dp
+
+
+class StockLotSaleTrackingDetail(models.Model):
+    _name = "stock.lot.sale.tracking.detail"
+    _description = "Stock Lot Sale Tracking Detail"
+    _auto = False
+
+    lot_id = fields.Many2one(
+        comodel_name='stock.production.lot',
+        string='Lot/Serial Number',
+        readonly=True)
+    move_id = fields.Many2one(
+        comodel_name='stock.move',
+        readonly=True,
+    )
+    picking_type_id = fields.Many2one(
+        comodel_name='stock.picking.type',
+        string='Operation Type',
+        readonly=True,
+    )
+    order_id = fields.Many2one(
+        comodel_name='sale.order',
+        string='Sale Order',
+        readonly=True)
+    partner_id = fields.Many2one(
+        comodel_name='res.partner',
+        string='Partner',
+        readonly=True,
+    )
+
+    product_id = fields.Many2one(
+        comodel_name='product.product',
+        string='Product',
+        readonly=True)
+    default_code = fields.Char(
+        related='product_id.default_code',
+        readonly=True,
+    )
+    quant_id = fields.Many2one(
+        comodel_name='stock.quant',
+        readonly=True,
+    )
+    date = fields.Datetime(
+        string='Delivery Date',
+        readonly=True)
+    product_uom = fields.Many2one(
+        comodel_name='product.uom',
+        string='Unit of Measure',
+        readonly=True)
+    company_id = fields.Many2one(
+        comodel_name='res.company',
+        string='Company',
+        readonly=True)
+    product_uom_qty = fields.Float(
+        string='Quantity',
+        digits=dp.get_precision('Product Unit of Measure'),
+        readonly=True)
+    inventory_value = fields.Float(
+        related='quant_id.inventory_value',
+        readonly=True,
+    )
+
+    def _get_select_columns(self):
+        columns = [
+            'row_number() OVER() AS id',
+            'sq.lot_id',
+            'so.id as order_id',
+            'sm.product_id',
+            'sm.id as move_id',
+            'sq.id as quant_id',
+            'sm.picking_type_id',
+            'sm.partner_id',
+            'sm.date',
+            'sm.product_uom',
+            'sm.company_id',
+            'sq.qty as product_uom_qty'
+        ]
+        return columns
+
+    def _get_from(self):
+        sql_from = [
+            'stock_move sm',
+            'JOIN stock_location loc ON loc.id = sm.location_dest_id',
+            'JOIN stock_quant_move_rel sq_mv ON sq_mv.move_id = sm.id',
+            'JOIN stock_quant sq ON sq.id = sq_mv.quant_id',
+            'LEFT JOIN sale_order so ON so.procurement_group_id = sm.group_id',
+        ]
+        return sql_from
+
+    def _get_where(self):
+        sql_where = " WHERE loc.usage = 'customer' AND sm.state = 'done'"
+        return sql_where
+
+    def _get_group_by(self):
+        sql_group_by = [
+            'sq.lot_id',
+            'so.id',
+            'sm.id',
+            'sm.product_id',
+            'sm.partner_id',
+            'sq.id',
+            'sm.picking_type_id',
+            'sm.date',
+            'sm.product_uom',
+            'sm.company_id',
+        ]
+        return sql_group_by
+
+    def _get_order_by(self):
+        sql_order_by = [
+            'so.id',
+            'sm.product_id',
+            'sm.date',
+            'sm.product_uom',
+            'sm.company_id',
+        ]
+        return sql_order_by
+
+    def _prepare_sql(self):
+        sql = "SELECT "
+        sql += ", ".join([select for select in self._get_select_columns()])
+        sql += " FROM "
+        sql += " ".join([sql_from for sql_from in self._get_from()])
+        sql += self._get_where()
+        sql += " GROUP BY "
+        sql += ", ".join([group for group in self._get_group_by()])
+        sql += " ORDER BY "
+        sql += ", ".join([order for order in self._get_order_by()])
+        return sql
+
+    @api.model_cr
+    def init(self):
+        sql = """CREATE or REPLACE VIEW stock_lot_sale_tracking_detail as ("""
+        sql += self._prepare_sql()
+        sql += """)"""
+        tools.drop_view_if_exists(self.env.cr, self._table)
+        self.env.cr.execute(sql)

--- a/stock_lot_sale_tracking/security/security.xml
+++ b/stock_lot_sale_tracking/security/security.xml
@@ -8,4 +8,13 @@
         <field name="perm_write" eval="0"/>
         <field name="perm_unlink" eval="0"/>
     </record>
+
+    <record model="ir.model.access" id="stock_lot_tracking_detail_access_everybody">
+        <field name="name">Stock Lot Sale Tracking detail: access everybody</field>
+        <field name="model_id" ref="model_stock_lot_sale_tracking_detail"/>
+        <field name="perm_read" eval="1"/>
+        <field name="perm_create" eval="0"/>
+        <field name="perm_write" eval="0"/>
+        <field name="perm_unlink" eval="0"/>
+    </record>
 </odoo>

--- a/stock_lot_sale_tracking/tests/__init__.py
+++ b/stock_lot_sale_tracking/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_lot_tracking_detail

--- a/stock_lot_sale_tracking/tests/test_lot_tracking_detail.py
+++ b/stock_lot_sale_tracking/tests/test_lot_tracking_detail.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests import common
+
+
+class TestLotTrackingDetail(common.TransactionCase):
+
+    def setUp(self):
+        super(TestLotTrackingDetail, self).setUp()
+        self.sale_obj = self.env['sale.order']
+        self.sale_line_obj = self.env['sale.order.line']
+        self.chg_qty_obj = self.env['stock.change.product.qty']
+        self.lot_icecream = self.env.ref('stock.lot_icecream_0')
+        self.lot_icecream_1 = self.env.ref('stock.lot_icecream_1')
+        self.picking_type_out = self.env.ref('stock.picking_type_out')
+        self.picking_type_out.use_existing_lots = True
+        self.partner_1 = self.env.ref('base.res_partner_1')
+        self.shipping_1 = self.env.ref('base.res_partner_address_1')
+        self.stock = self.env.ref('stock.stock_location_stock')
+        self.lot_icecream.product_id.tracking = 'lot'
+        vals = {
+            'partner_id': self.partner_1.id,
+            'partner_shipping_id': self.shipping_1.id,
+        }
+        self.order = self.sale_obj.create(vals)
+        vals = {
+            'order_id': self.order.id,
+            'product_id': self.lot_icecream.product_id.id,
+            'product_uom_qty': 5.0,
+            'product_uom': self.lot_icecream.product_id.uom_id.id,
+        }
+        self.line_1 = self.sale_line_obj.create(vals)
+
+        vals = {
+            'product_id': self.lot_icecream.product_id.id,
+            'new_quantity': 2.0,
+            'lot_id': self.lot_icecream.id,
+            'location_id': self.stock.id,
+        }
+        wizard = self.chg_qty_obj.create(vals)
+        wizard.change_product_qty()
+
+        vals = {
+            'product_id': self.lot_icecream.product_id.id,
+            'new_quantity': 3.0,
+            'lot_id': self.lot_icecream_1.id,
+            'location_id': self.stock.id,
+        }
+        wizard = self.chg_qty_obj.create(vals)
+        wizard.change_product_qty()
+
+    def test_lot_tracking(self):
+        self.order.action_confirm()
+        pickings = self.order.picking_ids.filtered(
+            lambda p: p.location_dest_id.usage == 'customer')
+        self.assertEquals(
+            1,
+            len(pickings)
+        )
+        self.assertEquals(
+            2,
+            len(pickings.pack_operation_product_ids.pack_lot_ids)
+        )
+        for pack_lot in pickings.pack_operation_product_ids.pack_lot_ids:
+            if pack_lot.lot_id == self.lot_icecream:
+                pack_lot.qty = 2.0
+            if pack_lot.lot_id == self.lot_icecream_1:
+                pack_lot.qty = 3.0
+        pickings.action_done()
+        self.assertEquals(
+            2,
+            self.order.sale_lot_tracking_count
+        )
+        self.assertEquals(
+            2,
+            len(self.order.sale_lot_tracking_ids)
+        )

--- a/stock_lot_sale_tracking/views/sale_order.xml
+++ b/stock_lot_sale_tracking/views/sale_order.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale.order.form (in stock_lot_sale_tracking)</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button name="action_view_lot_tracking_detail"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-barcode"
+                    attrs="{'invisible': [('sale_lot_tracking_count', '=', 0)]}">
+                    <div class="o_form_field o_stat_info">
+                        <span class="o_stat_value"><field name="sale_lot_tracking_count"/></span>
+                        <span class="o_stat_text">Lot Tracking Detail</span>
+                    </div>
+                </button>
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/stock_lot_sale_tracking/views/stock_lot_sale_detail.xml
+++ b/stock_lot_sale_tracking/views/stock_lot_sale_detail.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_stock_lot_sale_detail_tree" model="ir.ui.view">
+        <field name="name">stock.lot.sale.detail.tree (in stock_lot_sale_tracking)</field>
+        <field name="model">stock.lot.sale.tracking.detail</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="order_id"/>
+                <field name="partner_id"/>
+                <field name="product_id"/>
+                <field name="default_code"/>
+                <field name="lot_id"/>
+                <field name="picking_type_id"/>
+                <field name="date"/>
+                <field name="product_uom_qty"/>
+                <field name="inventory_value"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_stock_lot_sale_detail_search" model="ir.ui.view">
+        <field name="name">stock.lot.sale.detail.search (in stock_lot_sale_tracking)</field>
+        <field name="model">stock.lot.sale.tracking.detail</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="order_id"/>
+                <field name="partner_id"/>
+                <field name="product_id"/>
+                <field name="lot_id"/>
+                <field name="date"/>
+                <field name="picking_type_id"/>
+                <filter name="today" string="Today" domain="[('date', '>=', datetime.datetime.combine(context_today(), datetime.time(0,0,0)))]"/>
+                <filter name="last_week" string="Last Week" domain="[('date','&gt;', (context_today() - datetime.timedelta(weeks=1)).strftime('%%Y-%%m-%%d') )]"/>
+                <filter name="last_week" string="Last Month" domain="[('date','&gt;', (context_today() - datetime.timedelta(weeks=4)).strftime('%%Y-%%m-%%d') )]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Operation Type" name="groupby_picking_type" domain="[]" context="{'group_by':'picking_type_id'}"/>
+                    <filter string="Lot" name="groupby_lot" domain="[]" context="{'group_by':'lot_id'}"/>
+                    <filter string="Partner" name="groupby_partner" domain="[]" context="{'group_by':'partner_id'}"/>
+                    <filter string="Sale Order" name="groupby_order" domain="[]" context="{'group_by':'order_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_stock_lot_sale_detail" model="ir.actions.act_window">
+        <field name="name">Lot Tracking Detail</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.lot.sale.tracking.detail</field>
+        <field name="view_mode">tree</field>
+       <field name="context">{'search_default_today': 1, 'search_default_groupby_lot': 1}</field>
+    </record>
+
+    <record id="action_stock_lot_sale_detail_from_sale" model="ir.actions.act_window">
+        <field name="name">Lot Tracking Detail</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.lot.sale.tracking.detail</field>
+        <field name="view_mode">tree</field>
+    </record>
+
+    <menuitem id="stock_lot_tracking_detail_menu"
+              action="action_stock_lot_sale_detail"
+              parent="stock.menu_warehouse_report"
+              sequence="30"/>
+
+</odoo>


### PR DESCRIPTION
When tracking delivery lots is important, it's quite useful to retrieve delivered ones from sale order.

This adds : 

- A button link on Sale Order level
- A report entry menu in Inventory


![image](https://user-images.githubusercontent.com/19529533/68932550-26c12300-0793-11ea-88de-3546e1719c13.png)

![image](https://user-images.githubusercontent.com/19529533/68932575-3476a880-0793-11ea-9dcd-5b1f02061816.png)

![image](https://user-images.githubusercontent.com/19529533/68932711-74d62680-0793-11ea-8a77-d235a9722a6b.png)
