### PR TITLE
[8.0] Add missing index

### DIFF
--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -28,7 +28,8 @@ class ProcurementOrder(models.Model):
     mts_mto_procurement_id = fields.Many2one(
         'procurement.order',
         string="Mto+Mts Procurement",
-        copy=False)
+        copy=False,
+        index=True)
     mts_mto_procurement_ids = fields.One2many(
         'procurement.order',
         'mts_mto_procurement_id',


### PR DESCRIPTION
In case of big table adding the index on mts_mto_procurement_id
improve the speed to read of mts_mto_procurement_ids

Same PR as https://github.com/OCA/stock-logistics-warehouse/pull/775