### PR TITLE
[9.0] Add missing index

### DIFF
--- a/stock_mts_mto_rule/__openerp__.py
+++ b/stock_mts_mto_rule/__openerp__.py
@@ -21,7 +21,7 @@
 ##############################################################################
 
 {'name': 'Stock MTS+MTO Rule',
- 'version': '9.0.1.0.0',
+ 'version': '9.0.1.1.0',
  'author': 'Akretion,Odoo Community Association (OCA)',
  'website': 'http://www.akretion.com',
  'license': 'AGPL-3',

--- a/stock_mts_mto_rule/model/procurement.py
+++ b/stock_mts_mto_rule/model/procurement.py
@@ -28,7 +28,8 @@ class ProcurementOrder(models.Model):
     mts_mto_procurement_id = fields.Many2one(
         'procurement.order',
         string="Mto+Mts Procurement",
-        copy=False)
+        copy=False,
+        index=True)
     mts_mto_procurement_ids = fields.One2many(
         'procurement.order',
         'mts_mto_procurement_id',


### PR DESCRIPTION
In case of big table adding the index on mts_mto_procurement_id
improve the speed to read of mts_mto_procurement_ids

same PR as https://github.com/OCA/stock-logistics-warehouse/pull/775