### PR TITLE
[13.0] Add isort third party detection from requirements.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+requirements.txt merge=union

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -9,4 +9,3 @@ line_length=88
 known_odoo=odoo
 known_odoo_addons=odoo.addons
 sections=FUTURE,STDLIB,THIRDPARTY,ODOO,ODOO_ADDONS,FIRSTPARTY,LOCALFOLDER
-known_third_party=setuptools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     name: isort except __init__.py
     'types': [python]
     exclude: /__init__\.py$
-    additional_dependencies: [pipreqs, pip-api]
+    additional_dependencies: ["pipreqs==0.4.10", "pip-api==0.0.13"]
 - repo: https://github.com/pre-commit/mirrors-eslint
   rev: v6.5.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,16 +51,14 @@ repos:
   rev: v1.24.0
   hooks:
   - id: pyupgrade
-- repo: https://github.com/asottile/seed-isort-config
-  rev: v1.9.3
-  hooks:
-  - id: seed-isort-config
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+- repo: https://github.com/timothycrosley/isort
+  rev: 4.3.21-2
   hooks:
   - id: isort
     name: isort except __init__.py
+    'types': [python]
     exclude: /__init__\.py$
+    additional_dependencies: [pipreqs, pip-api]
 - repo: https://github.com/pre-commit/mirrors-eslint
   rev: v6.5.1
   hooks:


### PR DESCRIPTION
The current setup used in the OCA for isort is done by using 2
pre-commit hooks:

1. seed-isort-config: find third-party libs and updates the '.isort.cfg' file's "known_third_party" with the list
2. isort: runs isort, which will use the list of third party libs provided by 'seed-isort-config'

This is [an issue](https://github.com/OCA/maintainer-quality-tools/issues/625) with the workflow adopted by many contributors of the OCA: as the pull requests may need some time to be merged, we use temporary branches where we aggregate the various PRs.

If several pull requests add a third party library, we'll have a conflict, and when the process of merging these pull requests is automated (e.g. with [git-aggregator](https://github.com/acsone/git-aggregator)), it becomes tedious.

The list of libs in the "known_third_party" variable is not even editable manually, as "seed-isort-config" overwrite the value on every commit: it doesn't really make sense to actually store this.

As [pointed out](https://github.com/OCA/maintainer-quality-tools/issues/625#issuecomment-573094697) by @sbidoul, isort mentions in their changelog:

> Support for using requirements files to auto determine third-paty
> section if pipreqs & requirementslib are installed.

Which is the goal of this change, whose details are:

* Remove 'seed-isort-config' from pre-commit as the list of libs will be
  provided by requirements.txt
* Replace the isort pre-commit repo by the official repo (the mirror says
  it is been deprecated in favor of the official repo)
* Adds [pipreqs and pip-api](https://github.com/timothycrosley/isort/blob/500bafabbd51a6005c11a00c4738a2438990e48a/pyproject.toml#L42) in additional dependencies to activate isort's feature to read requirements.txt
* Adds types: [python] in the pre-commit config: the mirror had it and the official repo doesn't. Without it, some files such as .pot are modified (different EOF).
* Add an union merge driver on 'requirements.txt' to resolve conflicts
on this file (on conflicts, both lines are kept, which works in most
cases on this file)

Alternatively, we could evaluate ['reorder-python-imports'](https://github.com/asottile/reorder_python_imports) in place of 'isort'

I propose to evaluate this configuration on this repository, since this is where I ran into the issue. If the result is good (my first test shows it should), then we can apply the same commit on https://github.com/OCA/maintainer-quality-tools
