### PR TITLE
[13.0][FIX] Fix compute contains_unreserved on NewId records

### DIFF
--- a/stock_available_unreserved/models/quant.py
+++ b/stock_available_unreserved/models/quant.py
@@ -17,6 +17,10 @@ class StockQuant(models.Model):
     @api.depends("product_id", "location_id", "quantity", "reserved_quantity")
     def _compute_contains_unreserved(self):
         for record in self:
+            # Avoid error when adding a new line on manually Update Quantity
+            if isinstance(record.id, models.NewId):
+                record.contains_unreserved = False
+                continue
             available = record._get_available_quantity(
                 record.product_id, record.location_id
             )


### PR DESCRIPTION
This PR aim to fix an error found when updating product quantities from product card.
```
Error:
Odoo Server Error

Traceback (most recent call last):
  File "/.repo_requirements/odoo/odoo/http.py", line 619, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/.repo_requirements/odoo/odoo/http.py", line 309, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/.repo_requirements/odoo/odoo/tools/pycompat.py", line 14, in reraise
    raise value
  File "/.repo_requirements/odoo/odoo/http.py", line 664, in dispatch
    result = self._call_function(**self.params)
  File "/.repo_requirements/odoo/odoo/http.py", line 345, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/service/model.py", line 93, in wrapper
    return f(dbname, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/http.py", line 338, in checked_call
    result = self.endpoint(*a, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 909, in __call__
    return self.method(*args, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 510, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/odoo-13.0/addons/web/controllers/main.py", line 1319, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/odoo-13.0/addons/web/controllers/main.py", line 1311, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 396, in call_kw
    model.flush()
  File "/.repo_requirements/odoo/odoo/models.py", line 5368, in flush
    self.recompute()
  File "/.repo_requirements/odoo/odoo/models.py", line 5770, in recompute
    process(next(iter(fields_to_compute)))
  File "/.repo_requirements/odoo/odoo/models.py", line 5753, in process
    recs.mapped(field.name)
  File "/.repo_requirements/odoo/odoo/models.py", line 5185, in mapped
    recs = recs._mapped_func(operator.itemgetter(name))
  File "/.repo_requirements/odoo/odoo/models.py", line 5144, in _mapped_func
    vals = [func(rec) for rec in self]
  File "/.repo_requirements/odoo/odoo/models.py", line 5144, in <listcomp>
    vals = [func(rec) for rec in self]
  File "/.repo_requirements/odoo/odoo/models.py", line 5589, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/.repo_requirements/odoo/odoo/fields.py", line 973, in __get__
    self.compute_value(recs)
  File "/.repo_requirements/odoo/odoo/fields.py", line 1087, in compute_value
    records._compute_field_value(self)
  File "/.repo_requirements/odoo/odoo/models.py", line 3905, in _compute_field_value
    getattr(self, field.compute)()
  File "/home/odoo/build/OCA/stock-logistics-warehouse/stock_available_unreserved/models/quant.py", line 21, in _compute_contains_unreserved
    record.product_id, record.location_id
  File "/home/odoo/odoo-13.0/addons/stock/models/stock_quant.py", line 328, in _get_available_quantity
    return sum([available_quantity for available_quantity in availaible_quantities.values() if float_compare(available_quantity, 0, precision_rounding=rounding) > 0])
  File "/home/odoo/odoo-13.0/addons/stock/models/stock_quant.py", line 328, in <listcomp>
    return sum([available_quantity for available_quantity in availaible_quantities.values() if float_compare(available_quantity, 0, precision_rounding=rounding) > 0])
  File "/.repo_requirements/odoo/odoo/tools/float_utils.py", line 156, in float_compare
    precision_rounding=precision_rounding)
  File "/.repo_requirements/odoo/odoo/tools/float_utils.py", line 30, in _float_check_precision
    "precision_rounding must be positive, got %s" % precision_rounding
AssertionError: precision_rounding must be positive, got 0.0
```
CC @ForgeFlow @LoisRForgeFlow 