### PR TITLE
[12.0] [WIP] [IMP] stock_quant_manual_assign set quantity done optional by picking…

### DIFF
--- a/stock_quant_manual_assign/README.rst
+++ b/stock_quant_manual_assign/README.rst
@@ -23,7 +23,7 @@ Stock - Manual Quant Assignment
     :target: https://runbot.odoo-community.org/runbot/153/12.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module allows you to manually change the automatic quant selection.
 
@@ -78,6 +78,10 @@ Contributors
 
   * Jordi Ballester <jordi.ballester@eficent.com>
   * Lois Rilo <lois.rilo@eficent.com>
+
+* `PESOL <https://pesol.es>`_:
+
+  * Angel Moya <angel.moya@pesol.es>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_quant_manual_assign/__init__.py
+++ b/stock_quant_manual_assign/__init__.py
@@ -1,1 +1,2 @@
 from . import wizard
+from . import models

--- a/stock_quant_manual_assign/__manifest__.py
+++ b/stock_quant_manual_assign/__manifest__.py
@@ -3,6 +3,7 @@
 # Copyright 2018 Fanha Giang
 # Copyright 2018 Tecnativa - Vicent Cubells
 # Copyright 2016-2018 Tecnativa - Pedro M. Baeza
+# Copyright 2020 PESOL - Angel Moya
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {
@@ -22,6 +23,7 @@
     "data": [
         "wizard/assign_manual_quants_view.xml",
         "views/stock_move_view.xml",
+        "views/stock_picking_type_view.xml"
     ],
     "installable": True,
 }

--- a/stock_quant_manual_assign/models/__init__.py
+++ b/stock_quant_manual_assign/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking_type

--- a/stock_quant_manual_assign/models/stock_picking_type.py
+++ b/stock_quant_manual_assign/models/stock_picking_type.py
@@ -1,0 +1,12 @@
+# Copyright 2020 PESOL - Angel Moya
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import fields, models
+
+
+class PickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    quant_manual_assign_update_qty_done = fields.Boolean(
+        string='Update Qty Done On Quant Manual Assign',
+        default=True)

--- a/stock_quant_manual_assign/readme/CONFIGURE.rst
+++ b/stock_quant_manual_assign/readme/CONFIGURE.rst
@@ -1,0 +1,1 @@
+On /Inventory/Configuration/Operation Types you can configure to set quantity done or not on manual quants assign.

--- a/stock_quant_manual_assign/views/stock_picking_type_view.xml
+++ b/stock_quant_manual_assign/views/stock_picking_type_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="stock_picking_type_manual_quants_form_view">
+        <field name="name">stock.picking.type.form</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='show_reserved']" position="after">
+                <field name="quant_manual_assign_update_qty_done" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -53,8 +53,10 @@ class AssignManualQuants(models.TransientModel):
         for line in self.quants_lines:
             line._assign_quant_line()
         # Auto-fill all lines as done
-        for ml in move.move_line_ids:
-            ml.qty_done = ml.product_qty
+        # if it is configured on picking type
+        if move.picking_id.picking_type_id.quant_manual_assign_update_qty_done:
+            for ml in move.move_line_ids:
+                ml.qty_done = ml.product_qty
         move._recompute_state()
         move.mapped('picking_id')._compute_state()
         return {}


### PR DESCRIPTION
On module stock_quant_manual_assign, whe you set manually a quant on stock move, this quant is reserved and done.

We need to manually reserve, but do not update quantity done.

To be consistent with previous development we decided to do it configurable, depending on picking type, this way previous installation will work same way, but now we can configure by picking type if we want reserve or update quantity done.