### PR TITLE
[13.0] Create module stock_location_children

### DIFF
--- a/setup/stock_location_children/odoo/addons/stock_location_children
+++ b/setup/stock_location_children/odoo/addons/stock_location_children
@@ -1,0 +1,1 @@
+../../../../stock_location_children

--- a/setup/stock_location_children/setup.py
+++ b/setup/stock_location_children/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_location_children/__init__.py
+++ b/stock_location_children/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_location_children/__manifest__.py
+++ b/stock_location_children/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock location children",
+    "summary": "Add relation between stock location and all its children",
+    "version": "13.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["stock"],
+}

--- a/stock_location_children/models/__init__.py
+++ b/stock_location_children/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_location

--- a/stock_location_children/models/stock_location.py
+++ b/stock_location_children/models/stock_location.py
@@ -5,19 +5,19 @@ from odoo import api, fields, models
 
 class StockLocation(models.Model):
 
-    _inherit = 'stock.location'
+    _inherit = "stock.location"
 
     children_ids = fields.Many2many(
-        'stock.location',
-        'stock_location_children_ids',
-        'parent_id',
-        'children_id',
-        compute='_compute_children_ids',
+        "stock.location",
+        "stock_location_children_ids",
+        "parent_id",
+        "children_id",
+        compute="_compute_children_ids",
         store=True,
-        help='All the children (multi-level) stock location of this location',
+        help="All the children (multi-level) stock location of this location",
     )
 
-    @api.depends('child_ids', 'child_ids.children_ids')
+    @api.depends("child_ids", "child_ids.children_ids")
     def _compute_children_ids(self):
         query = """SELECT sub.id, ARRAY_AGG(sl2.id) AS children
             FROM stock_location sl2,
@@ -35,8 +35,8 @@ class StockLocation(models.Model):
         for loc in self:
             all_ids = []
             for row in rows:
-                if row.get('id') == loc.id:
-                    all_ids = row.get('children')
+                if row.get("id") == loc.id:
+                    all_ids = row.get("children")
                     break
             if all_ids:
                 loc.children_ids = [(6, 0, all_ids)]

--- a/stock_location_children/models/stock_location.py
+++ b/stock_location_children/models/stock_location.py
@@ -17,7 +17,7 @@ class StockLocation(models.Model):
         help="All the children (multi-level) stock location of this location",
     )
 
-    @api.depends("child_ids", "child_ids.child_ids")
+    @api.depends("child_ids", "children_ids.child_ids")
     def _compute_children_ids(self):
         query = """SELECT sub.id, ARRAY_AGG(sl2.id) AS children
             FROM stock_location sl2,
@@ -30,6 +30,7 @@ class StockLocation(models.Model):
             AND sub.id IN %s
             GROUP BY sub.id;
         """
+        self.flush(["location_id", "child_ids"])
         self.env.cr.execute(query, (tuple(self.ids),))
         rows = self.env.cr.dictfetchall()
         for loc in self:

--- a/stock_location_children/models/stock_location.py
+++ b/stock_location_children/models/stock_location.py
@@ -17,7 +17,7 @@ class StockLocation(models.Model):
         help="All the children (multi-level) stock location of this location",
     )
 
-    @api.depends("child_ids", "child_ids.children_ids")
+    @api.depends("child_ids", "child_ids.child_ids")
     def _compute_children_ids(self):
         query = """SELECT sub.id, ARRAY_AGG(sl2.id) AS children
             FROM stock_location sl2,

--- a/stock_location_children/models/stock_location.py
+++ b/stock_location_children/models/stock_location.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+
+class StockLocation(models.Model):
+
+    _inherit = 'stock.location'
+
+    children_ids = fields.Many2many(
+        'stock.location',
+        'stock_location_children_ids',
+        'parent_id',
+        'children_id',
+        compute='_compute_children_ids',
+        store=True,
+        help='All the children (multi-level) stock location of this location',
+    )
+
+    @api.depends('child_ids', 'child_ids.children_ids')
+    def _compute_children_ids(self):
+        for loc in self:
+            if not loc.child_ids.mapped('child_ids'):
+                all_children = loc.child_ids
+            else:
+                all_children = loc.child_ids | loc.child_ids.children_ids
+            loc.children_ids = all_children

--- a/stock_location_children/readme/CONTRIBUTORS.rst
+++ b/stock_location_children/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/stock_location_children/readme/DESCRIPTION.rst
+++ b/stock_location_children/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module adds a `children_ids` field on `stock.location` in order to compute
+and store all the children for a `stock.location` and not only its first level
+children as is the case for `child_ids`.

--- a/stock_location_children/tests/__init__.py
+++ b/stock_location_children/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_location_children

--- a/stock_location_children/tests/test_stock_location_children.py
+++ b/stock_location_children/tests/test_stock_location_children.py
@@ -1,0 +1,77 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import SavepointCase
+
+
+class TestStockLocationChildren(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        ref = cls.env.ref
+        cls.stock_input = ref("stock.stock_location_company")
+        cls.stock_location = ref("stock.stock_location_stock")
+        cls.stock_shelf_1 = ref("stock.stock_location_components")
+        cls.stock_shelf_2 = ref("stock.stock_location_14")
+        cls.stock_shelf_2_refrigerator = ref(
+            "stock.location_refrigerator_small"
+        )
+
+    def test_location_children(self):
+        self.assertFalse(self.stock_shelf_2_refrigerator.child_ids)
+        self.assertEqual(
+            self.stock_shelf_2.child_ids,
+            self.stock_shelf_2_refrigerator
+        )
+        self.assertEqual(
+            self.stock_shelf_2.child_ids,
+            self.stock_shelf_2.children_ids
+        )
+        self.assertFalse(self.stock_shelf_1.child_ids)
+        self.assertFalse(self.stock_shelf_1.children_ids)
+        self.assertEqual(
+            self.stock_location.child_ids,
+            self.stock_shelf_1 | self.stock_shelf_2
+        )
+        self.assertEqual(
+            self.stock_location.children_ids,
+            self.stock_shelf_1 | self.stock_shelf_2 | self.stock_shelf_2_refrigerator
+        )
+
+    def test_create_write_location(self):
+        refrigerator_drawer = self.env['stock.location'].create({
+            'name': 'Refrigerator drawer',
+            'location_id': self.stock_shelf_2_refrigerator.id
+        })
+        self.assertEqual(
+            self.stock_shelf_2_refrigerator.child_ids,
+            refrigerator_drawer
+        )
+        self.assertEqual(
+            self.stock_shelf_2_refrigerator.children_ids,
+            refrigerator_drawer
+        )
+        self.assertEqual(
+            self.stock_shelf_2.children_ids,
+            self.stock_shelf_2_refrigerator | refrigerator_drawer
+        )
+        self.assertEqual(
+            self.stock_location.children_ids,
+            self.stock_shelf_1 | self.stock_shelf_2 |
+            self.stock_shelf_2_refrigerator | refrigerator_drawer
+        )
+        refrigerator_drawer.location_id = self.stock_input
+        self.assertFalse(self.stock_shelf_2_refrigerator.child_ids)
+        self.assertEqual(
+            self.stock_shelf_2.child_ids,
+            self.stock_shelf_2_refrigerator
+        )
+        self.assertEqual(
+            self.stock_shelf_2.child_ids,
+            self.stock_shelf_2.children_ids
+        )
+        self.assertEqual(
+            self.stock_location.children_ids,
+            self.stock_shelf_1 | self.stock_shelf_2 | self.stock_shelf_2_refrigerator
+        )

--- a/stock_location_children/tests/test_stock_location_children.py
+++ b/stock_location_children/tests/test_stock_location_children.py
@@ -11,9 +11,18 @@ class TestStockLocationChildren(SavepointCase):
         ref = cls.env.ref
         cls.stock_input = ref("stock.stock_location_company")
         cls.stock_location = ref("stock.stock_location_stock")
-        cls.stock_shelf_1 = ref("stock.stock_location_components")
-        cls.stock_shelf_2 = ref("stock.stock_location_14")
-        cls.stock_shelf_2_refrigerator = ref("stock.location_refrigerator_small")
+        cls.test_location = cls.env["stock.location"].create(
+            {"name": "Test Location", "location_id": cls.stock_location.id}
+        )
+        cls.stock_shelf_1 = cls.env["stock.location"].create(
+            {"name": "Test Shelf 1", "location_id": cls.test_location.id}
+        )
+        cls.stock_shelf_2 = cls.env["stock.location"].create(
+            {"name": "Test Shelf 2", "location_id": cls.test_location.id}
+        )
+        cls.stock_shelf_2_refrigerator = cls.env["stock.location"].create(
+            {"name": "Test Shelf Refrigerator", "location_id": cls.stock_shelf_2.id}
+        )
 
     def test_location_children(self):
         self.assertFalse(self.stock_shelf_2_refrigerator.child_ids)
@@ -22,10 +31,10 @@ class TestStockLocationChildren(SavepointCase):
         self.assertFalse(self.stock_shelf_1.child_ids)
         self.assertFalse(self.stock_shelf_1.children_ids)
         self.assertEqual(
-            self.stock_location.child_ids, self.stock_shelf_1 | self.stock_shelf_2
+            self.test_location.child_ids, self.stock_shelf_1 | self.stock_shelf_2
         )
         self.assertEqual(
-            self.stock_location.children_ids,
+            self.test_location.children_ids,
             self.stock_shelf_1 | self.stock_shelf_2 | self.stock_shelf_2_refrigerator,
         )
 
@@ -45,7 +54,7 @@ class TestStockLocationChildren(SavepointCase):
             self.stock_shelf_2_refrigerator | refrigerator_drawer,
         )
         self.assertEqual(
-            self.stock_location.children_ids,
+            self.test_location.children_ids,
             self.stock_shelf_1
             | self.stock_shelf_2
             | self.stock_shelf_2_refrigerator
@@ -56,6 +65,6 @@ class TestStockLocationChildren(SavepointCase):
         self.assertEqual(self.stock_shelf_2.child_ids, self.stock_shelf_2_refrigerator)
         self.assertEqual(self.stock_shelf_2.child_ids, self.stock_shelf_2.children_ids)
         self.assertEqual(
-            self.stock_location.children_ids,
+            self.test_location.children_ids,
             self.stock_shelf_1 | self.stock_shelf_2 | self.stock_shelf_2_refrigerator,
         )

--- a/stock_location_children/tests/test_stock_location_children.py
+++ b/stock_location_children/tests/test_stock_location_children.py
@@ -4,7 +4,6 @@ from odoo.tests import SavepointCase
 
 
 class TestStockLocationChildren(SavepointCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -14,64 +13,49 @@ class TestStockLocationChildren(SavepointCase):
         cls.stock_location = ref("stock.stock_location_stock")
         cls.stock_shelf_1 = ref("stock.stock_location_components")
         cls.stock_shelf_2 = ref("stock.stock_location_14")
-        cls.stock_shelf_2_refrigerator = ref(
-            "stock.location_refrigerator_small"
-        )
+        cls.stock_shelf_2_refrigerator = ref("stock.location_refrigerator_small")
 
     def test_location_children(self):
         self.assertFalse(self.stock_shelf_2_refrigerator.child_ids)
-        self.assertEqual(
-            self.stock_shelf_2.child_ids,
-            self.stock_shelf_2_refrigerator
-        )
-        self.assertEqual(
-            self.stock_shelf_2.child_ids,
-            self.stock_shelf_2.children_ids
-        )
+        self.assertEqual(self.stock_shelf_2.child_ids, self.stock_shelf_2_refrigerator)
+        self.assertEqual(self.stock_shelf_2.child_ids, self.stock_shelf_2.children_ids)
         self.assertFalse(self.stock_shelf_1.child_ids)
         self.assertFalse(self.stock_shelf_1.children_ids)
         self.assertEqual(
-            self.stock_location.child_ids,
-            self.stock_shelf_1 | self.stock_shelf_2
+            self.stock_location.child_ids, self.stock_shelf_1 | self.stock_shelf_2
         )
         self.assertEqual(
             self.stock_location.children_ids,
-            self.stock_shelf_1 | self.stock_shelf_2 | self.stock_shelf_2_refrigerator
+            self.stock_shelf_1 | self.stock_shelf_2 | self.stock_shelf_2_refrigerator,
         )
 
     def test_create_write_location(self):
-        refrigerator_drawer = self.env['stock.location'].create({
-            'name': 'Refrigerator drawer',
-            'location_id': self.stock_shelf_2_refrigerator.id
-        })
-        self.assertEqual(
-            self.stock_shelf_2_refrigerator.child_ids,
-            refrigerator_drawer
+        refrigerator_drawer = self.env["stock.location"].create(
+            {
+                "name": "Refrigerator drawer",
+                "location_id": self.stock_shelf_2_refrigerator.id,
+            }
         )
+        self.assertEqual(self.stock_shelf_2_refrigerator.child_ids, refrigerator_drawer)
         self.assertEqual(
-            self.stock_shelf_2_refrigerator.children_ids,
-            refrigerator_drawer
+            self.stock_shelf_2_refrigerator.children_ids, refrigerator_drawer
         )
         self.assertEqual(
             self.stock_shelf_2.children_ids,
-            self.stock_shelf_2_refrigerator | refrigerator_drawer
+            self.stock_shelf_2_refrigerator | refrigerator_drawer,
         )
         self.assertEqual(
             self.stock_location.children_ids,
-            self.stock_shelf_1 | self.stock_shelf_2 |
-            self.stock_shelf_2_refrigerator | refrigerator_drawer
+            self.stock_shelf_1
+            | self.stock_shelf_2
+            | self.stock_shelf_2_refrigerator
+            | refrigerator_drawer,
         )
         refrigerator_drawer.location_id = self.stock_input
         self.assertFalse(self.stock_shelf_2_refrigerator.child_ids)
-        self.assertEqual(
-            self.stock_shelf_2.child_ids,
-            self.stock_shelf_2_refrigerator
-        )
-        self.assertEqual(
-            self.stock_shelf_2.child_ids,
-            self.stock_shelf_2.children_ids
-        )
+        self.assertEqual(self.stock_shelf_2.child_ids, self.stock_shelf_2_refrigerator)
+        self.assertEqual(self.stock_shelf_2.child_ids, self.stock_shelf_2.children_ids)
         self.assertEqual(
             self.stock_location.children_ids,
-            self.stock_shelf_1 | self.stock_shelf_2 | self.stock_shelf_2_refrigerator
+            self.stock_shelf_1 | self.stock_shelf_2 | self.stock_shelf_2_refrigerator,
         )


### PR DESCRIPTION
This module adds a `children_ids` field on `stock.location` in order to compute
and store all the children for a `stock.location` and not only its first level
children as is the case for `child_ids`