### PR TITLE
[11.0] stock_available_mrp: consider product types

### DIFF
--- a/stock_available_mrp/README.rst
+++ b/stock_available_mrp/README.rst
@@ -11,7 +11,8 @@ the quantity available to promise, where the "Potential quantity" is the
 quantity that can be manufactured with the components immediately at hand.
 By configuration, the "Potential quantity" can be computed based on other product field.
 For example, "Potential quantity" can be the quantity that can be manufactured
-with the components available to promise.
+with the components available to promise. 
+"Potential quantity" set to -1.0 means "no limit to production".
 
 Usage
 =====

--- a/stock_available_mrp/tests/test_potential_qty.py
+++ b/stock_available_mrp/tests/test_potential_qty.py
@@ -454,6 +454,32 @@ class TestPotentialQty(TransactionCase):
         )
 
         self.assertEqual(
-            {p1.id: 3.0, p2.id: 3.0, p3.id: 0.0},
+            {p1.id: -1.0, p2.id: 3.0, p3.id: 0.0},
             {p.id: p.potential_qty for p in products}
         )
+
+    def test_potential_quantity_service_and_stockable(self):
+        stockable_product = self.product_model.create(
+            {'name': 'Test Product', 'type': 'product'}
+        )
+        service_product = self.product_model.create(
+            {'name': 'Test PService', 'type': 'service'}
+        )
+
+        # stockable_product need one service_product
+        self.create_simple_bom(stockable_product, service_product)
+
+        self.assertEqual(stockable_product.potential_qty, -1.0)
+
+    def test_potential_quantity_consumable_and_stockable(self):
+        stockable_product = self.product_model.create(
+            {'name': 'Test Product', 'type': 'product'}
+        )
+        consumable_product = self.product_model.create(
+            {'name': 'Test PService', 'type': 'consu'}
+        )
+
+        # stockable_product need one consumable_product
+        self.create_simple_bom(stockable_product, consumable_product)
+
+        self.assertEqual(stockable_product.potential_qty, -1.0)


### PR DESCRIPTION
Impacting module: stock_available_mrp 

potential_qty changed to -1.0 when BoM consist only from products type consumable or service (not stockable product type). Otherwise calculate potential_qty based on stockable product.

![quantity](https://user-images.githubusercontent.com/59824990/76979569-66ae3780-6938-11ea-89f7-6231c9af3555.png)
