### PR TITLE
[IMP] stock_request_direction (Warehouse On Change)

### DIFF
--- a/stock_request_direction/models/stock_request_order.py
+++ b/stock_request_direction/models/stock_request_order.py
@@ -24,6 +24,14 @@ class StockRequestOrder(models.Model):
             self.location_id = \
                 self.warehouse_id.lot_stock_id.id
 
+    @api.onchange('warehouse_id')
+    def _onchange_warehouse_id(self):
+        if self.direction:
+            self.direction = False
+        for stock_request in self.stock_request_ids:
+            if stock_request.route_id:
+                stock_request.route_id = False
+
     def change_childs(self):
         super().change_childs()
         if not self._context.get('no_change_childs', False):

--- a/stock_request_direction/models/stock_request_order.py
+++ b/stock_request_direction/models/stock_request_order.py
@@ -27,6 +27,11 @@ class StockRequestOrder(models.Model):
             if stock_request.route_id:
                 stock_request.route_id = False
 
+    @api.onchange('warehouse_id')
+    def onchange_warehouse_id(self):
+        # Onchange no longer needed
+        pass
+
     def change_childs(self):
         super().change_childs()
         if not self._context.get('no_change_childs', False):

--- a/stock_request_direction/models/stock_request_order.py
+++ b/stock_request_direction/models/stock_request_order.py
@@ -13,7 +13,7 @@ class StockRequestOrder(models.Model):
                                  states={'draft': [('readonly', False)]},
                                  readonly=True)
 
-    @api.onchange('direction')
+    @api.onchange('warehouse_id', 'direction')
     def _onchange_location_id(self):
         if self.direction == 'outbound':
             # Stock Location set to Partner Locations/Customers
@@ -23,11 +23,6 @@ class StockRequestOrder(models.Model):
             # Otherwise the Stock Location of the Warehouse
             self.location_id = \
                 self.warehouse_id.lot_stock_id.id
-
-    @api.onchange('warehouse_id')
-    def _onchange_warehouse_id(self):
-        if self.direction:
-            self.direction = False
         for stock_request in self.stock_request_ids:
             if stock_request.route_id:
                 stock_request.route_id = False


### PR DESCRIPTION
Since the location and routes depend on the warehouse that is selected on the stock request order, if the warehouse changes then so will the route options. This adds an on change event so if the warehouse changes, then the direction gets cleared and so do the routes on the product lines. This forces the user to properly reset the items using the correct routes for the newly selected warehouse.