### PR TITLE
[IMP] stock_request_picking_type: Synchronize Picking Type and Warehouse

### DIFF
--- a/stock_request_picking_type/models/stock_request_order.py
+++ b/stock_request_picking_type/models/stock_request_order.py
@@ -19,3 +19,12 @@ class StockRequestOrder(models.Model):
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type',
         default=_get_default_picking_type, required=True)
+
+    @api.onchange('warehouse_id')
+    def onchange_warehouse_picking_id(self):
+        if self.warehouse_id:
+            picking_type_id = self.env['stock.picking.type'].\
+                search([('code', '=', 'stock_request_order'),
+                        ('warehouse_id', '=', self.warehouse_id.id)], limit=1)
+            if picking_type_id:
+                    self._origin.write({'picking_type_id': picking_type_id.id})


### PR DESCRIPTION
If a user has 2 warehouses for a single company then it is reasonable to assume they would have an Operation Type for each warehouse related to Stock Requests for traceability purposes. The problem I produced on Runbot is that changing the warehouse does not change the picking type and can create a little confusion for the user from the Kanban view as shown here:

Kanban View:
![image](https://user-images.githubusercontent.com/39602586/82096268-75edff00-96b5-11ea-9fdc-3e2c888719b9.png)

List View:
![image](https://user-images.githubusercontent.com/39602586/82096299-83a38480-96b5-11ea-80de-92c93b81be8b.png)

The 2 options available is we can expose the picking_type_id field on the view, or if we want to keep it hidden, then we can go with my onchange method if it is acceptable.

I believe it is also worth noting, if the user creates the SRO inside one of the Kanban cards the Stock Picking Type will be set properly, this issue is only related to SRO's created from the Stock Request App.