### PR TITLE
[12.0][IMP] stock_move_location: Allow to select any location.

### DIFF
--- a/stock_move_location/__manifest__.py
+++ b/stock_move_location/__manifest__.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
-
 {
     "name": "Move Stock Location",
     "version": "12.0.1.3.1",

--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -103,7 +103,9 @@ class StockMoveLocationWizard(models.TransientModel):
         self.stock_move_location_line_ids = False
 
     def _get_locations_domain(self):
-        return [('usage', '=', 'internal')]
+        return ['|',
+                ('company_id', '=', self.env.user.company_id.id),
+                ('company_id', '=', False)]
 
     def _create_picking(self):
         return self.env['stock.picking'].create({


### PR DESCRIPTION
cc @Tecnativa
With this PR the behavior is the same that a picking. If I can do a internal transfer and I can select any location, Why in this module can not do it??
https://github.com/odoo/odoo/blob/a9a7834c8766246d3308eb09893f06a5b3639447/addons/stock/views/stock_picking_views.xml#L263-L264