### PR TITLE
[12.0][FIX] sale_stock_info_popup: Modify list editable support

### DIFF
--- a/sale_stock_info_popup/README.rst
+++ b/sale_stock_info_popup/README.rst
@@ -73,6 +73,7 @@ Contributors
 
   * Ernesto Tejeda
   * Pedro M. Baeza
+  * Alexandre D. Díaz
 
 This module is a backport from Odoo SA and as such, it is not
 included in the OCA CLA. That means we do not have a copy of

--- a/sale_stock_info_popup/readme/CONTRIBUTORS.rst
+++ b/sale_stock_info_popup/readme/CONTRIBUTORS.rst
@@ -2,6 +2,7 @@
 
   * Ernesto Tejeda
   * Pedro M. Baeza
+  * Alexandre D. Díaz
 
 This module is a backport from Odoo SA and as such, it is not
 included in the OCA CLA. That means we do not have a copy of

--- a/sale_stock_info_popup/static/description/index.html
+++ b/sale_stock_info_popup/static/description/index.html
@@ -417,6 +417,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Ernesto Tejeda</li>
 <li>Pedro M. Baeza</li>
+<li>Alexandre D. Díaz</li>
 </ul>
 </li>
 </ul>

--- a/sale_stock_info_popup/static/src/js/qty_at_date_widget.js
+++ b/sale_stock_info_popup/static/src/js/qty_at_date_widget.js
@@ -5,6 +5,7 @@ odoo.define('sale_stock.QtyAtDateWidget', function (require) {
 "use strict";
 
 var core = require('web.core');
+var ListRenderer = require('web.ListRenderer')
 var QWeb = core.qweb;
 
 var Widget = require('web.Widget');
@@ -12,6 +13,25 @@ var widget_registry = require('web.widget_registry');
 
 var _t = core._t;
 var time = require('web.time');
+
+/**
+ * Make the widget fully compatible with tree views
+ */
+ListRenderer.include({
+    /**
+     * @override
+     */
+    _renderBodyCell: function (record, node) {
+        var $td = this._super.apply(this, arguments);
+        if (node.tag === 'widget' && node.attrs.name === 'qty_at_date_widget') {
+            // Workaround: Thanks to this class the column will be ignored
+            // when try active a cell in the list.
+            // See: https://github.com/odoo/odoo/blob/c881e3fe2a8b3db43fa9613a52b996fdfab21392/addons/web/static/src/js/views/list/list_editable_renderer.js#L814
+            $td.addClass('o_list_button');
+        }
+        return $td;
+    }
+})
 
 var QtyAtDateWidget = Widget.extend({
     template: 'sale_stock.qtyAtDate',


### PR DESCRIPTION
Previous this commit, if the user click on a cell (after the cell created by this widget) Odoo gets a wrong index value and try to activate one of the following cells.
With this commit the cell created by this widget is treated like a button.. that are fully compatible with tree views.

cc @tecnativa TT24232