### PR TITLE
[12.0][IMP] stock_warehouse_calendar: robustness

### DIFF
--- a/stock_warehouse_calendar/models/stock_warehouse.py
+++ b/stock_warehouse_calendar/models/stock_warehouse.py
@@ -23,6 +23,8 @@ class StockWarehouse(models.Model):
         :return: datetime: resulting date.
         """
         self.ensure_one()
+        if isinstance(delta, float):
+            delta = round(delta)
         if not isinstance(date_from, datetime):
             date_from = fields.Datetime.to_datetime(date_from)
         if delta == 0:


### PR DESCRIPTION
when delta argument is a float `plan_days` method can return
unexpected False result. This can lead to silent errors.
Therefore we ensure that delta is a integer in the helper.

@ForgeFlow