### PR TITLE
[13.0] Remove unique constraint on packaging type in cubiscan

### DIFF
--- a/stock_cubiscan/models/stock.py
+++ b/stock_cubiscan/models/stock.py
@@ -10,17 +10,3 @@ class StockWarehouse(models.Model):
     cubiscan_device_ids = fields.One2many(
         "cubiscan.device", "warehouse_id", string="Cubiscan Devices"
     )
-
-
-class ProductPackaging(models.Model):
-    _inherit = "product.packaging"
-    # FIXME: move this constraint in product_packaging_type
-    # https://github.com/OCA/product-attribute/tree/13.0/product_packaging_type
-    _sql_constraints = [
-        (
-            "product_packaging_type_unique",
-            "unique (product_id, packaging_type_id)",
-            "It is forbidden to have different packagings "
-            "with the same type for a given product.",
-        )
-    ]


### PR DESCRIPTION
The constraint is moved to the module stock_packaging_type:

https://github.com/OCA/product-attribute/pull/654

Having this constraint in this module doesn't make sense.