### PR TITLE
[FIX] stock_secondary_unit: Compute secondary_unit_qty_available field with sudo

### DIFF
--- a/stock_secondary_unit/models/product.py
+++ b/stock_secondary_unit/models/product.py
@@ -15,7 +15,7 @@ class StockProductSecondaryUnit(models.AbstractModel):
     )
 
     def _compute_secondary_unit_qty_available(self):
-        for product in self:
+        for product in self.with_context(company_owned=True).sudo():
             if not product.stock_secondary_uom_id:
                 product.secondary_unit_qty_available = 0.0
             else:


### PR DESCRIPTION
cc @Tecnativa TT25561
In kanban view also the user has not inventory user group the available quantities has been computed.
I have tried adding compute_sudo=True to field but this is not working

ping @carlosdauden ping  @victoralmau 