### PR TITLE
[12.0][FIX] stock_pull_list: send company recordset to _get_rule

### DIFF
--- a/stock_pull_list/wizards/stock_pull_list_wizard.py
+++ b/stock_pull_list/wizards/stock_pull_list_wizard.py
@@ -122,7 +122,7 @@ class PullListWizard(models.TransientModel):
     def _get_stock_rule_id(self, product_id, location_id):
         values = {
             "warehouse_id": self.warehouse_id,
-            "company_id": self.env.user.company_id.id,
+            "company_id": self.env.user.company_id,
         }
         stock_rule_id = self.env["procurement.group"]._get_rule(
             product_id, location_id, values)


### PR DESCRIPTION
Due to https://github.com/odoo/odoo/commit/31a54b5e859ead7972cdccc956518e14038476ba I guess this change is required.
https://github.com/OCA/stock-logistics-warehouse/pull/952 affected.

CC @ForgeFlow 