### PR TITLE
[13.0] Improve put-away release in vertical lift

### DIFF
--- a/stock_vertical_lift/models/vertical_lift_operation_put.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_put.py
@@ -172,10 +172,11 @@ class VerticalLiftOperationPut(models.Model):
         self.current_move_line_id.fetch_vertical_lift_tray_dest()
 
     def button_release(self):
-        # release (close) the tray each time, because for put-away, we
-        # never know if the operator will scan another line or not
-        self.shuttle_id.release_vertical_lift_tray()
         super().button_release()
         if self.count_move_lines_to_do_all() == 0:
+            # we don't need to release (close) the tray until we have reached
+            # the last line: the release is implicit when a next line is
+            # fetched if the tray change
+            self.shuttle_id.release_vertical_lift_tray()
             # sorry not sorry
             return self._rainbow_man()


### PR DESCRIPTION
If we have several goods to put in the same tray, it is inefficient to
release (close) the tray between each line if we reopen the same tray.
Release the tray only when the last line is reached.