### PR TITLE
[13.0] Remove _order override in stock.location

### DIFF
--- a/stock_inventory_lockdown/models/stock_location.py
+++ b/stock_inventory_lockdown/models/stock_location.py
@@ -9,7 +9,6 @@ class StockLocation(models.Model):
     """Refuse changes during exhaustive Inventories"""
 
     _inherit = "stock.location"
-    _order = "name"
 
     @api.constrains("location_id")
     def _check_inventory_location_id(self):


### PR DESCRIPTION
The default order of stock.location is 'complete_name'.
Changing it to "name" can have side effects, and shouldn't be required
for stock_inventory_lockdown.

See https://github.com/OCA/stock-logistics-warehouse/pull/811/files#r512797834