### PR TITLE
[IMP + FIX] stock_move_location: Display reserved quantity in wizard lines. Reassign reserved quantities for quants moved.

### DIFF
--- a/stock_move_location/i18n/es.po
+++ b/stock_move_location/i18n/es.po
@@ -6,16 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-03 17:47+0000\n"
-"PO-Revision-Date: 2020-02-03 18:48+0100\n"
-"Last-Translator: Enric Tobella <etobella@creublanca.es>\n"
+"POT-Creation-Date: 2020-11-02 20:30+0000\n"
+"PO-Revision-Date: 2020-11-02 21:37+0100\n"
+"Last-Translator: Sergio Teruel <sergio.teruel@tecnativa.com>\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.3\n"
 
 #. module: stock_move_location
 #: model:ir.model.fields,field_description:stock_move_location.field_wiz_stock_move_location__apply_putaway_strategy
@@ -62,9 +62,8 @@ msgstr "Ubicación de destino"
 
 #. module: stock_move_location
 #: model:ir.model.fields,field_description:stock_move_location.field_wiz_stock_move_location__destination_location_disable
-#, fuzzy
 msgid "Destination Location Disable"
-msgstr "Ubicación de destino"
+msgstr "Ubicación de destino desactivada"
 
 #. module: stock_move_location
 #: model:ir.model.fields,field_description:stock_move_location.field_wiz_stock_move_location__display_name
@@ -75,7 +74,6 @@ msgstr "Nombre mostrado"
 #. module: stock_move_location
 #: model:ir.model.fields,field_description:stock_move_location.field_wiz_stock_move_location__edit_locations
 #: model_terms:ir.ui.view,arch_db:stock_move_location.view_wiz_stock_move_location_form_stock_move_location
-#, fuzzy
 msgid "Edit Locations"
 msgstr "(editar)"
 
@@ -130,9 +128,8 @@ msgstr "Líneas de movimiento de Ubicación"
 
 #. module: stock_move_location
 #: model_terms:ir.ui.view,arch_db:stock_move_location.stock_picking_type_kanban
-#, fuzzy
 msgid "Move On Hand"
-msgstr " Disponible"
+msgstr "Disponible"
 
 #. module: stock_move_location
 #: model:ir.actions.act_window,name:stock_move_location.wiz_stock_move_location_action
@@ -153,9 +150,8 @@ msgstr "La cantidad movida no puede superar la cantidad máxima o ser negativo"
 
 #. module: stock_move_location
 #: model:ir.actions.act_window,name:stock_move_location.wiz_stock_quant_location_action
-#, fuzzy
 msgid "Move to location..."
-msgstr "Mover desde ubicación..."
+msgstr "Mover a ubicación..."
 
 #. module: stock_move_location
 #: model:ir.model.fields,field_description:stock_move_location.field_wiz_stock_move_location__origin_location_id
@@ -165,9 +161,8 @@ msgstr "Ubicación de origen"
 
 #. module: stock_move_location
 #: model:ir.model.fields,field_description:stock_move_location.field_wiz_stock_move_location__origin_location_disable
-#, fuzzy
 msgid "Origin Location Disable"
-msgstr "Ubicación de origen"
+msgstr "Ubicación origen desactivada"
 
 #. module: stock_move_location
 #: model:ir.model.fields,field_description:stock_move_location.field_stock_move__location_move
@@ -177,7 +172,6 @@ msgstr "Parte de un movimiento entre ubicaciones"
 #. module: stock_move_location
 #: model:ir.model,name:stock_move_location.model_stock_picking_type
 #: model:ir.model.fields,field_description:stock_move_location.field_wiz_stock_move_location__picking_type_id
-#, fuzzy
 msgid "Picking Type"
 msgstr "Tipo de operación"
 
@@ -202,10 +196,14 @@ msgid "Quantity to move"
 msgstr "Cantidad a mover"
 
 #. module: stock_move_location
+#: model:ir.model.fields,field_description:stock_move_location.field_wiz_stock_move_location_line__reserved_quantity
+msgid "Reserved quantity"
+msgstr "Cantidad Reservada"
+
+#. module: stock_move_location
 #: model:ir.model.fields,field_description:stock_move_location.field_stock_picking_type__show_move_onhand
-#, fuzzy
 msgid "Show Move On hand stock"
-msgstr "Stock On Hand"
+msgstr "Mostrar cantidad disponible"
 
 #. module: stock_move_location
 #: model:ir.model.fields,help:stock_move_location.field_stock_picking_type__show_move_onhand
@@ -250,15 +248,3 @@ msgstr ""
 #: model:ir.model.fields,help:stock_move_location.field_wiz_stock_move_location__origin_location_disable
 msgid "technical field to disable the edition of origin location."
 msgstr ""
-
-#~ msgid "Add all"
-#~ msgstr "Añadir todo"
-
-#~ msgid "Clear all"
-#~ msgstr "Limpiar todo"
-
-#~ msgid "wiz.stock.move.location"
-#~ msgstr "wiz.stock.move.location"
-
-#~ msgid "wiz.stock.move.location.line"
-#~ msgstr "wiz.stock.move.location.line"

--- a/stock_move_location/i18n/stock_move_location.pot
+++ b/stock_move_location/i18n/stock_move_location.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-11-02 20:30+0000\n"
+"PO-Revision-Date: 2020-11-02 20:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -189,6 +191,11 @@ msgstr ""
 #. module: stock_move_location
 #: model:ir.model.fields,field_description:stock_move_location.field_wiz_stock_move_location_line__move_quantity
 msgid "Quantity to move"
+msgstr ""
+
+#. module: stock_move_location
+#: model:ir.model.fields,field_description:stock_move_location.field_wiz_stock_move_location_line__reserved_quantity
+msgid "Reserved quantity"
 msgstr ""
 
 #. module: stock_move_location

--- a/stock_move_location/wizard/stock_move_location.xml
+++ b/stock_move_location/wizard/stock_move_location.xml
@@ -84,6 +84,11 @@
                                     attrs="{'readonly': [('custom', '!=', True)]}"
                                     force_save="1"
                                 />
+                                <field
+                                    name="reserved_quantity"
+                                    readonly="1"
+                                    force_save="1"
+                                />
                             </tree>
                             <kanban class="o_kanban_mobile">
                                 <templates>

--- a/stock_move_location/wizard/stock_move_location_line.py
+++ b/stock_move_location/wizard/stock_move_location_line.py
@@ -41,6 +41,9 @@ class StockMoveLocationWizardLine(models.TransientModel):
     max_quantity = fields.Float(
         string="Maximum available quantity", digits="Product Unit of Measure"
     )
+    reserved_quantity = fields.Float(
+        string="Reserved quantity", digits="Product Unit of Measure"
+    )
     custom = fields.Boolean(string="Custom line", default=True)
 
     @staticmethod


### PR DESCRIPTION
**Behavior before this PR:**

- Create a outgoing picking with any product with available stock
- Check availability
- Move all stock to other location with the wizard
- Run sheduler

The detailed operaciont have two records, one with 0 units and other (new) with the reserved quatities

**Behavior before this PR:**
- Create a outgoing picking with any product with available stock
- Check availability
- Move all stock to other location with the wizard
- Now the reserved quantities get from new location
- Run sheduler

All Ok.

cc @Tecnativa TT26510
ping @carlosdauden @chienandalu 