### PR TITLE
[Fix] requiemrent are not referencing properly openupgradelib to work with ansible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/OCA/openupgradelib.git@master#egg=openupgradelib
+git+https://github.com/OCA/openupgradelib.git


### PR DESCRIPTION
seems that the previous syntaxe was causing some issues when called from ansible and pip module.
This one is equivalent and seems to work