### PR TITLE
[13.0] Add picking_type_id in stock_reserve_rule list/search views

### DIFF
--- a/stock_reserve_rule/views/stock_reserve_rule_views.xml
+++ b/stock_reserve_rule/views/stock_reserve_rule_views.xml
@@ -78,6 +78,7 @@
             <search string="Reservation Rule">
                 <field name="name" />
                 <field name="location_id" />
+                <field name="picking_type_id" />
                 <separator />
                 <filter
                     string="Archived"
@@ -95,6 +96,7 @@
                 <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="location_id" />
+                <field name="picking_type_id" />
                 <field name="rule_domain" />
             </tree>
         </field>


### PR DESCRIPTION
It's an important information for the reservation rules,
and currently we have to records one-by-one to check the configuration.