### PR TITLE
[13.0] stock_reserve_rule: Change picking type to many2many in reserve rules

### DIFF
--- a/stock_reserve_rule/__manifest__.py
+++ b/stock_reserve_rule/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Stock Reservation Rules",
     "summary": "Configure reservation rules by location",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.1.0",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "category": "Stock Management",

--- a/stock_reserve_rule/i18n/stock_reserve_rule.pot
+++ b/stock_reserve_rule/i18n/stock_reserve_rule.pot
@@ -29,7 +29,7 @@ msgid "Advanced Removal Strategy"
 msgstr ""
 
 #. module: stock_reserve_rule
-#: model:ir.model.fields,help:stock_reserve_rule.field_stock_reserve_rule__picking_type_id
+#: model:ir.model.fields,help:stock_reserve_rule.field_stock_reserve_rule__picking_type_ids
 msgid "Apply this rule only if the operation type of the move is the same."
 msgstr ""
 
@@ -145,8 +145,8 @@ msgid "Location"
 msgstr ""
 
 #. module: stock_reserve_rule
-#: model:ir.model.fields,field_description:stock_reserve_rule.field_stock_reserve_rule__picking_type_id
-msgid "Operation Type"
+#: model:ir.model.fields,field_description:stock_reserve_rule.field_stock_reserve_rule__picking_type_ids
+msgid "Operation Types"
 msgstr ""
 
 #. module: stock_reserve_rule

--- a/stock_reserve_rule/migrations/13.0.1.1.0/post-migration.py
+++ b/stock_reserve_rule/migrations/13.0.1.1.0/post-migration.py
@@ -1,0 +1,18 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+    INSERT INTO stock_picking_type_stock_reserve_rule_rel
+      (stock_reserve_rule_id, stock_picking_type_id)
+    SELECT id, picking_type_id
+    FROM stock_reserve_rule
+    WHERE picking_type_id IS NOT NULL
+    ON CONFLICT DO NOTHING;
+    """
+    )

--- a/stock_reserve_rule/models/__init__.py
+++ b/stock_reserve_rule/models/__init__.py
@@ -1,4 +1,5 @@
 from . import stock_move
 from . import stock_location
 from . import stock_quant
+from . import stock_picking_type
 from . import stock_reserve_rule

--- a/stock_reserve_rule/models/stock_picking_type.py
+++ b/stock_reserve_rule/models/stock_picking_type.py
@@ -1,0 +1,12 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    reserve_rule_ids = fields.Many2many(
+        comodel_name="stock.reserve.rule", inverse_name="picking_type_ids",
+    )

--- a/stock_reserve_rule/models/stock_reserve_rule.py
+++ b/stock_reserve_rule/models/stock_reserve_rule.py
@@ -46,9 +46,9 @@ class StockReserveRule(models.Model):
         required=True,
         help="Rule applied only in this location and sub-locations.",
     )
-    picking_type_id = fields.Many2one(
+    picking_type_ids = fields.Many2many(
         comodel_name="stock.picking.type",
-        string="Operation Type",
+        string="Operation Types",
         help="Apply this rule only if the operation type of the move is the same.",
     )
 
@@ -82,9 +82,9 @@ class StockReserveRule(models.Model):
         )
 
     def _is_rule_applicable(self, move):
-        if self.picking_type_id:
+        if self.picking_type_ids:
             picking_type = move.picking_type_id or move.picking_id.picking_type_id
-            if picking_type != self.picking_type_id:
+            if picking_type not in self.picking_type_ids:
                 return False
         domain = safe_eval(self.rule_domain) or []
         if domain:

--- a/stock_reserve_rule/tests/test_reserve_rule.py
+++ b/stock_reserve_rule/tests/test_reserve_rule.py
@@ -274,12 +274,12 @@ class TestReserveRule(common.SavepointCase):
 
         self._create_rule(
             # different picking, should be excluded
-            {"picking_type_id": self.wh.int_type_id.id, "sequence": 1},
+            {"picking_type_ids": [(6, 0, self.wh.int_type_id.ids)], "sequence": 1},
             [{"location_id": self.loc_zone1.id, "sequence": 1}],
         )
         self._create_rule(
             # same picking type as the move
-            {"picking_type_id": self.wh.pick_type_id.id, "sequence": 2},
+            {"picking_type_ids": [(6, 0, self.wh.pick_type_id.ids)], "sequence": 2},
             [
                 {"location_id": self.loc_zone2.id, "sequence": 1},
                 {"location_id": self.loc_zone3.id, "sequence": 2},

--- a/stock_reserve_rule/views/stock_reserve_rule_views.xml
+++ b/stock_reserve_rule/views/stock_reserve_rule_views.xml
@@ -22,7 +22,11 @@
                         <group>
                             <field name="active" invisible="1" />
                             <field name="location_id" />
-                            <field name="picking_type_id" />
+                            <field
+                                name="picking_type_ids"
+                                widget="many2many_tags"
+                                options="{'no_create': 1}"
+                            />
                             <field name="sequence" />
                         </group>
                         <group>
@@ -78,6 +82,7 @@
             <search string="Reservation Rule">
                 <field name="name" />
                 <field name="location_id" />
+                <field name="picking_type_ids" />
                 <separator />
                 <filter
                     string="Archived"
@@ -95,6 +100,11 @@
                 <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="location_id" />
+                <field
+                    name="picking_type_ids"
+                    widget="many2many_tags"
+                    options="{'no_create': 1}"
+                />
                 <field name="rule_domain" />
             </tree>
         </field>


### PR DESCRIPTION
The picking type field allows to restrict the reservation rules to a picking type. There is no reason to restrict to only one picking type, this PR replaces the many2one per a many2many.