### PR TITLE
[12.0][FIX] stock_putaway_product_form: Remove tests import in __init__.py

### DIFF
--- a/stock_putaway_product_form/__init__.py
+++ b/stock_putaway_product_form/__init__.py
@@ -1,5 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
-from . import tests
 from .hooks import post_init_hook


### PR DESCRIPTION
Remove tests import in __init__.py related to https://github.com/OCA/stock-logistics-warehouse/pull/1001#discussion_r528505031

Please @sergio-teruel review it.
@Tecnativa TT25955