### PR TITLE
[13.0][FIX] stock_vertical_lift: handles multiple move lines on pick

### DIFF
--- a/stock_vertical_lift/demo/stock_inventory_demo.xml
+++ b/stock_vertical_lift/demo/stock_inventory_demo.xml
@@ -7,7 +7,27 @@
         <field name="product_id" ref="product_running_socks" />
         <field name="product_uom_id" ref="uom.product_uom_unit" />
         <field name="inventory_id" ref="stock_inventory_vertical_lift_0" />
-        <field name="product_qty">30.0</field>
+        <field name="product_qty">10.0</field>
+        <field
+            name="location_id"
+            ref="stock_location_vertical_lift_demo_tray_1b_x1y2"
+        />
+    </record>
+    <record id="stock_inventory_vertical_lift_line_2" model="stock.inventory.line">
+        <field name="product_id" ref="product_running_socks" />
+        <field name="product_uom_id" ref="uom.product_uom_unit" />
+        <field name="inventory_id" ref="stock_inventory_vertical_lift_0" />
+        <field name="product_qty">10.0</field>
+        <field
+            name="location_id"
+            ref="stock_location_vertical_lift_demo_tray_1b_x2y2"
+        />
+    </record>
+    <record id="stock_inventory_vertical_lift_line_3" model="stock.inventory.line">
+        <field name="product_id" ref="product_running_socks" />
+        <field name="product_uom_id" ref="uom.product_uom_unit" />
+        <field name="inventory_id" ref="stock_inventory_vertical_lift_0" />
+        <field name="product_qty">10.0</field>
         <field
             name="location_id"
             ref="stock_location_vertical_lift_demo_tray_1b_x3y2"

--- a/stock_vertical_lift/tests/common.py
+++ b/stock_vertical_lift/tests/common.py
@@ -154,10 +154,11 @@ class VerticalLiftCase(common.LocationTrayTypeCase):
         inventory.action_start()
         return inventory
 
-    def _test_button_release(self, move_line, expected_state):
-        # for the test, we'll consider our last line has been delivered
-        move_line.qty_done = move_line.product_qty
-        move_line.move_id._action_done()
+    def _test_button_release(self, move_lines, expected_state):
+        # for the test, we'll consider all the lines has been delivered
+        for move_line in move_lines:
+            move_line.qty_done = move_line.product_qty
+        move_lines.picking_id.action_done()
         # release, no further operation in queue
         operation = self.shuttle._operation_for_mode()
         # the release button can be used only in the state... release

--- a/stock_vertical_lift/tests/test_pick.py
+++ b/stock_vertical_lift/tests/test_pick.py
@@ -13,7 +13,7 @@ class TestPick(VerticalLiftCase):
         )
         # we have a move line to pick created by demo picking
         # stock_picking_out_demo_vertical_lift_1
-        cls.out_move_line = cls.picking_out.move_line_ids
+        cls.out_move_line = cls.picking_out.move_line_ids[0]
 
     def test_switch_pick(self):
         self.shuttle.switch_pick()
@@ -159,7 +159,7 @@ class TestPick(VerticalLiftCase):
 
     def test_button_release(self):
         self._open_screen("pick")
-        self._test_button_release(self.out_move_line, "noop")
+        self._test_button_release(self.picking_out.move_line_ids, "noop")
 
     def test_process_current_pick(self):
         operation = self._open_screen("pick")
@@ -183,7 +183,7 @@ class TestPick(VerticalLiftCase):
                 # fmt: off
                 'cells': [
                     [0, 0, 0, 0, 0, 0, 0, 0],
-                    [0, 0, 1, 0, 0, 0, 0, 0],
+                    [1, 1, 1, 0, 0, 0, 0, 0],
                 ]
                 # fmt: on
             },


### PR DESCRIPTION
If there is two move lines for the same product in the vertical lift (stored in2 differents trays for instance), the pick scenario was failing when the user was processing the first line.

To circumvent this, instead of validating directly the move, we put the line in its own stock move, then we put the stock move in its own transfer and validate this one.

Methods used to do that have been copied from the `shopfloor` module, they probably deserves their own module as they are quite generic.

Ref. 1866