### PR TITLE
[13.0][FIX] stock_secondary_unit: Incorrect secondary unit link in product variants view on common form. Create related template secondary unit field.

### DIFF
--- a/stock_secondary_unit/models/product.py
+++ b/stock_secondary_unit/models/product.py
@@ -40,3 +40,9 @@ class ProductTemplate(models.Model):
 class ProductProduct(models.Model):
     _inherit = ["product.product", "stock.product.secondary.unit"]
     _name = "product.product"
+
+    stock_secondary_uom_id = fields.Many2one(
+        comodel_name="product.secondary.unit",
+        string="Second unit for inventory",
+        related="product_tmpl_id.stock_secondary_uom_id",
+    )


### PR DESCRIPTION
cc @Tecnativa TT27057
ping @carlosdauden @CarlosRoca13 