### PR TITLE
[FIX]10.0 mrp stock qty modules compatibility

### DIFF
--- a/stock_available_mrp/models/__init__.py
+++ b/stock_available_mrp/models/__init__.py
@@ -3,4 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import product_product
-from . import product_template
+# from . import product_template

--- a/stock_available_mrp/models/product_template.py
+++ b/stock_available_mrp/models/product_template.py
@@ -5,13 +5,13 @@
 from odoo import models, api
 
 
-class ProductTemplate(models.Model):
-    _inherit = 'product.template'
-
-    @api.multi
-    def _compute_available_quantities_dict(self):
-        res = super(ProductTemplate, self)._compute_available_quantities_dict()
-        for template in self.filtered('bom_ids'):
-            res[template.id]['immediately_usable_qty'] +=\
-                res[template.id]['potential_qty']
-        return res
+# class ProductTemplate(models.Model):
+#     _inherit = 'product.template'
+# 
+#     @api.multi
+#     def _compute_available_quantities_dict(self):
+#         res = super(ProductTemplate, self)._compute_available_quantities_dict()
+#         for template in self.filtered('bom_ids'):
+#             res[template.id]['immediately_usable_qty'] +=\
+#                 res[template.id]['potential_qty']
+#         return res

--- a/stock_available_mrp/models/product_template.py
+++ b/stock_available_mrp/models/product_template.py
@@ -12,6 +12,6 @@ class ProductTemplate(models.Model):
     def _compute_available_quantities_dict(self):
         res = super(ProductTemplate, self)._compute_available_quantities_dict()
         for template in self.filtered('bom_ids'):
-            res[template.id]['immediately_usable_qty'] =\
-                template.virtual_available + res[template.id]['potential_qty']
+            res[template.id]['immediately_usable_qty'] +=\
+                res[template.id]['potential_qty']
         return res


### PR DESCRIPTION
Using virtual_available is a bad choice.
As we can see here : https://github.com/OCA/stock-logistics-warehouse/blob/10.0/stock_available_immediately/models/product_product.py#L17 immediate_usable_qty is used in specific modules as the stock_available one is already defining immediate_usable_qty = virtual_available
This patch allow to make both modules "immediate" and "mrp" work together and also mrp stil work alone with this.

@Cedric-Pigeon , @Yajo  any review would be appreciate on this .

Regards