### PR TITLE
[13.0][FIX] stock_vertical_lift: Error in tests

### DIFF
--- a/stock_vertical_lift/models/vertical_lift_shuttle.py
+++ b/stock_vertical_lift/models/vertical_lift_shuttle.py
@@ -145,6 +145,11 @@ class VerticalLiftShuttle(models.Model):
         record = self.env[model].search([("shuttle_id", "=", self.id)])
         if not record:
             record = self.env[model].create({"shuttle_id": self.id})
+        # Since https://github.com/odoo/odoo/commit/3a6ac95
+        # _compute_vertical_lift_shuttle_id() don't work fine
+        # These change fix it temporally
+        if "location_id" in record:
+            record.location_id._compute_vertical_lift_shuttle_id()
         return record
 
     def action_open_screen(self):


### PR DESCRIPTION
Actually (13.0) `stock_vertical_lift` show errors in Travis CI test 
https://travis-ci.com/github/OCA/stock-logistics-warehouse/builds/209069134

`_compute_vertical_lift_kind` is not called automatically.
Probably exists a better solution but i don't understand a lot these addons and all dependencies.

Related to: https://github.com/OCA/stock-logistics-warehouse/pull/1021#issuecomment-746464712

ping @guewen 