### PR TITLE
[FIX] Empty 'Reason Code' nulls the mandatory 'Scrap Location'

### DIFF
--- a/scrap_reason_code/models/stock_scrap.py
+++ b/scrap_reason_code/models/stock_scrap.py
@@ -24,7 +24,7 @@ class StockScrap(models.Model):
             self.scrap_location_id = self.reason_code_id.location_id
 
     def write(self, vals):
-        if "reason_code_id" in vals:
+        if vals.get("reason_code_id"):
             vals.update(
                 {
                     "scrap_location_id": self.env["scrap.reason.code"]
@@ -36,7 +36,7 @@ class StockScrap(models.Model):
 
     @api.model
     def create(self, vals):
-        if "reason_code_id" in vals:
+        if vals.get("reason_code_id"):
             vals["scrap_location_id"] = (
                 self.env["scrap.reason.code"]
                 .browse(vals.get("reason_code_id"))


### PR DESCRIPTION
The 'Scrap Location' (field ```scrap_location_id```) is mandatory for the model ```stock.scrap```, while the 'Reason Code' (field ```reason_code_id```) is not. If the 'Reason Code' is set, then the location indicated there is taken as the new scrap location (this is done in the code, the user never sees anything in the user-interface).

The problem was: Because of how the check of the field ```scrap_location_id``` was done, it could be that we received a falsy value when creating/updating the object, which would result in an empty record for the Reason Code, and thus an empty new scrap location taken from there. The scrap location is a mandatory field, thus the user got the error of a mandatory field not being set.