### PR TITLE
Revert "[13.0][FIX] stock_vertical_lift: Error in tests"

### DIFF
--- a/stock_vertical_lift/models/vertical_lift_shuttle.py
+++ b/stock_vertical_lift/models/vertical_lift_shuttle.py
@@ -145,11 +145,6 @@ class VerticalLiftShuttle(models.Model):
         record = self.env[model].search([("shuttle_id", "=", self.id)])
         if not record:
             record = self.env[model].create({"shuttle_id": self.id})
-        # Since https://github.com/odoo/odoo/commit/3a6ac95
-        # _compute_vertical_lift_shuttle_id() don't work fine
-        # These change fix it temporally
-        if "location_id" in record:
-            record.location_id._compute_vertical_lift_shuttle_id()
         return record
 
     def action_open_screen(self):


### PR DESCRIPTION
Reverts OCA/stock-logistics-warehouse#1035, which was a work-around.
The underlying issue is fixed by: https://github.com/odoo/odoo/pull/63979