### PR TITLE
[13.0] stock_reserve_rule: ensure fifo/fefo order first

### DIFF
--- a/stock_reserve_rule/models/stock_reserve_rule.py
+++ b/stock_reserve_rule/models/stock_reserve_rule.py
@@ -264,28 +264,17 @@ class StockReserveRuleRemoval(models.Model):
         def is_greater_eq(value, other):
             return float_compare(value, other, precision_rounding=rounding) >= 0
 
-        for pack_quantity in packaging_quantities:
-            # Get quants quantity on each loop because they may change.
-            # Sort by max quant first so we have more chance to take a full
-            # package. But keep the original ordering for equal quantities!
-            bins = sorted(
-                [
-                    (
-                        sum(quants.mapped("quantity"))
-                        - sum(quants.mapped("reserved_quantity")),
-                        location,
-                    )
-                    for location, quants in quants_per_bin
-                ],
-                reverse=True,
+        for location, location_quants in quants_per_bin:
+            location_quantity = sum(location_quants.mapped("quantity")) - sum(
+                location_quants.mapped("reserved_quantity")
             )
+            if location_quantity <= 0:
+                continue
 
-            for location_quantity, location in bins:
-                if location_quantity <= 0:
-                    continue
+            for pack_quantity in packaging_quantities:
                 enough_for_packaging = is_greater_eq(location_quantity, pack_quantity)
-                asked_more_than_packaging = is_greater_eq(need, pack_quantity)
-                if enough_for_packaging and asked_more_than_packaging:
+                asked_at_least_packaging_qty = is_greater_eq(need, pack_quantity)
+                if enough_for_packaging and asked_at_least_packaging_qty:
                     # compute how much packaging we can get
                     take = (need // pack_quantity) * pack_quantity
                     need = yield location, location_quantity, take

--- a/stock_reserve_rule/tests/test_reserve_rule.py
+++ b/stock_reserve_rule/tests/test_reserve_rule.py
@@ -1,6 +1,6 @@
 # Copyright 2019 Camptocamp (https://www.camptocamp.com)
 
-from odoo import exceptions
+from odoo import exceptions, fields
 from odoo.tests import common
 
 
@@ -103,8 +103,10 @@ class TestReserveRule(common.SavepointCase):
             )
         return picking
 
-    def _update_qty_in_location(self, location, product, quantity):
-        self.env["stock.quant"]._update_available_quantity(product, location, quantity)
+    def _update_qty_in_location(self, location, product, quantity, in_date=None):
+        self.env["stock.quant"]._update_available_quantity(
+            product, location, quantity, in_date=in_date
+        )
 
     def _create_rule(self, rule_values, removal_values):
         rule_config = {
@@ -403,10 +405,25 @@ class TestReserveRule(common.SavepointCase):
         )
         self.assertEqual(move.state, "assigned")
 
-    def test_rule_empty_bin_largest_first(self):
-        self._update_qty_in_location(self.loc_zone1_bin1, self.product1, 30)
-        self._update_qty_in_location(self.loc_zone1_bin2, self.product1, 60)
-        self._update_qty_in_location(self.loc_zone2_bin1, self.product1, 50)
+    def test_rule_empty_bin_fifo(self):
+        self._update_qty_in_location(
+            self.loc_zone1_bin1,
+            self.product1,
+            30,
+            in_date=fields.Datetime.to_datetime("2021-01-04 12:00:00"),
+        )
+        self._update_qty_in_location(
+            self.loc_zone1_bin2,
+            self.product1,
+            60,
+            in_date=fields.Datetime.to_datetime("2021-01-02 12:00:00"),
+        )
+        self._update_qty_in_location(
+            self.loc_zone2_bin1,
+            self.product1,
+            50,
+            in_date=fields.Datetime.to_datetime("2021-01-05 12:00:00"),
+        )
         picking = self._create_picking(self.wh, [(self.product1, 80)])
 
         self._create_rule(
@@ -424,11 +441,10 @@ class TestReserveRule(common.SavepointCase):
         move = picking.move_lines
         ml = move.move_line_ids
 
-        # We expect to take 60 in zone1/bin2 as it will empty a bin,
-        # and we prefer to take in the largest empty bins first to minimize
-        # the number of operations.
-        # Then we cannot take in zone1/bin1 as it would not be empty afterwards
-
+        # We expect to take 60 in zone1/bin2 as it will empty a bin and
+        # respecting fifo, the 60 of zone2 should be taken before the 30 of
+        # zone1. Then, as zone1/bin1 would not be empty, it is discarded. The
+        # remaining is taken in zone2 which has no rule.
         self.assertRecordValues(
             ml,
             [


### PR DESCRIPTION
## Modify empty bin rule to always respect fifo, lifo, ...

The former implementation was sorting the quants per location and trying
to take as much quantities as possible from the same locations, to limit
the number of operations to do. Then, only, removal order (fifo, ...)
was applied. It is more important to respect removal order than limiting
the operations, so remove this "optimization".

## Modify packaging rule to always respect fifo, lifo, ... 

The former implementation was to take as much as possible of the largest
packaging, to the smallest packacking, to have less to move.
Then, only, removal order (fifo, ...) was applied for equal quantities.
It is more important to respect removal order than limiting the
operations, so remove this "optimization".