### PR TITLE
[13.0][IMP] stock_secondary_unit: Use secondary units directly in pickings

### DIFF
--- a/stock_secondary_unit/views/stock_picking_views.xml
+++ b/stock_secondary_unit/views/stock_picking_views.xml
@@ -12,11 +12,15 @@
                 expr="//field[@name='move_ids_without_package']/tree/field[@name='product_uom_qty']"
                 position="before"
             >
-                <field name="secondary_uom_qty" />
+                <field
+                    name="secondary_uom_qty"
+                    attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"
+                />
                 <field
                     name="secondary_uom_id"
                     domain="[('product_tmpl_id.product_variant_ids', 'in', [product_id])]"
                     options="{'no_create': True}"
+                    attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
[IMP] stock_secondary_unit: Use product_secondary_unit mixin model from product-attribute repository.

cc @Tecnativa TT27363
ping @carlosdauden @chienandalu 
