### PR TITLE
[12.0][IMP] stock_quant_manual_assign: make qty_done fill optional

### DIFF
--- a/stock_quant_manual_assign/__init__.py
+++ b/stock_quant_manual_assign/__init__.py
@@ -1,1 +1,2 @@
+from . import models
 from . import wizard

--- a/stock_quant_manual_assign/__manifest__.py
+++ b/stock_quant_manual_assign/__manifest__.py
@@ -22,6 +22,7 @@
     "data": [
         "wizard/assign_manual_quants_view.xml",
         "views/stock_move_view.xml",
+        "views/stock_picking_type_views.xml",
     ],
     "installable": True,
 }

--- a/stock_quant_manual_assign/i18n/stock_quant_manual_assign.pot
+++ b/stock_quant_manual_assign/i18n/stock_quant_manual_assign.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-01-13 08:46+0000\n"
+"PO-Revision-Date: 2021-01-13 08:46+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,6 +23,11 @@ msgstr ""
 #. module: stock_quant_manual_assign
 #: model:ir.model,name:stock_quant_manual_assign.model_assign_manual_quants_lines
 msgid "Assign Manual Quants Lines"
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: model:ir.model.fields,field_description:stock_quant_manual_assign.field_stock_picking_type__auto_fill_qty_done
+msgid "Auto-fill Quantity Done"
 msgstr ""
 
 #. module: stock_quant_manual_assign
@@ -122,6 +129,11 @@ msgid "Package"
 msgstr ""
 
 #. module: stock_quant_manual_assign
+#: model:ir.model,name:stock_quant_manual_assign.model_stock_picking_type
+msgid "Picking Type"
+msgstr ""
+
+#. module: stock_quant_manual_assign
 #: model:ir.model.fields,field_description:stock_quant_manual_assign.field_assign_manual_quants_lines__qty
 msgid "QTY"
 msgstr ""
@@ -158,7 +170,12 @@ msgid "Select"
 msgstr ""
 
 #. module: stock_quant_manual_assign
-#: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:176
+#: model:ir.model.fields,help:stock_quant_manual_assign.field_stock_picking_type__auto_fill_qty_done
+msgid "Select this in case done quantity of the stock move line should be auto-filled when quants are manually assigned."
+msgstr ""
+
+#. module: stock_quant_manual_assign
+#: code:addons/stock_quant_manual_assign/wizard/assign_manual_quants.py:177
 #, python-format
 msgid "Selected line quantity is higher than the available one. Maybe an operation with this product has been done meanwhile or you have manually increased the suggested value."
 msgstr ""

--- a/stock_quant_manual_assign/models/__init__.py
+++ b/stock_quant_manual_assign/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking_type

--- a/stock_quant_manual_assign/models/stock_picking_type.py
+++ b/stock_quant_manual_assign/models/stock_picking_type.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    auto_fill_qty_done = fields.Boolean(
+        "Auto-fill Quantity Done",
+        help="Select this in case done quantity of the stock move line should "
+             "be auto-filled when quants are manually assigned."
+    )

--- a/stock_quant_manual_assign/readme/CONFIGURATION.rst
+++ b/stock_quant_manual_assign/readme/CONFIGURATION.rst
@@ -1,0 +1,3 @@
+In case you would like to auto-fill the done quantity of the stock move line
+with manual assignment of a quant, go to *Invenory > Configuration > Warehouse Management > Operation Types*,
+and select 'Auto-fill Quantity Done' for concerned types.

--- a/stock_quant_manual_assign/tests/test_stock_quant_manual_assign.py
+++ b/stock_quant_manual_assign/tests/test_stock_quant_manual_assign.py
@@ -10,6 +10,7 @@ class TestStockQuantManualAssign(TransactionCase):
     def setUp(self):
         super(TestStockQuantManualAssign, self).setUp()
         self.quant_model = self.env['stock.quant']
+        self.picking_model = self.env['stock.picking']
         self.move_model = self.env['stock.move']
         self.quant_assign_wizard = self.env['assign.manual.quants']
         self.product = self.env['product.product'].create({
@@ -22,6 +23,7 @@ class TestStockQuantManualAssign(TransactionCase):
         self.location1 = self.env.ref('stock.location_inventory')
         self.location2 = self.env.ref('stock.location_procurement')
         self.location3 = self.env.ref('stock.location_production')
+        self.picking_type = self.env.ref('stock.picking_type_out')
         self.quant1 = self.quant_model.sudo().create({
             'product_id': self.product.id,
             'quantity': 100.0,
@@ -44,6 +46,7 @@ class TestStockQuantManualAssign(TransactionCase):
             'product_uom': self.product.uom_id.id,
             'location_id': self.location_src.id,
             'location_dest_id': self.location_dst.id,
+            'picking_type_id': self.picking_type.id,
         })
         self.move._action_confirm()
 
@@ -94,6 +97,26 @@ class TestStockQuantManualAssign(TransactionCase):
         wizard.assign_quants()
         self.assertAlmostEqual(len(self.move.move_line_ids),
                                len(wizard.quants_lines.filtered('selected')))
+        self.assertFalse(self.move.picking_type_id.auto_fill_qty_done)
+        self.assertEqual(sum(self.move.move_line_ids.mapped('qty_done')), 0.0)
+
+    def test_quant_manual_assign_auto_fill_qty_done(self):
+        wizard = self.quant_assign_wizard.with_context(
+            active_id=self.move.id).create({
+            })
+        wizard.quants_lines[0].write({
+            'selected': True,
+        })
+        wizard.quants_lines[0]._onchange_selected()
+        wizard.quants_lines[1].write({
+            'selected': True,
+            'qty': 50.0,
+        })
+        self.assertEqual(wizard.lines_qty, 150.0)
+        self.picking_type.auto_fill_qty_done = True
+        wizard.assign_quants()
+        self.assertTrue(self.move.picking_type_id.auto_fill_qty_done)
+        self.assertEqual(sum(self.move.move_line_ids.mapped('qty_done')), 150.0)
 
     def test_quant_assign_wizard_after_availability_check(self):
         self.move._action_assign()

--- a/stock_quant_manual_assign/views/stock_picking_type_views.xml
+++ b/stock_quant_manual_assign/views/stock_picking_type_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="view_picking_type_form">
+        <field name="name">Operation Types</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='show_reserved']" position="after">
+                <field name="auto_fill_qty_done" attrs="{'invisible':[('code','=','incoming')]}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -52,9 +52,10 @@ class AssignManualQuants(models.TransientModel):
         move._do_unreserve()
         for line in self.quants_lines:
             line._assign_quant_line()
-        # Auto-fill all lines as done
-        for ml in move.move_line_ids:
-            ml.qty_done = ml.product_qty
+        if move.picking_type_id.auto_fill_qty_done:
+            # Auto-fill all lines as done
+            for ml in move.move_line_ids:
+                ml.qty_done = ml.product_qty
         move._recompute_state()
         move.mapped('picking_id')._compute_state()
         return {}


### PR DESCRIPTION
There are cases where auto-filling of qty_done of stock move line is not desirable.
e.g. you assign quants manually for some of the moves in a picking and not the others,
in such case you need to go over all the moves in the picking to either remove qty_done
or fill it in to proceed with the validation of the entire moves. Auto-fill behavior is
also troublesome when this function is used in a manufacturing order. i.e. having
qty_done of the component move live messes up the outcome of the production.

This PR makes the auto-fill of qty_done optional per picking type.

Related: https://github.com/OCA/manufacture/pull/586