### PR TITLE
[FIX] stock_mts_mto_rule: Installation across companies

### DIFF
--- a/stock_mts_mto_rule/data/stock_data.xml
+++ b/stock_mts_mto_rule/data/stock_data.xml
@@ -7,5 +7,6 @@
         <field name="name">Make To Order + Make To Stock</field>
         <field name="sequence">5</field>
         <field name="product_selectable" eval="True" />
+        <field name="company_id" eval="False" />
     </record>
 </odoo>


### PR DESCRIPTION
This change make the module to install  across all companies
 not only company we are on in the moment of the installation