### PR TITLE
[13.0][FIX] stock_vertical_lift: skip button is only for pick operation

### DIFF
--- a/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
+++ b/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
@@ -65,15 +65,6 @@
                     </div>
                     <div class="o_shuttle_content o_shuttle_content_right">
                         <div>
-                            <button
-                                name="button_skip"
-                                type="object"
-                                string="Skip"
-                                icon="fa-forward"
-                                class="btn-danger"
-                                barcode_trigger="skip"
-                                attrs="{'invisible': [('state', '=', 'noop')]}"
-                            />
                             <!-- will react on barcode 'O-BTN.save' -->
                             <button
                                 name="button_save"

--- a/stock_vertical_lift/views/vertical_lift_operation_pick_views.xml
+++ b/stock_vertical_lift/views/vertical_lift_operation_pick_views.xml
@@ -21,6 +21,17 @@
             <form position="attributes">
                 <attribute name="string">Pick Screen</attribute>
             </form>
+            <button name="button_save" position="before">
+                <button
+                    name="button_skip"
+                    type="object"
+                    string="Skip"
+                    icon="fa-forward"
+                    class="btn-danger"
+                    barcode_trigger="skip"
+                    attrs="{'invisible': [('state', '=', 'noop')]}"
+                />
+            </button>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
The button to skip an operation is only implemented for the pick
operation (not for the put or for the inventory ones) but it was
shown in the screens for all the operations, yielding to a stack
trace when it was pressed from the wrong operationg. The button
has been moved now to the screen for the pick operation, only.