### PR TITLE
[13.0] Fix stock_vertical_lift skip screen

### DIFF
--- a/stock_vertical_lift/models/vertical_lift_operation_pick.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_pick.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from itertools import cycle
+
 from odoo import _, models
 
 
@@ -83,15 +85,30 @@ class VerticalLiftOperationPick(models.Model):
     def fetch_tray(self):
         self.current_move_line_id.fetch_vertical_lift_tray_source()
 
+    def _get_next_move_line(self, order):
+        def get_next(move_lines, current_move_line):
+            if not move_lines:
+                return False
+            move_lines_cycle = cycle(move_lines)
+            if not current_move_line or current_move_line not in move_lines:
+                return next(move_lines_cycle)
+            # Point to current_move_line and then return the next
+            while next(move_lines_cycle) != current_move_line:
+                continue
+            return next(move_lines_cycle)
+
+        move_lines = self.env["stock.move.line"].search(
+            self._domain_move_lines_to_do(), order=order
+        )
+        return get_next(move_lines, self.current_move_line_id)
+
     def select_next_move_line(self):
         self.ensure_one()
         next_move_line_order = "vertical_lift_skipped"
         if self._order:
             # If there already exists an order, keep it.
             next_move_line_order += "," + self._order
-        next_move_line = self.env["stock.move.line"].search(
-            self._domain_move_lines_to_do(), limit=1, order=next_move_line_order
-        )
+        next_move_line = self._get_next_move_line(next_move_line_order)
         self.current_move_line_id = next_move_line
         if next_move_line:
             if next_move_line.vertical_lift_skipped:

--- a/stock_vertical_lift/tests/test_pick.py
+++ b/stock_vertical_lift/tests/test_pick.py
@@ -34,17 +34,29 @@ class TestPick(VerticalLiftCase):
     def test_pick_select_next_move_line(self):
         operation = self._open_screen("pick")
         operation.select_next_move_line()
-        self.assertEqual(operation.current_move_line_id, self.out_move_line)
+        self.assertEqual(
+            operation.current_move_line_id, self.picking_out.move_line_ids[1]
+        )
         self.assertEqual(operation.state, "scan_destination")
 
     def test_pick_select_next_move_line_was_skipped(self):
         """Previously skipped moves can be reprocessed"""
         self.picking_out.move_line_ids.write({"vertical_lift_skipped": True})
         operation = self._open_screen("pick")
+        self.assertEqual(
+            operation.current_move_line_id, self.picking_out.move_line_ids[0]
+        )
         operation.select_next_move_line()
-        self.assertEqual(operation.current_move_line_id, self.out_move_line)
+        self.assertEqual(
+            operation.current_move_line_id, self.picking_out.move_line_ids[1]
+        )
         self.assertEqual(operation.state, "scan_destination")
         self.assertFalse(operation.current_move_line_id.vertical_lift_skipped)
+        # When I skip the last move I come back to the first
+        operation.select_next_move_line()
+        self.assertEqual(
+            operation.current_move_line_id, self.picking_out.move_line_ids[0]
+        )
 
     def test_pick_save(self):
         operation = self._open_screen("pick")


### PR DESCRIPTION
In vertical lift we have a button to skip screens. When we reach the last screen, we must be able to move to the first one.