### PR TITLE
[12.0][IMP] stock_request_analytic + stock_request_purchase: Add Analytic Tags and propagate to PO

### DIFF
--- a/stock_request_analytic/models/stock_request.py
+++ b/stock_request_analytic/models/stock_request.py
@@ -10,6 +10,8 @@ class StockRequest(models.Model):
 
     analytic_account_id = fields.Many2one(
         'account.analytic.account', string='Analytic Account')
+    analytic_tag_ids = fields.Many2many(
+        'account.analytic.tag', string='Analytic Tags')
 
     @api.constrains('analytic_account_id')
     def _check_analytic_company_constrains(self):

--- a/stock_request_analytic/models/stock_request_order.py
+++ b/stock_request_analytic/models/stock_request_order.py
@@ -17,12 +17,20 @@ class StockRequestOrder(models.Model):
         string='Analytic Accounts',
         readonly=True,
     )
+    analytic_tag_ids = fields.One2many(
+        comodel_name='account.analytic.tag',
+        compute='_compute_analytic_ids',
+        string='Analytic Tags',
+        readonly=True,
+    )
 
     @api.depends('stock_request_ids')
     def _compute_analytic_ids(self):
         for req in self.sudo():
             req.analytic_account_ids = req.stock_request_ids.mapped(
                 'analytic_account_id')
+            req.analytic_tag_ids = req.stock_request_ids.mapped(
+                'analytic_tag_ids')
             req.analytic_count = len(req.analytic_account_ids)
 
     @api.multi

--- a/stock_request_analytic/models/stock_rule.py
+++ b/stock_request_analytic/models/stock_rule.py
@@ -13,7 +13,13 @@ class ProcurementRule(models.Model):
             product_id, product_qty, product_uom, location_id, name, origin,
             values, group_id)
         if values.get('stock_request_id'):
-            analytic_account_id = self.env['stock.request'].browse(
-                values['stock_request_id']).analytic_account_id.id
-            res.update(analytic_account_id=analytic_account_id)
+            stock_request = self.env['stock.request'].browse(
+                values['stock_request_id']
+            )
+            analytic_account = stock_request.analytic_account_id
+            analytic_tags = stock_request.analytic_tag_ids
+            res.update(
+                analytic_account_id=analytic_account.id,
+                analytic_tag_ids=[(4, tag.id) for tag in analytic_tags],
+            )
         return res

--- a/stock_request_analytic/views/stock_request_order_views.xml
+++ b/stock_request_analytic/views/stock_request_order_views.xml
@@ -10,6 +10,7 @@
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <field name="analytic_account_ids" invisible="1"/>
+                <field name="analytic_tag_ids" />
                 <button type="object"
                     name="action_view_analytic"
                     class="oe_stat_button"

--- a/stock_request_analytic/views/stock_request_views.xml
+++ b/stock_request_analytic/views/stock_request_views.xml
@@ -10,6 +10,7 @@
         <field name="arch" type="xml">
             <field name="procurement_group_id" position="after">
                 <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
+                <field name="analytic_tag_ids" groups="analytic.group_analytic_accounting"/>
             </field>
         </field>
     </record>

--- a/stock_request_purchase/models/stock_rule.py
+++ b/stock_request_purchase/models/stock_rule.py
@@ -12,7 +12,14 @@ class StockRule(models.Model):
         vals = super(StockRule, self)._prepare_purchase_order_line(
             product_id, product_qty, product_uom, values, po, supplier)
         if 'stock_request_id' in values:
-            vals['stock_request_ids'] = [(4, values['stock_request_id'])]
+            stock_request = self.env["stock.request"].browse(values['stock_request_id'])
+            vals['stock_request_ids'] = [(4, stock_request.id)]
+            if stock_request.analytic_account_id:
+                vals['account_analytic_id'] = stock_request.analytic_account_id.id
+            if stock_request.analytic_tag_ids:
+                vals['analytic_tag_ids'] = [
+                    (4, tag.id) for tag in stock_request.analytic_tag_ids
+                ]
         return vals
 
     def _update_purchase_order_line(self, product_id, product_qty, product_uom,

--- a/stock_request_purchase/tests/test_stock_request_purchase.py
+++ b/stock_request_purchase/tests/test_stock_request_purchase.py
@@ -230,3 +230,35 @@ class TestStockRequestPurchase(common.TransactionCase):
         self.assertEqual(action['domain'], '[]')
         self.assertEqual('views' in action.keys(), True)
         self.assertEqual(action['res_id'], order.purchase_ids[0].id)
+
+    def test_create_request_analytic_data(self):
+        """Single Stock request with analytic data"""
+        expected_date = fields.Datetime.now()
+        analytic_accont = self.env["account.analytic.account"].create({
+            "name": "Test Analytic Account",
+        })
+        analytic_tags = self.env.ref('analytic.tag_contract')
+        vals = {
+            'company_id': self.main_company.id,
+            'warehouse_id': self.warehouse.id,
+            'location_id': self.warehouse.lot_stock_id.id,
+            'expected_date': expected_date,
+            'stock_request_ids': [(0, 0, {
+                'product_id': self.product.id,
+                'product_uom_id': self.product.uom_id.id,
+                'product_uom_qty': 5.0,
+                'company_id': self.main_company.id,
+                'warehouse_id': self.warehouse.id,
+                'location_id': self.warehouse.lot_stock_id.id,
+                'expected_date': expected_date,
+                'analytic_account_id': analytic_accont.id,
+                'analytic_tag_ids': [(6, 0, analytic_tags.ids)],
+            })]
+        }
+        order = self.env['stock.request.order'].sudo(
+            self.stock_request_user).create(vals)
+        order.action_confirm()
+        order.refresh()
+        purchase = order.sudo().purchase_ids[0]
+        self.assertEqual(purchase.order_line[0].account_analytic_id, analytic_accont)
+        self.assertEqual(purchase.order_line[0].analytic_tag_ids, analytic_tags)


### PR DESCRIPTION
Needs https://github.com/OCA/account-analytic/pull/366 to add `analytic_tag_ids` field to `stock.move`.

@Tecnativa
TT28488

ping @pedrobaeza @chienandalu 