### PR TITLE
[12.0][FIX] stock_request_purchase: Check if fields exists previously and prevent error about it

### DIFF
--- a/stock_request_purchase/models/stock_rule.py
+++ b/stock_request_purchase/models/stock_rule.py
@@ -11,14 +11,17 @@ class StockRule(models.Model):
                                      product_uom, values, po, supplier):
         vals = super(StockRule, self)._prepare_purchase_order_line(
             product_id, product_qty, product_uom, values, po, supplier)
-        if 'stock_request_id' in values:
-            stock_request = self.env["stock.request"].browse(values['stock_request_id'])
-            vals['stock_request_ids'] = [(4, stock_request.id)]
-            if stock_request.analytic_account_id:
-                vals['account_analytic_id'] = stock_request.analytic_account_id.id
-            if stock_request.analytic_tag_ids:
-                vals['analytic_tag_ids'] = [
-                    (4, tag.id) for tag in stock_request.analytic_tag_ids
+        if "stock_request_id" in values:
+            request = self.env["stock.request"].browse(values["stock_request_id"])
+            vals["stock_request_ids"] = [(4, request.id)]
+            if (
+                request._fields.get("analytic_account_id")
+                and request.analytic_account_id
+            ):
+                vals["account_analytic_id"] = request.analytic_account_id.id
+            if request._fields.get("analytic_tag_ids") and request.analytic_tag_ids:
+                vals["analytic_tag_ids"] = [
+                    (4, tag.id) for tag in request.analytic_tag_ids
                 ]
         return vals
 

--- a/stock_request_purchase/tests/test_stock_request_purchase.py
+++ b/stock_request_purchase/tests/test_stock_request_purchase.py
@@ -233,6 +233,8 @@ class TestStockRequestPurchase(common.TransactionCase):
 
     def test_create_request_analytic_data(self):
         """Single Stock request with analytic data"""
+        if not self.stock_request._fields.get("analytic_account_id"):
+            self.skipTest('No analytic addon installed')
         expected_date = fields.Datetime.now()
         analytic_accont = self.env["account.analytic.account"].create({
             "name": "Test Analytic Account",


### PR DESCRIPTION
Check if fields (`analytic_account_id` + `analytic_tag_ids`) exists previously and prevent error about it.

Related to https://github.com/OCA/stock-logistics-warehouse/pull/1105

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa