### PR TITLE
[FIX] stock_available_mrp: don't force type

### DIFF
--- a/stock_available_mrp/tests/test_potential_qty.py
+++ b/stock_available_mrp/tests/test_potential_qty.py
@@ -29,11 +29,9 @@ class TestPotentialQty(TransactionCase):
             'mrp.product_product_table_kit_product_template')
         #  First variant
         self.var1 = self.browse_ref('mrp.product_product_table_kit')
-        self.var1.type = 'consu'
         #  Second variant
         self.var2 = self.browse_ref(
             'stock_available_mrp.product_kit_1a')
-        self.var2.type = 'consu'
         # Make bolt a stockable product to be able to change its stock
         # we need to unreserve the existing move before being able to do it.
         bolt = self.env.ref('mrp.product_product_computer_desk_bolt')


### PR DESCRIPTION
In Odoo change odoo/odoo@3d34d58
the products with Kit BoMs couldn't longer be other than `consu`.
This was reverted in odoo/odoo@6c4623a
and some products are raising errors when forcing the type

cc @Tecnativa TT28781