### PR TITLE
[13.0][FIX] stock_available_unreserved, include scrap location on the compute.

### DIFF
--- a/stock_available_unreserved/models/product.py
+++ b/stock_available_unreserved/models/product.py
@@ -91,6 +91,18 @@ class ProductProduct(models.Model):
                 product_sums.get(product.id, 0.0),
                 precision_rounding=product.uom_id.rounding,
             )
+            for obj_company in self.env.companies:
+                scrap_location = self.env["stock.location"].search(
+                    [("scrap_location", "=", True), ("company_id", "=", obj_company.id)]
+                )
+                quant_scrap = self.env["stock.quant"].search(
+                    [
+                        ("product_id", "=", product.id),
+                        ("location_id", "=", scrap_location.id),
+                    ]
+                )
+                if quant_scrap:
+                    available_not_res = available_not_res + quant_scrap.quantity
             res[product.id] = {"qty_available_not_res": available_not_res}
         return res
 


### PR DESCRIPTION
Pull request created to include the scrap location on the compute value for the available_unreserved.

So when we have a scrap location with a specific product it will be computed on the available_not_res field.