### PR TITLE
stock.request.order tier validation search view fix

### DIFF
--- a/stock_request_tier_validation/views/stock_request_order_view.xml
+++ b/stock_request_tier_validation/views/stock_request_order_view.xml
@@ -69,9 +69,9 @@
     </record>
 
     <record id="view_stock_request_order_filter" model="ir.ui.view">
-        <field name="name">stock.request.select - stock_request_tier_validation</field>
-        <field name="model">stock.request</field>
-        <field name="inherit_id" ref="stock_request.stock_request_search"/>
+        <field name="name">stock.request.order.select - stock_request_tier_validation</field>
+        <field name="model">stock.request.order</field>
+        <field name="inherit_id" ref="stock_request.stock_request_order_search"/>
         <field name="arch" type="xml">
             <search position="inside">
                 <group expand="0" string="Need actions">


### PR DESCRIPTION
It seems we had a typo on the stock.request.order tier validation search view which was wrongly affected to stock.request again.

Before this fix:
![2021-04-20_11-31_1](https://user-images.githubusercontent.com/16926/115445852-c71f4080-a1ec-11eb-8447-4e398ec70215.png)
![2021-04-20_11-31](https://user-images.githubusercontent.com/16926/115445868-cab2c780-a1ec-11eb-91fa-6cd12acc5fe3.png)
