### PR TITLE
[14.0][stock_available] Add depends_context to quantity computed field

### DIFF
--- a/stock_available/models/product_product.py
+++ b/stock_available/models/product_product.py
@@ -33,6 +33,15 @@ class ProductProduct(models.Model):
         return res, stock_dict
 
     @api.depends("virtual_available")
+    @api.depends_context(
+        "lot_id",
+        "owner_id",
+        "package_id",
+        "from_date",
+        "to_date",
+        "location",
+        "warehouse",
+    )
     def _compute_available_quantities(self):
         res, _ = self._compute_available_quantities_dict()
         for product in self:


### PR DESCRIPTION
Without this fix, the quantity fields will always give the same result in a same transaction even if asked location change for instance.

@ivantodorovich @hparfr @alan196 