### PR TITLE
Zippcube measure update

### DIFF
--- a/stock_measuring_device_zippcube/components/zippcube_device_component.py
+++ b/stock_measuring_device_zippcube/components/zippcube_device_component.py
@@ -35,5 +35,8 @@ class ZippcubeDevice(Component):
         }
 
     def post_update_packaging_measures(self, measures, packaging, wizard_line):
-        wizard_line.wizard_id._notify(_("Please, press the REFRESH button."))
+        # wizard_line is only set when measurements are made from the measurement
+        # device wizard.
+        if wizard_line:
+            wizard_line.wizard_id._notify(_("Please, press the REFRESH button."))
         packaging._measuring_device_release()


### PR DESCRIPTION
When the measure update is called from somewhere else than the
device wizard, an exception is raised.