### PR TITLE
[13.0][FIX] stock_request_picking_type - fixing stock.picking.type.kanban view

### DIFF
--- a/stock_request_picking_type/views/stock_picking_views.xml
+++ b/stock_request_picking_type/views/stock_picking_views.xml
@@ -13,23 +13,34 @@
             <xpath expr='//div[@name="stock_picking"]' position="after">
                 <div
                     t-if="record.code.raw_value == 'stock_request_order'"
-                    t-attf-class="#{kanban_color(record.color.raw_value)}"
+                    t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}"
                 >
                     <div>
                         <div t-attf-class="o_kanban_card_header">
                             <div class="o_kanban_card_header_title">
-                                <a
-                                    type="object"
-                                    name="get_stock_request_order_picking_type_action"
-                                    class="o_primary"
-                                >
+                                <div class="o_primary" t-if="!selection_mode">
+                                    <a
+                                        type="object"
+                                        name="get_stock_request_order_picking_type_action"
+                                    >
+                                        <field name="name" />
+                                    </a>
+                                </div>
+                                <div class="o_primary" t-if="selection_mode">
                                     <field name="name" />
-                                </a>
+                                </div>
                                 <div class="o_secondary">
-                                    <field class="o_secondary" name="warehouse_id" />
+                                    <field
+                                        class="o_secondary"
+                                        name="warehouse_id"
+                                        readonly="1"
+                                    />
                                 </div>
                             </div>
-                            <div class="o_kanban_manage_button_section">
+                            <div
+                                class="o_kanban_manage_button_section"
+                                t-if="!selection_mode"
+                            >
                                 <a class="o_kanban_manage_toggle_button" href="#">
                                     <i
                                         class="fa fa-ellipsis-v"
@@ -40,14 +51,17 @@
                                 </a>
                             </div>
                         </div>
-                        <div class="container o_kanban_card_content">
+                        <div
+                            class="container o_kanban_card_content"
+                            t-if="!selection_mode"
+                        >
                             <div class="row">
                                 <div class="col-6 o_kanban_primary_left">
                                     <button
                                         class="btn btn-primary"
                                         name="%(action_picking_dashboard)d"
                                         type="action"
-                                        context="{'search_default_todo': 1}"
+                                        context="{'search_default_submitted': 1}"
                                     >
                                         <span
                                             t-if="record.code.raw_value =='stock_request_order'"
@@ -65,7 +79,7 @@
                                             <a
                                                 name="%(action_picking_dashboard)d"
                                                 type="action"
-                                                context="{'search_default_inprogress': 1}"
+                                                context="{'search_default_open': 1}"
                                             >
                                                 In Progress
                                             </a>
@@ -120,8 +134,8 @@
                                         <a
                                             name="%(action_picking_dashboard)d"
                                             type="action"
-                                            context="{'search_default_todo': 1}"
-                                        >To Do</a>
+                                            context="{'search_default_draft': 1}"
+                                        >Draft</a>
                                     </div>
                                     <div role="menuitem">
                                         <a
@@ -166,7 +180,7 @@
                                         data-field="color"
                                     />
                                 </div>
-                                <div role="menuitem" class="col-4 text-right">
+                                <div role="menuitem" class="col-4 text-center">
                                     <a type="edit">Settings</a>
                                 </div>
                             </div>

--- a/stock_request_picking_type/views/stock_request_order_views.xml
+++ b/stock_request_picking_type/views/stock_request_order_views.xml
@@ -4,14 +4,22 @@
         <field name="model">stock.request.order</field>
         <field name="inherit_id" ref="stock_request.stock_request_order_search" />
         <field name="arch" type="xml">
-            <xpath expr='//filter[@name="location"]' position="after">
+            <field name="warehouse_id" position="after">
+                <field name="expected_date" />
+            </field>
+            <filter name="draft" position="after">
                 <filter
-                    string="Operation Type"
-                    name="picking_type_id"
-                    domain="[]"
-                    context="{'group_by': 'picking_type_id'}"
+                    string="Submitted"
+                    name="submitted"
+                    domain="[('state','=','submitted')]"
                 />
-            </xpath>
+                <filter
+                    string="Late"
+                    domain="['&amp;', ('expected_date', '&lt;', current_date), ('state', 'in', ('submitted', 'open'))]"
+                    name="late"
+                    help="Late Stock Requests"
+                />
+            </filter>
         </field>
     </record>
     <record id="stock_request_order_form_picking_type" model="ir.ui.view">
@@ -37,7 +45,6 @@
         <field name="view_id" eval="False" />
         <field name="search_view_id" ref="stock_request_order_search" />
         <field name="domain">[('picking_type_id', '=', active_id)]</field>
-        <field name="context">{'default_picking_type_id': active_id}</field>
     </record>
     <record id="action_stock_request_order_form" model="ir.actions.act_window">
         <field name="name">Stock Request Orders</field>


### PR DESCRIPTION
Reproduce : 

Go to Inventory/Overview.
Click on Stock Requests.
![image](https://user-images.githubusercontent.com/32102436/118619617-0ed1c180-b7c5-11eb-9230-d67981f2b3c7.png)
Leads to an error.
![image](https://user-images.githubusercontent.com/32102436/118619728-25781880-b7c5-11eb-8236-3cd73750a756.png)
Furthermore, buttons on this kanban card use filters that does not exist, so they don't work.
