### PR TITLE
[13.0] [FIX] stock_request: Fix multi-company rule.

### DIFF
--- a/stock_request/security/stock_request_security.xml
+++ b/stock_request/security/stock_request_security.xml
@@ -78,7 +78,7 @@
             <field name="global" eval="True" />
             <field
                 name="domain_force"
-            >['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+            >['|',('company_id','=',False), ('company_id', 'in', company_ids)]</field>
         </record>
         <record id="stock_request_order_followers_rule" model="ir.rule">
             <field name="name">Follow Stock Request Order</field>


### PR DESCRIPTION
The rule only apply for the user company not for the company that the user selected in the tab. This is old way, in v13 we use company_ids.