### PR TITLE
stock_vertical_lift_storage_type: fix tests

### DIFF
--- a/stock_vertical_lift_storage_type/tests/test_put.py
+++ b/stock_vertical_lift_storage_type/tests/test_put.py
@@ -128,6 +128,8 @@ class TestPut(VerticalLiftCase):
         # the dest location was Vertical Lift, it has been change to Vertical
         # Lift/Shuttle 1, and the computation from there took the first cell
         # available, we should be the pos x1 and y1 in the tray A.
+
+        # FIXME
         self.assertEqual(move_line.location_dest_id, self.location_1a_x1y1)
         self.assertEqual(
             move_line.package_level_id.location_dest_id, self.location_1a_x1y1


### PR DESCRIPTION
@jbaudoux could you check why this test if failing?

https://travis-ci.com/github/OCA/stock-logistics-warehouse/jobs/513083935#L2610

It could be related to the storage type change you made recently.

It could be a flappy test because the build was green on 13.0 few commits before:

![image](https://user-images.githubusercontent.com/347149/121848768-ca194780-ccea-11eb-8f54-40a89754b39e.png)
