### PR TITLE
[13.0][FIX] stock_secondary_unit: Allow use secondary units in form view for mobile views

### DIFF
--- a/stock_secondary_unit/views/stock_picking_views.xml
+++ b/stock_secondary_unit/views/stock_picking_views.xml
@@ -23,6 +23,21 @@
                     attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"
                 />
             </xpath>
+            <xpath
+                expr="//field[@name='move_ids_without_package']/form//field[@name='product_uom_qty']"
+                position="before"
+            >
+                <field
+                    name="secondary_uom_qty"
+                    attrs="{'invisible': [('parent.immediate_transfer', '=', True)], 'readonly': [('is_initial_demand_editable', '=', False)]}"
+                />
+                <field
+                    name="secondary_uom_id"
+                    domain="[('product_tmpl_id.product_variant_ids', 'in', [product_id])]"
+                    options="{'no_create': True}"
+                    attrs="{'invisible': [('parent.immediate_transfer', '=', True)], 'readonly': [('is_initial_demand_editable', '=', False)]}"
+                />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
cc @Tecnativa TT30538
ping @joao-p-marques @carlosdauden 

This PR adds secondary_uom_qty and secondary_uom_id fields to form views to be ready for mobile views