### PR TITLE
[13.0] stock_cycle_count error on location_id

### DIFF
--- a/stock_cycle_count/models/stock_location.py
+++ b/stock_cycle_count/models/stock_location.py
@@ -115,9 +115,6 @@ class StockLocation(models.Model):
         self.ensure_one()
         action = self.env.ref("stock_cycle_count.act_accuracy_stats")
         result = action.read()[0]
-        result["context"] = {"search_default_location_id": self.id}
-        new_domain = (
-            result["domain"][:-1] + ", ('location_id', 'child_of', active_ids)]"
-        )
+        new_domain = result["domain"][:-1] + ", ('location_ids', 'in', active_ids)]"
         result["domain"] = new_domain
         return result


### PR DESCRIPTION
Hi, when i try open Accuracy Stats get following error
![image](https://user-images.githubusercontent.com/7775116/123280131-22f89500-d4ce-11eb-8657-d84efc5b32d2.png)


![image](https://user-images.githubusercontent.com/7775116/123279945-f6dd1400-d4cd-11eb-9154-613f0aef8a4c.png)

field in` stock.inventory` is `location_ids(many2many)` https://github.com/odoo/odoo/blob/13.0/addons/stock/models/stock_inventory.py#L45-L49
