### PR TITLE
[13.0] [FIX] stock_inventory_include_exhausted: Filtered with product…

### DIFF
--- a/stock_inventory_include_exhausted/models/stock_inventory.py
+++ b/stock_inventory_include_exhausted/models/stock_inventory.py
@@ -18,6 +18,8 @@ class StockInventory(models.Model):
 
         if self.include_exhausted:
             domain = [("qty_available", "=", 0), ("type", "=", "product")]
+            product_ids = [data.get("product_id") for data in vals]
+            domain.append(("id", "not in", product_ids))
             if self.product_ids:
                 domain.append(("id", "in", self.product_ids.ids))
             exhausted_products = self.env["product.product"].search(domain)

--- a/stock_inventory_include_exhausted/tests/test_stock_inventory_include_exhausted.py
+++ b/stock_inventory_include_exhausted/tests/test_stock_inventory_include_exhausted.py
@@ -51,6 +51,9 @@ class StockInventoryIncludeExhaustedTest(TransactionCase):
         self.location = self.location_model.create(
             {"name": "Inventory tests 1", "usage": "internal"}
         )
+        self.location2 = self.location_model.create(
+            {"name": "Inventory tests 2", "usage": "internal"}
+        )
 
     def _create_inventory_all_products(self, name, location, include_exhausted):
         inventory = self.inventory_model.create(


### PR DESCRIPTION
… who has already created inventory line to avoid duplicated line.

Is is similar to odoo did for v14 https://github.com/odoo/odoo/blob/14.0/addons/stock/models/stock_inventory.py#L287 to consider if the inventory line has already created to avoid create again for the same product and location.