### PR TITLE
[13.0][stock_request_stage][add] new module to manage stock requests using stages

### DIFF
--- a/setup/stock_request_stage/odoo/addons/stock_request_stage
+++ b/setup/stock_request_stage/odoo/addons/stock_request_stage
@@ -1,0 +1,1 @@
+../../../../stock_request_stage

--- a/setup/stock_request_stage/setup.py
+++ b/setup/stock_request_stage/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -236,6 +236,10 @@ class StockRequest(models.Model):
             raise ValidationError(_("The picking policy must be equal to the order"))
 
     def _action_confirm(self):
+        if self.state != "draft":
+            raise UserError(
+                _("You can only confirm a stock request from a draft state")
+            )
         self._action_launch_procurement_rule()
         self.write({"state": "open"})
 

--- a/stock_request_stage/__init__.py
+++ b/stock_request_stage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_request_stage/__manifest__.py
+++ b/stock_request_stage/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2018 Creu Blanca
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Stock Request Stage",
+    "version": "13.0.1.0.1",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "license": "LGPL-3",
+    "summary": "Adds the possibility to manage stock requests by stages",
+    "depends": ["stock_request"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/stock_request_stage_views.xml",
+        "views/stock_request_views.xml",
+        "views/stock_request_menu.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/stock_request_stage/models/__init__.py
+++ b/stock_request_stage/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_request_stage
+from . import stock_request

--- a/stock_request_stage/models/stock_request.py
+++ b/stock_request_stage/models/stock_request.py
@@ -1,0 +1,64 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, fields, models
+from odoo.tools.misc import format_date
+
+
+class StockRequest(models.Model):
+    _inherit = "stock.request"
+
+    def _get_default_stage_id(self):
+        search_domain = [("fold", "=", False)]
+        order = "sequence"
+        return (
+            self.env["stock.request.stage"]
+            .search(search_domain, order=order, limit=1)
+            .id
+        )
+
+    stage_id = fields.Many2one(
+        "stock.request.stage",
+        default=_get_default_stage_id,
+        group_expand="_read_group_stage_ids",
+    )
+    color = fields.Integer(string="Color Index")
+    expected_date_formatted = fields.Char(compute="_compute_expected_date_formatted")
+    image_128 = fields.Image(related="product_id.image_128", readonly=True)
+
+    @api.depends("expected_date")
+    def _compute_expected_date_formatted(self):
+        for request in self:
+            request.expected_date_formatted = (
+                format_date(self.env, request.expected_date_formatted)
+                if request.expected_date
+                else None
+            )
+
+    @api.model
+    def _read_group_stage_ids(self, stages, domain, order):
+        return stages.sudo().search([], order=order)
+
+    def update_request_state(self):
+        for rec in self:
+            set_state = rec.stage_id.set_state
+            if set_state == "draft" and rec.state != "draft":
+                rec.action_draft()
+            elif set_state == "open" and rec.state != "open":
+                rec.action_confirm()
+            elif set_state == "cancel" and rec.state != "cancel":
+                rec.action_cancel()
+            elif set_state == "done" and rec.state != "done":
+                rec.action_done()
+
+    @api.model
+    def create(self, vals):
+        request = super(StockRequest, self).create(vals)
+        if vals.get("stage_id"):
+            request.update_request_state()
+        return request
+
+    def write(self, vals):
+        super(StockRequest, self).write(vals)
+        if vals.get("stage_id"):
+            self.update_request_state()

--- a/stock_request_stage/models/stock_request_stage.py
+++ b/stock_request_stage/models/stock_request_stage.py
@@ -1,0 +1,31 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import fields, models
+
+from odoo.addons.stock_request.models.stock_request import REQUEST_STATES
+
+
+class StockRequestStage(models.Model):
+    _name = "stock.request.stage"
+    _description = "Stock Request Stage"
+    _order = "sequence, id"
+
+    def _get_default_project_ids(self):
+        default_project_id = self.env.context.get("default_project_id")
+        return [default_project_id] if default_project_id else None
+
+    name = fields.Char(string="Stage Name", required=True, translate=True)
+    description = fields.Text(translate=True)
+    sequence = fields.Integer(default=1)
+    fold = fields.Boolean(
+        string="Folded in Kanban",
+        help="This stage is folded in the kanban view when there are "
+        "no records in that stage to display.",
+    )
+    set_state = fields.Selection(
+        selection=REQUEST_STATES,
+        string="Target Status",
+        help="Status that should be set when the stock request reaches to "
+        "this stage.",
+    )

--- a/stock_request_stage/models/stock_request_stage.py
+++ b/stock_request_stage/models/stock_request_stage.py
@@ -29,3 +29,8 @@ class StockRequestStage(models.Model):
         help="Status that should be set when the stock request reaches to "
         "this stage.",
     )
+    complete_pickings = fields.Boolean(
+        string="Complete pickings",
+        help="When this stage is reached the system will try to complete the "
+        "pickings associated with the stock request.",
+    )

--- a/stock_request_stage/readme/CONFIGURE.rst
+++ b/stock_request_stage/readme/CONFIGURE.rst
@@ -1,0 +1,7 @@
+To configure this module:
+
+* Go to Stock Requests > Settings
+
+Define new stages as needed. If you want to change the status of a stock
+request when a certain stage is reached, indicate the target status in the
+stage.

--- a/stock_request_stage/readme/CONTRIBUTORS.rst
+++ b/stock_request_stage/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `ForgeFlow <https://www.forgeflow.com>`_
+
+  * Jordi Ballester (ForgeFlow, S) <jordi.ballester@forgeflow.com>.

--- a/stock_request_stage/readme/DESCRIPTION.rst
+++ b/stock_request_stage/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module allows you to manage the completion of stock requests in stages.
+A Kanban view is added to stock requests, allowing you to move stock requests
+across the defined stages.

--- a/stock_request_stage/readme/USAGE.rst
+++ b/stock_request_stage/readme/USAGE.rst
@@ -1,0 +1,3 @@
+* Go to 'Stock Requests / Stock Requests' and press the Kanban view. You will
+  be able to move each stock request through the various stages that you may
+  have defined.

--- a/stock_request_stage/security/ir.model.access.csv
+++ b/stock_request_stage/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_request_stage_user,stock.request.stage.user,model_stock_request_stage,stock_request.group_stock_request_user,1,0,0,0
+access_stock_request_stage_manager,stock.request.stage manager,model_stock_request_stage,stock_request.group_stock_request_user,1,1,1,1

--- a/stock_request_stage/views/stock_request_menu.xml
+++ b/stock_request_stage/views/stock_request_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <menuitem
+        id="stock_request_stage_menu"
+        name="Stages"
+        parent="stock_request.menu_stock_request_config"
+        action="stock_request_stage_action"
+        groups="stock_request.group_stock_request_manager"
+    />
+</odoo>

--- a/stock_request_stage/views/stock_request_stage_views.xml
+++ b/stock_request_stage/views/stock_request_stage_views.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ForgeFlow
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <record id="view_stock_request_stage_tree" model="ir.ui.view">
+        <field name="name">stock.request.stage.tree</field>
+        <field name="model">stock.request.stage</field>
+        <field name="arch" type="xml">
+            <tree string="Stock Request Stage">
+                <field name="sequence" widget="handle" />
+                <field name="name" />
+                <field name="fold" />
+                <field name="description" />
+            </tree>
+        </field>
+    </record>
+    <record id="view_stock_request_stage_form" model="ir.ui.view">
+        <field name="name">stock.request.stage.form</field>
+        <field name="model">stock.request.stage</field>
+        <field name="arch" type="xml">
+            <form string="Stock Request Stage">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name" />
+                        </group>
+                        <group>
+                            <field name="fold" />
+                            <field name="sequence" />
+                            <field name="set_state" />
+                        </group>
+                    </group>
+                    <group string="Stage Description">
+                        <field
+                            name="description"
+                            placeholder="Add a description..."
+                            nolabel="1"
+                            colspan="2"
+                        />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="stock_request_stage_action" model="ir.actions.act_window">
+        <field name="name">Stages</field>
+        <field name="res_model">stock.request.stage</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="view_stock_request_stage_tree" />
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+            Create a new stage to manage stock requests
+          </p>
+            <p>
+            Define the steps that will be used in the stock request from the
+            creation, up to the closing.
+            You will use these stages in order to track the progress in
+            solving a stock request.
+          </p>
+        </field>
+    </record>
+</odoo>

--- a/stock_request_stage/views/stock_request_stage_views.xml
+++ b/stock_request_stage/views/stock_request_stage_views.xml
@@ -28,6 +28,7 @@
                             <field name="fold" />
                             <field name="sequence" />
                             <field name="set_state" />
+                            <field name="complete_pickings" />
                         </group>
                     </group>
                     <group string="Stage Description">

--- a/stock_request_stage/views/stock_request_views.xml
+++ b/stock_request_stage/views/stock_request_views.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ForgeFlow
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <record id="view_stock_request_tree" model="ir.ui.view">
+        <field name="name">stock.request.tree</field>
+        <field name="model">stock.request</field>
+        <field name="inherit_id" ref="stock_request.view_stock_request_tree" />
+        <field name="arch" type="xml">
+            <field name="state" position="before">
+                <field name="stage_id" />
+            </field>
+        </field>
+    </record>
+    <record id="view_stock_request_form" model="ir.ui.view">
+        <field name="name">stock.request.form</field>
+        <field name="model">stock.request</field>
+        <field name="inherit_id" ref="stock_request.view_stock_request_form" />
+        <field name="arch" type="xml">
+            <field name="picking_policy" position="after">
+                <field name="stage_id" />
+            </field>
+        </field>
+    </record>
+    <record id="view_stock_request_kanban" model="ir.ui.view">
+        <field name="name">stock.request.kanban.view</field>
+        <field name="model">stock.request</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="stage_id" quick_create="false">
+                <field name="color" />
+                <field
+                    name="stage_id"
+                    options='{"group_by_tooltip": {"description": "Description"}}'
+                />
+                <field name="requested_by" />
+                <field name="product_id" />
+                <field name="product_uom_id" />
+                <field name="product_uom_qty" />
+                <field name="message_needaction_counter" />
+                <field name="expected_date" />
+                <field name="expected_date_formatted" />
+                <field name="activity_ids" />
+                <field name="activity_state" />
+                <templates>
+                    <t t-name="kanban-box">
+                        <div
+                            t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card o_kanban_record_has_image_fill oe_kanban_global_click"
+                        >
+                            <field
+                                name="image_128"
+                                widget="image"
+                                class="o_kanban_image_fill_left"
+                                options='{"preview_image": "image_128", "size": [60, 60]}'
+                            />
+                            <div class="oe_kanban_content">
+                                <div class="o_kanban_record_top">
+                                    <div class="o_kanban_record_headings">
+                                        <strong class="o_kanban_record_title">
+                                            <field name="name" />
+                                        </strong>
+                                        <br />
+                                    </div>
+                                    <div
+                                        class="o_dropdown_kanban dropdown"
+                                        t-if="!selection_mode"
+                                        groups="base.group_user"
+                                    >
+                                        <a
+                                            role="button"
+                                            class="dropdown-toggle o-no-caret btn"
+                                            data-toggle="dropdown"
+                                            data-display="static"
+                                            href="#"
+                                            aria-label="Dropdown menu"
+                                            title="Dropdown menu"
+                                        >
+                                            <span class="fa fa-ellipsis-v" />
+                                        </a>
+                                        <div class="dropdown-menu" role="menu">
+                                            <a
+                                                t-if="widget.editable"
+                                                role="menuitem"
+                                                type="edit"
+                                                class="dropdown-item"
+                                            >Edit</a>
+                                            <a
+                                                t-if="widget.deletable"
+                                                role="menuitem"
+                                                type="delete"
+                                                class="dropdown-item"
+                                            >Delete</a>
+                                            <div
+                                                role="separator"
+                                                class="dropdown-divider"
+                                            />
+                                            <ul
+                                                class="oe_kanban_colorpicker"
+                                                data-field="color"
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="o_kanban_record_body">
+                                    <field name="product_id" />
+                                    <br />
+                                    <field name="location_id" />
+                                </div>
+                                <div
+                                    class="o_kanban_record_bottom"
+                                    t-if="!selection_mode"
+                                >
+                                    <div class="oe_kanban_bottom_left">
+                                        <field name="state" />
+                                        <field
+                                            name="activity_ids"
+                                            widget="kanban_activity"
+                                        />
+                                        <t
+                                            t-if="record.message_needaction_counter.raw_value"
+                                        >
+                                            <span
+                                                role="alert"
+                                                class='oe_kanban_mail_new'
+                                                title='Unread Messages'
+                                            >
+                                                <i
+                                                    class='fa fa-comments'
+                                                    role="img"
+                                                    aria-label="Unread Messages"
+                                                />
+                                                <t
+                                                    t-raw="record.message_needaction_counter.raw_value"
+                                                />
+                                            </span>
+                                        </t>
+                                        <!-- formating of the date -->
+                                        <t t-set="date_format" t-value="'MM/DD/YY'" />
+                                        <t t-set="date" t-value="" />
+                                        <!-- color of the span -->
+                                        <t
+                                            t-if="record.expected_date.raw_value and moment(record.expected_date.raw_value.toISOString()).startOf('day') lt moment().startOf('day')"
+                                        >
+                                            <t
+                                                t-set="expected_date_class"
+                                                t-value="'oe_kanban_text_red'"
+                                            />
+                                        </t>
+                                        <t
+                                            t-elif="record.expected_date.raw_value and moment(record.expected_date.raw_value.toISOString()).startOf('day') lt moment().endOf('day')"
+                                        >
+                                            <t
+                                                t-set="expected_date_class"
+                                                t-value="'text-warning font-weight-bold'"
+                                            />
+                                        </t>
+                                        <!-- Date value -->
+                                        <t
+                                            t-if="record.expected_date.raw_value"
+                                            t-set="date"
+                                            t-value="record.expected_date_formatted.raw_value"
+                                        />
+                                        <span
+                                            name="date"
+                                            t-attf-class="#{expected_date_class || ''}"
+                                        >
+                                            <t t-esc="date" />
+                                        </span>
+                                    </div>
+                                    <div class="oe_kanban_bottom_right">
+                                        <span>
+                                            <field name="product_uom_qty" />
+                                            <field name="product_uom_id" />
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="oe_clear" />
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+    <record id="stock_request.action_stock_request_form" model="ir.actions.act_window">
+        <field name="view_mode">tree,form,pivot,kanban</field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module allows you to manage the completion of stock requests in stages.
A Kanban view is added to stock requests, allowing you to move stock requests
across the defined stages.


![image](https://user-images.githubusercontent.com/7683926/125826197-65d76e5e-d89f-4aad-bcb1-5991bf2b4310.png)
