### PR TITLE
[FIX] add OCA repos for dependencies

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,4 @@
 # See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca_dependencies-txt
+
+server-ux
+web


### PR DESCRIPTION
Dependencies are missing for 

- stock_demand_estimate_matrix
- stock_picking_cancel_confirm 

in oca_dependencies.txt, causing other PR with OCA PR dependecies to fail ([PR 659 on manufacture)](https://github.com/OCA/manufacture/pull/659)
This PR fixes it.