### PR TITLE
[14.0][IMP] stock_quant_manual_assign: auto-set done now optional

### DIFF
--- a/stock_quant_manual_assign/__init__.py
+++ b/stock_quant_manual_assign/__init__.py
@@ -1,1 +1,2 @@
 from . import wizard
+from . import models

--- a/stock_quant_manual_assign/__manifest__.py
+++ b/stock_quant_manual_assign/__manifest__.py
@@ -3,6 +3,7 @@
 # Copyright 2018 Fanha Giang
 # Copyright 2018 Tecnativa - Vicent Cubells
 # Copyright 2016-2018 Tecnativa - Pedro M. Baeza
+# Copyright 2021 ForgeFlow - Lois Rilo
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {
@@ -19,6 +20,7 @@
     "depends": ["stock"],
     "data": [
         "wizard/assign_manual_quants_view.xml",
+        "wizard/res_config_settings_views.xml",
         "views/stock_move_view.xml",
         "security/ir.model.access.csv",
     ],

--- a/stock_quant_manual_assign/models/__init__.py
+++ b/stock_quant_manual_assign/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_company

--- a/stock_quant_manual_assign/models/res_company.py
+++ b/stock_quant_manual_assign/models/res_company.py
@@ -1,0 +1,16 @@
+# Copyright 2021 ForgeFlow S.L. (http://www.forgeflow.com)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    stock_quant_manual_assign_as_done = fields.Boolean(
+        string="Manually Assigned Quants Increase Done Quantity",
+        default=True,
+        help="When using the Manual Quants wizard in operations, a reservation "
+        "for the selected quant will be done, you can decide if this will "
+        "also automatically increase the done quantity or not",
+    )

--- a/stock_quant_manual_assign/wizard/__init__.py
+++ b/stock_quant_manual_assign/wizard/__init__.py
@@ -1,1 +1,2 @@
 from . import assign_manual_quants
+from . import res_config_settings

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -62,8 +62,9 @@ class AssignManualQuants(models.TransientModel):
         for line in self.quants_lines:
             line._assign_quant_line()
         # Auto-fill all lines as done
-        for ml in move.move_line_ids:
-            ml.qty_done = ml.product_qty
+        if move.company_id.stock_quant_manual_assign_as_done:
+            for ml in move.move_line_ids:
+                ml.qty_done = ml.product_qty
         move._recompute_state()
         move.mapped("picking_id")._compute_state()
         return {}

--- a/stock_quant_manual_assign/wizard/res_config_settings.py
+++ b/stock_quant_manual_assign/wizard/res_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2021 ForgeFlow S.L. (http://www.forgeflow.com)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    stock_quant_manual_assign_as_done = fields.Boolean(
+        related="company_id.stock_quant_manual_assign_as_done", readonly=False
+    )

--- a/stock_quant_manual_assign/wizard/res_config_settings_views.xml
+++ b/stock_quant_manual_assign/wizard/res_config_settings_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2021 ForgeFlow S.L. (http://www.forgeflow.com)
+    License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+-->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field
+            name="name"
+        >res.config.settings.view.form.inherit.stock - stock_quant_manual_assign</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div name="operations_setting_container" position="inside">
+                <div class="col-12 col-lg-6 o_setting_box" id="warning_info">
+                    <div class="o_setting_left_pane">
+                        <field name="stock_quant_manual_assign_as_done" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="stock_quant_manual_assign_as_done" />
+                        <span
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                        />
+                        <div class="text-muted">
+                            When using the Manual Quants wizard in operations, a reservation
+                            for the selected quant will be done, you can decide if this will
+                            also automatically increase the done quantity or not.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Add *Manually Assigned Quants Increase Done Quantity* setting.

If you only have some operations manually selected, if the done 
qty es automatically set, you are forced to manually go through
the other operations and set the done quanity, otherwise       
validating the picking will complete it partially.

@ForgeFlow