### PR TITLE
[13.0][IMP] stock_quant_manual_assign: make qty_done fill optional

### DIFF
--- a/stock_quant_manual_assign/__init__.py
+++ b/stock_quant_manual_assign/__init__.py
@@ -1,1 +1,2 @@
+from . import models
 from . import wizard

--- a/stock_quant_manual_assign/__manifest__.py
+++ b/stock_quant_manual_assign/__manifest__.py
@@ -17,6 +17,10 @@
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "depends": ["stock"],
-    "data": ["wizard/assign_manual_quants_view.xml", "views/stock_move_view.xml"],
+    "data": [
+        "wizard/assign_manual_quants_view.xml",
+        "views/stock_move_view.xml",
+        "views/stock_picking_type_views.xml",
+    ],
     "installable": True,
 }

--- a/stock_quant_manual_assign/models/__init__.py
+++ b/stock_quant_manual_assign/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking_type

--- a/stock_quant_manual_assign/models/stock_picking_type.py
+++ b/stock_quant_manual_assign/models/stock_picking_type.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    auto_fill_qty_done = fields.Boolean(
+        "Auto-fill Quantity Done",
+        help="Select this in case done quantity of the stock move line should "
+        "be auto-filled when quants are manually assigned.",
+    )

--- a/stock_quant_manual_assign/readme/CONFIGURATION.rst
+++ b/stock_quant_manual_assign/readme/CONFIGURATION.rst
@@ -1,0 +1,3 @@
+In case you would like to auto-fill the done quantity of the stock move line
+with manual assignment of a quant, go to *Invenory > Configuration > Warehouse Management > Operation Types*,
+and select 'Auto-fill Quantity Done' for concerned types.

--- a/stock_quant_manual_assign/views/stock_picking_type_views.xml
+++ b/stock_quant_manual_assign/views/stock_picking_type_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="view_picking_type_form">
+        <field name="name">Operation Types</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='show_reserved']" position="after">
+                <field
+                    name="auto_fill_qty_done"
+                    attrs="{'invisible':[('code','=','incoming')]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -58,9 +58,10 @@ class AssignManualQuants(models.TransientModel):
         move._do_unreserve()
         for line in self.quants_lines:
             line._assign_quant_line()
-        # Auto-fill all lines as done
-        for ml in move.move_line_ids:
-            ml.qty_done = ml.product_qty
+        if move.picking_type_id.auto_fill_qty_done:
+            # Auto-fill all lines as done
+            for ml in move.move_line_ids:
+                ml.qty_done = ml.product_qty
         move._recompute_state()
         move.mapped("picking_id")._compute_state()
         return {}

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -79,31 +79,36 @@ class AssignManualQuants(models.TransientModel):
         )
         quants_lines = []
         for quant in available_quants:
-            line = {
-                "quant_id": quant.id,
-                "on_hand": quant.quantity,
-                "location_id": quant.location_id.id,
-                "lot_id": quant.lot_id.id,
-                "package_id": quant.package_id.id,
-                "owner_id": quant.owner_id.id,
-                "selected": False,
-            }
-            move_lines = move.move_line_ids.filtered(
-                lambda ml: (
-                    ml.location_id == quant.location_id
-                    and ml.lot_id == quant.lot_id
-                    and ml.owner_id == quant.owner_id
-                    and ml.package_id == quant.package_id
-                )
-            )
-            line["qty"] = sum(move_lines.mapped("product_uom_qty"))
-            line["selected"] = bool(line["qty"])
-            line["reserved"] = quant.reserved_quantity - line["qty"]
+            line = self._prepare_wizard_line(move, quant)
             quants_lines.append(line)
         res.update(
             {"quants_lines": [(0, 0, x) for x in quants_lines], "move_id": move.id}
         )
         return res
+
+    @api.model
+    def _prepare_wizard_line(self, move, quant):
+        line = {
+            "quant_id": quant.id,
+            "on_hand": quant.quantity,
+            "location_id": quant.location_id.id,
+            "lot_id": quant.lot_id.id,
+            "package_id": quant.package_id.id,
+            "owner_id": quant.owner_id.id,
+            "selected": False,
+        }
+        move_lines = move.move_line_ids.filtered(
+            lambda ml: (
+                ml.location_id == quant.location_id
+                and ml.lot_id == quant.lot_id
+                and ml.owner_id == quant.owner_id
+                and ml.package_id == quant.package_id
+            )
+        )
+        line["qty"] = sum(move_lines.mapped("product_uom_qty"))
+        line["selected"] = bool(line["qty"])
+        line["reserved"] = quant.reserved_quantity - line["qty"]
+        return line
 
 
 class AssignManualQuantsLines(models.TransientModel):


### PR DESCRIPTION
There are cases where auto-filling of qty_done of stock move line is not desirable.
e.g. you assign quants manually for some of the moves in a picking and not the others,
in such case you need to go over all the moves in the picking to either remove qty_done
or fill it in to proceed with the validation of the entire moves. Auto-fill behavior is
also troublesome when this function is used in a manufacturing order. i.e. having
qty_done of the component move live messes up the outcome of the production.

Forward port of https://github.com/OCA/stock-logistics-warehouse/pull/1055.

@ForgeFlow