### PR TITLE
[14.0][IMP] stock_quant_manual_assign: make qty_done fill optional

### DIFF
--- a/stock_quant_manual_assign/__init__.py
+++ b/stock_quant_manual_assign/__init__.py
@@ -1,1 +1,2 @@
+from . import models
 from . import wizard

--- a/stock_quant_manual_assign/__manifest__.py
+++ b/stock_quant_manual_assign/__manifest__.py
@@ -21,6 +21,7 @@
         "wizard/assign_manual_quants_view.xml",
         "views/stock_move_view.xml",
         "security/ir.model.access.csv",
+        "views/stock_picking_type_views.xml",
     ],
     "installable": True,
 }

--- a/stock_quant_manual_assign/models/__init__.py
+++ b/stock_quant_manual_assign/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking_type

--- a/stock_quant_manual_assign/models/stock_picking_type.py
+++ b/stock_quant_manual_assign/models/stock_picking_type.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    auto_fill_qty_done = fields.Boolean(
+        "Auto-fill Quantity Done",
+        help="Select this in case done quantity of the stock move line should "
+        "be auto-filled when quants are manually assigned.",
+    )

--- a/stock_quant_manual_assign/readme/CONFIGURATION.rst
+++ b/stock_quant_manual_assign/readme/CONFIGURATION.rst
@@ -1,0 +1,3 @@
+In case you would like to auto-fill the done quantity of the stock move line
+with manual assignment of a quant, go to *Invenory > Configuration > Warehouse Management > Operation Types*,
+and select 'Auto-fill Quantity Done' for concerned types.

--- a/stock_quant_manual_assign/tests/test_stock_quant_manual_assign.py
+++ b/stock_quant_manual_assign/tests/test_stock_quant_manual_assign.py
@@ -9,6 +9,7 @@ class TestStockQuantManualAssign(TransactionCase):
     def setUp(self):
         super(TestStockQuantManualAssign, self).setUp()
         self.quant_model = self.env["stock.quant"]
+        self.picking_model = self.env["stock.picking"]
         self.location_model = self.env["stock.location"]
         self.move_model = self.env["stock.move"]
         self.quant_assign_wizard = self.env["assign.manual.quants"]
@@ -38,6 +39,7 @@ class TestStockQuantManualAssign(TransactionCase):
                 "location_id": self.location_src.id,
             }
         )
+        self.picking_type = self.env.ref("stock.picking_type_out")
         self.quant1 = self.quant_model.sudo().create(
             {
                 "product_id": self.product.id,
@@ -67,6 +69,7 @@ class TestStockQuantManualAssign(TransactionCase):
                 "product_uom": self.product.uom_id.id,
                 "location_id": self.location_src.id,
                 "location_dest_id": self.location_dst.id,
+                "picking_type_id": self.picking_type.id,
             }
         )
         self.move._action_confirm()
@@ -136,6 +139,21 @@ class TestStockQuantManualAssign(TransactionCase):
             2,
             "There are 2 quants selected",
         )
+        self.assertFalse(self.move.picking_type_id.auto_fill_qty_done)
+        self.assertEqual(sum(self.move.move_line_ids.mapped("qty_done")), 0.0)
+
+    def test_quant_manual_assign_auto_fill_qty_done(self):
+        wizard = self.quant_assign_wizard.with_context(active_id=self.move.id).create(
+            {}
+        )
+        wizard.quants_lines[0].write({"selected": True})
+        wizard.quants_lines[0]._onchange_selected()
+        wizard.quants_lines[1].write({"selected": True, "qty": 50.0})
+        self.assertEqual(wizard.lines_qty, 150.0)
+        self.picking_type.auto_fill_qty_done = True
+        wizard.assign_quants()
+        self.assertTrue(self.move.picking_type_id.auto_fill_qty_done)
+        self.assertEqual(sum(self.move.move_line_ids.mapped("qty_done")), 150.0)
 
     def test_quant_assign_wizard_after_availability_check(self):
         self.move._action_assign()

--- a/stock_quant_manual_assign/views/stock_picking_type_views.xml
+++ b/stock_quant_manual_assign/views/stock_picking_type_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="view_picking_type_form">
+        <field name="name">Operation Types</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='show_reserved']" position="after">
+                <field
+                    name="auto_fill_qty_done"
+                    attrs="{'invisible':[('code','=','incoming')]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -61,9 +61,10 @@ class AssignManualQuants(models.TransientModel):
         move._do_unreserve()
         for line in self.quants_lines:
             line._assign_quant_line()
-        # Auto-fill all lines as done
-        for ml in move.move_line_ids:
-            ml.qty_done = ml.product_qty
+        if move.picking_type_id.auto_fill_qty_done:
+            # Auto-fill all lines as done
+            for ml in move.move_line_ids:
+                ml.qty_done = ml.product_qty
         move._recompute_state()
         move.mapped("picking_id")._compute_state()
         return {}


### PR DESCRIPTION
There are cases where auto-filling of qty_done of stock move line is not desirable.
e.g. you assign quants manually for some of the moves in a picking and not the others,
in such case you need to go over all the moves in the picking to either remove qty_done
or fill it in to proceed with the validation of the entire moves. Auto-fill behavior is
also troublesome when this function is used in a manufacturing order. i.e. having
qty_done of the component move live messes up the outcome of the production.

Forward port of https://github.com/OCA/stock-logistics-warehouse/pull/1204.

@ForgeFlow