### PR TITLE
[13.0][FIX] stock_move_packaging_qty: Warning on runbot

### DIFF
--- a/stock_move_packaging_qty/models/stock_move.py
+++ b/stock_move_packaging_qty/models/stock_move.py
@@ -4,8 +4,6 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
-from odoo.addons import decimal_precision as dp
-
 
 class StockPicking(models.Model):
     _inherit = "stock.move"
@@ -20,7 +18,7 @@ class StockPicking(models.Model):
         string="Package quantity",
         compute="_compute_product_packaging_qty",
         inverse="_inverse_product_packaging_qty",
-        digits=dp.get_precision("Product Unit of Measure"),
+        digits="Product Unit of Measure",
     )
 
     @api.depends(


### PR DESCRIPTION
Since v13 the use of decimal_precision is deprecated, so we have to use
the correct way.

cc @Tecnativa TT30810