### PR TITLE
[13.0][FIX] s_o_manual_procurement: handle NewId

### DIFF
--- a/stock_orderpoint_manual_procurement/models/stock_warehouse_orderpoint.py
+++ b/stock_orderpoint_manual_procurement/models/stock_warehouse_orderpoint.py
@@ -41,8 +41,19 @@ class StockWarehouseOrderpoint(models.Model):
 
     @api.depends("product_min_qty", "product_id", "qty_multiple")
     def _compute_procure_recommended(self):
-        op_qtys = self._quantity_in_progress()
+        # '_quantity_in_progress' override in 'purchase_stock' method has not
+        # been designed to work with NewIds (resulting in KeyError exceptions).
+        # To circumvent this, we knowingly skip such records here.
+        op_qtys = self.filtered(lambda x: x.id)._quantity_in_progress()
         for op in self:
+            if not op.id:
+                op.update(
+                    {
+                        "procure_recommended_qty": False,
+                        "procure_recommended_date": False,
+                    }
+                )
+                continue
             qty = 0.0
             virtual_qty = op.with_context(
                 location=op.location_id.id

--- a/stock_orderpoint_manual_procurement/tests/test_stock_orderpoint_manual_procurement.py
+++ b/stock_orderpoint_manual_procurement/tests/test_stock_orderpoint_manual_procurement.py
@@ -170,3 +170,11 @@ class TestStockWarehouseOrderpoint(common.TransactionCase):
         self.assertEquals(len(purchase_line), 1)
         pol_date = fields.Date.from_string(purchase_line.date_planned)
         self.assertEquals(pol_date, manual_date)
+
+    def test_compute_procure_recommended_with_newid(self):
+        """'_compute_procure_recommended' method uses '_quantity_in_progress'
+        standard method which could trigger an issue in 'purchase_stock' when
+        dealing with NewID IDs.
+        """
+        self.create_orderpoint_procurement()
+        self.reorder.new(origin=self.reorder)._compute_procure_recommended()


### PR DESCRIPTION
The use of `_quantity_in_progress` method in a computed field triggers a `KeyError` in the [`purchase_stock`](https://github.com/odoo/odoo/blob/b99b96f17ae765eeccac0f70dd52c5b6f42835a0/addons/purchase_stock/models/stock.py#L170) if the computed orderpoint record has a `NewId` value instead of an integer.
Hash of `NewId(origin=1)` and `1` are equal but it is not enough to get them compared as equals for key lookup in a dictionary.

How this issue has been triggered (could be done through another way for sure):

1. Install `stock_orderpoint_purchase_link` (it shows a `orderpoint_ids` field on POL form)
2. On an existing PO, open the form of one of the POL having `orderpoint_ids` filled
3. In Edit mode, try to change the `date_planned` to trigger an onchange on PO
4. the onchange call will trigger the `_compute_procure_recommended` with a recordset with a `NewId(origin=...)`

The first commit reproduces the issue in a unit test while the second fix it.

```ERROR: TestStockWarehouseOrderpoint.test_compute_procure_recommended_with_newid
Traceback (most recent call last):
  File "/home/travis/build/camptocamp/stock-logistics-warehouse/stock_orderpoint_manual_procurement/tests/test_stock_orderpoint_manual_procurement.py", line 180, in test_compute_procure_recommended_with_newid
    self.reorder.new(origin=self.reorder)._compute_procure_recommended()
  File "/home/travis/build/camptocamp/stock-logistics-warehouse/stock_orderpoint_manual_procurement/models/stock_warehouse_orderpoint.py", line 44, in _compute_procure_recommended
    op_qtys = self._quantity_in_progress()
  File "/home/travis/odoo-13.0/addons/purchase_stock/models/stock.py", line 172, in _quantity_in_progress
    res[poline.orderpoint_id.id] += poline.product_uom._compute_quantity(poline.product_qty, poline.orderpoint_id.product_uom, round=False)
KeyError: 24
```