### PR TITLE
12.0 [IMP] simplify_stock_move_location

### DIFF
--- a/stock_move_location/readme/CONTRIBUTORS.rst
+++ b/stock_move_location/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
 * Lois Rilo <lois.rilo@eficent.com>
 * Jacques-Etienne Baudoux <je@bcim.be>
 * Iryna Vyshnevska <i.vyshnevska@mobilunity.com>
+* Takahiro Yabe <yabe@quartile.co>

--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -78,43 +78,23 @@ class StockMoveLocationWizard(models.TransientModel):
         # Load data directly from quants
         quants = self.env['stock.quant'].browse(
             self.env.context.get('active_ids', False))
-        res['stock_move_location_line_ids'] = self._prepare_wizard_move_lines(quants)
+        res['stock_move_location_line_ids'] = [
+            (
+                0,
+                0,
+                {
+                    'product_id': quant.product_id.id,
+                    'move_quantity': quant.quantity,
+                    'max_quantity': quant.quantity,
+                    'origin_location_id': quant.location_id.id,
+                    'lot_id': quant.lot_id.id,
+                    'product_uom_id': quant.product_uom_id.id,
+                    'custom': False,
+                }
+            )
+            for quant in quants
+        ]
         res['origin_location_id'] = first(quants).location_id.id
-        return res
-
-    @api.model
-    def _prepare_wizard_move_lines(self, quants):
-        res = []
-        exclude_reserved_qty = self.env.context.get('only_reserved_qty', False)
-        if not exclude_reserved_qty:
-            res = [(0, 0, {
-                'product_id': quant.product_id.id,
-                'move_quantity': quant.quantity,
-                'max_quantity': quant.quantity,
-                'origin_location_id': quant.location_id.id,
-                'lot_id': quant.lot_id.id,
-                'product_uom_id': quant.product_uom_id.id,
-                'custom': False,
-            }) for quant in quants]
-        else:
-            # if need move only available qty per product on location
-            for product, quant in groupby(quants, lambda r: r.product_id):
-                # we need only one quant per product
-                quant = list(quant)[0]
-                qty = quant._get_available_quantity(
-                    quant.product_id,
-                    quant.location_id,
-                )
-                if qty:
-                    res.append((0, 0, {
-                        'product_id': quant.product_id.id,
-                        'move_quantity': qty,
-                        'max_quantity': qty,
-                        'origin_location_id': quant.location_id.id,
-                        'lot_id': quant.lot_id.id,
-                        'product_uom_id': quant.product_uom_id.id,
-                        'custom': False,
-                    }))
         return res
 
     @api.onchange('origin_location_id')
@@ -263,9 +243,9 @@ class StockMoveLocationWizard(models.TransientModel):
         # Get origin_location_disable context key to prevent load all origin
         # location products when user opens the wizard from stock quants to
         # move it to other location.
-        lines = []
         if (not self.env.context.get('origin_location_disable') and
                 self.origin_location_id):
+            lines = []
             line_model = self.env["wiz.stock.move.location.line"]
             for line_val in self._get_stock_move_location_lines_values():
                 if line_val.get('max_quantity') <= 0:


### PR DESCRIPTION
make code clear and readable.
Deleted method was created in the commit https://github.com/OCA/stock-logistics-warehouse/commit/3a9fb80e8224e106c30f4b796d6aea6ea183bb91 on 29 Jun 2020.
I suggest displaying not only max_qty and move_qty but non-reserved_qty, which is more smart and user-friendly, I guess.