### PR TITLE
[12.0][IMP] stock_move_location: add option to propose available quantities

### DIFF
--- a/stock_move_location/models/stock_picking_type.py
+++ b/stock_move_location/models/stock_picking_type.py
@@ -11,6 +11,10 @@ class StockPickingType(models.Model):
         help="Show a button 'Move On Hand' in the Inventory Dashboard "
              "to initiate the process to move the products in stock "
              "at the origin location.")
+    suggest_available_qty = fields.Boolean(
+        help="If selected, move location wizard should default the available"
+        "(non-reserved) quantities for the transfer instead of the quantities on hand."
+    )
 
     def action_move_location(self):
         action = self.env.ref(

--- a/stock_move_location/readme/CONFIGURE.rst
+++ b/stock_move_location/readme/CONFIGURE.rst
@@ -1,0 +1,8 @@
+Go to *Inventory > Configuration > Warehouse Management > Operation Types* and make
+following adjustments as necessary on the operation types.
+
+* Select *Show Move On Hand Stock* to show the 'Move On Hand' button on the operation
+  type in the inventory overview.
+* Select *Suggest Available Qty* to make the default move quantity of the lines in the
+  move location wizard the available quantity (non-reserved quantity) instead of the
+  max quantity (quantity on hand).

--- a/stock_move_location/readme/CONTRIBUTORS.rst
+++ b/stock_move_location/readme/CONTRIBUTORS.rst
@@ -6,3 +6,5 @@
 * Lois Rilo <lois.rilo@eficent.com>
 * Jacques-Etienne Baudoux <je@bcim.be>
 * Iryna Vyshnevska <i.vyshnevska@mobilunity.com>
+* Takahiro Yabe <yabe@quartile.co>
+* Yoshi Tashiro <tashiro@quartile.co>

--- a/stock_move_location/tests/test_move_location.py
+++ b/stock_move_location/tests/test_move_location.py
@@ -52,8 +52,13 @@ class TestMoveLocation(TestsCommon):
         """Can't move more than exists."""
         wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
         wizard.onchange_origin_location()
+        line = wizard.stock_move_location_line_ids[0]
+        self.assertEqual(line.move_quantity, line.max_quantity)
         with self.assertRaises(ValidationError):
-            wizard.stock_move_location_line_ids[0].move_quantity += 1
+            line.move_quantity += 1
+        wizard.picking_type_id.suggest_available_qty = True
+        wizard.onchange_picking_type_id()
+        self.assertEqual(line.move_quantity, line.available_quantity)
 
     def test_move_location_wizard_ignore_reserved(self):
         """Can't move more than exists."""

--- a/stock_move_location/views/stock_picking_type_views.xml
+++ b/stock_move_location/views/stock_picking_type_views.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <field name="show_operations" position="after">
                 <field name="show_move_onhand" attrs='{"invisible": [("code", "not in", ["internal"])]}'/>
+                <field name="suggest_available_qty" attrs='{"invisible": [("code", "not in", ["internal"])]}'/>
             </field>
         </field>
     </record>

--- a/stock_move_location/wizard/stock_move_location.xml
+++ b/stock_move_location/wizard/stock_move_location.xml
@@ -31,7 +31,7 @@
           </group>
           <group name="lines">
             <field name="stock_move_location_line_ids" nolabel="1" widget="one2many_list" mode="tree,kanban">
-              <tree string="Inventory Details" editable="bottom" decoration-info="move_quantity != max_quantity" decoration-danger="(move_quantity &lt; 0) or (move_quantity > max_quantity)" create="0">
+              <tree string="Inventory Details" editable="bottom" decoration-info="move_quantity &lt;= available_quantity" decoration-warning="move_quantity > available_quantity" decoration-danger="(move_quantity &lt; 0) or (move_quantity > max_quantity)" create="0">
                   <field name="product_id"  domain="[('type','=','product')]"/>
                   <field name="product_uom_id" string="UoM" groups="uom.group_uom"/>
                   <field name="origin_location_id" readonly="1" force_save="1"/>
@@ -39,6 +39,7 @@
                   <field name="lot_id" domain="[('product_id', '=', product_id)]" context="{'default_product_id': product_id}"  groups="stock.group_production_lot" options="{'no_create': True}"/>
                   <field name="move_quantity"/>
                   <field name="custom" invisible="1" />
+                  <field name="available_quantity" attrs="{'readonly': [('custom', '!=', True)]}" force_save="1"/>
                   <field name="max_quantity" attrs="{'readonly': [('custom', '!=', True)]}" force_save="1"/>
               </tree>
               <kanban class="o_kanban_mobile">

--- a/stock_move_location/wizard/stock_move_location_line.py
+++ b/stock_move_location/wizard/stock_move_location_line.py
@@ -41,6 +41,10 @@ class StockMoveLocationWizardLine(models.TransientModel):
         comodel_name='stock.production.lot',
         domain="[('product_id','=',product_id)]"
     )
+    available_quantity = fields.Float(
+        string="Available Quantity",
+        digits=dp.get_precision('Product Unit of Measure'),
+    )
     move_quantity = fields.Float(
         string="Quantity to move",
         digits=dp.get_precision('Product Unit of Measure'),


### PR DESCRIPTION
This PR adds the available quantity column in the move location wizard line,
and allows users to configure in the operation type as necessary to make the available quantity
(non-reserved quantity) the default move quantity instead of the max quantity (quantity on hand).

With this, the risk of unexpectedly moving some reserved quants can be mitigated.

![image](https://user-images.githubusercontent.com/7766939/129652123-c13acd0e-f627-4b8b-870d-90b2238b9b2c.png)
