### PR TITLE
Change parent of model category Stock Request

### DIFF
--- a/stock_request/security/stock_request_security.xml
+++ b/stock_request/security/stock_request_security.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record model="ir.module.category" id="module_category_stock_request">
         <field name="name">Stock Request</field>
-        <field name="parent_id" ref="base.module_category_inventory_inventory" />
+        <field name="parent_id" ref="base.module_category_inventory" />
         <field name="sequence">10</field>
     </record>
     <record id="group_stock_request_user" model="res.groups">


### PR DESCRIPTION
Inventory category is duplicated in user page
![Selection_118](https://user-images.githubusercontent.com/24691983/130311318-d40f8a54-15f9-4625-8c41-b50b7ef3c4db.png)

After fixed, inventory category has only one.
![Selection_119](https://user-images.githubusercontent.com/24691983/130311362-14b5247e-e7bc-48b3-992b-4147cb0aac6b.png)

cc: @kittiu @ps-tubtim 