### PR TITLE
[13.0][FIX] stock_reserve_rule: allow removal strategy based on lots

### DIFF
--- a/stock_reserve_rule/models/stock_move.py
+++ b/stock_reserve_rule/models/stock_move.py
@@ -79,16 +79,22 @@ class StockMove(models.Model):
                         next_quant = strategy.send(still_need)
                         if not next_quant:
                             continue
-                        location, location_quantity, to_take = next_quant
+                        (
+                            location,
+                            location_quantity,
+                            to_take,
+                            strat_lot_id,
+                            strat_owner_id,
+                        ) = next_quant
                         taken_in_loc = super()._update_reserved_quantity(
                             # in this strategy, we take as much as we can
                             # from this bin
                             to_take,
                             location_quantity,
                             location_id=location,
-                            lot_id=lot_id,
+                            lot_id=strat_lot_id,
                             package_id=package_id,
-                            owner_id=owner_id,
+                            owner_id=strat_owner_id,
                             strict=strict,
                         )
                         still_need -= taken_in_loc

--- a/stock_reserve_rule/models/stock_reserve_rule.py
+++ b/stock_reserve_rule/models/stock_reserve_rule.py
@@ -194,7 +194,7 @@ class StockReserveRuleRemoval(models.Model):
         each time the strategy decides to take quantities in a location,
         it has to yield and retrieve the remaining needed using:
 
-            need = yield location, location_quantity, quantity_to_take
+            need = yield location, location_quantity, quantity_to_take, lot, owner
 
         See '_apply_strategy_default' for a short example.
 
@@ -211,6 +211,8 @@ class StockReserveRuleRemoval(models.Model):
                 quant.location_id,
                 quant.quantity - quant.reserved_quantity,
                 need,
+                quant.lot_id,
+                quant.owner_id,
             )
 
     def _apply_strategy_empty_bin(self, quants):
@@ -231,7 +233,7 @@ class StockReserveRuleRemoval(models.Model):
                 continue
 
             if float_compare(need, location_quantity, rounding) != -1:
-                need = yield location, location_quantity, need
+                need = yield location, location_quantity, need, None, None
 
     def _apply_strategy_packaging(self, quants):
         need = yield
@@ -277,4 +279,4 @@ class StockReserveRuleRemoval(models.Model):
                 if enough_for_packaging and asked_at_least_packaging_qty:
                     # compute how much packaging we can get
                     take = (need // pack_quantity) * pack_quantity
-                    need = yield location, location_quantity, take
+                    need = yield location, location_quantity, take, None, None


### PR DESCRIPTION
The lot is ignored in _apply_strategy which makes it not possible to
create removal rules based on it. A practical example is to create a
rule with a quant_domain on lot_id.use_date (Best Before Date). Even
though the quants will be filtered, the lots wont be taken into
consideration in _apply_strategy and so random lots will be reserved.
With the the signature for the _apply_strategy_%s methods is changed
to require returning the lot also or set it to False if it is not used.