### PR TITLE
[FIX] stock_mts_mto_rule: don't update route

### DIFF
--- a/stock_mts_mto_rule/__manifest__.py
+++ b/stock_mts_mto_rule/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Stock MTS+MTO Rule",
     "summary": "Add a MTS+MTO route",
-    "version": "13.0.1.2.0",
+    "version": "13.0.1.3.0",
     "development_status": "Mature",
     "category": "Warehouse",
     "website": "https://github.com/OCA/stock-logistics-warehouse",

--- a/stock_mts_mto_rule/data/stock_data.xml
+++ b/stock_mts_mto_rule/data/stock_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo>
+<odoo noupdate="1">
     <!--
          Procurement rules
     -->

--- a/stock_mts_mto_rule/migrations/13.0.1.3.0/pre-migration.py
+++ b/stock_mts_mto_rule/migrations/13.0.1.3.0/pre-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2021 Tecnativa David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Now the record is declared as noupdate
+    openupgrade.set_xml_ids_noupdate_value(
+        env, "stock_mts_mto_rule", ["route_mto_mts"], True,
+    )


### PR DESCRIPTION
Odoo declares routes as noupdate records so the user has the control
over them. Another side effect of updatable route records is on
initializing the record when OpenUpgrade is used to upgrade, which in a
multicompany environment with mixed companies in the products could lead
to a false company restriction error (maybe due to a bad declaration of
restrictions in the product_ids field).

cc @Tecnativa TT31601

Related issue: https://github.com/OCA/stock-logistics-warehouse/issues/1139