### PR TITLE
[13.0][FIX] stock_location_last_inventory_date

### DIFF
--- a/stock_location_last_inventory_date/__manifest__.py
+++ b/stock_location_last_inventory_date/__manifest__.py
@@ -12,4 +12,5 @@
     "application": False,
     "installable": True,
     "depends": ["product", "stock"],
+    "data": ["views/stock_location_views.xml"],
 }

--- a/stock_location_last_inventory_date/models/stock_location.py
+++ b/stock_location_last_inventory_date/models/stock_location.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class StockLocation(models.Model):
@@ -9,44 +9,19 @@ class StockLocation(models.Model):
     last_inventory_date = fields.Datetime(
         "Last Inventory Date",
         compute="_compute_last_inventory_date",
-        store=True,
-        help="Indicates the last inventory date for the location (only for "
-        "validated inventories). It is only computed for leaf locations.",
+        help="Indicates the last inventory date for the location, "
+        "including inventory done on parents location.",
     )
 
-    # This field reuses the Many2many already defined in the model
-    # stock.inventory, so this definition adds little overhead, and
-    # allows to create the list of depends needed by the field for the
-    # Last Inventory Date.
-    validated_inventory_ids = fields.Many2many(
-        "stock.inventory",
-        relation="stock_inventory_stock_location_rel",
-        column1="stock_location_id",
-        column2="stock_inventory_id",
-        string="Stock Inventories",
-        help="Stock inventories in state validated for this location.",
-        domain="[('location_ids', 'in', id), ('state', '=', 'done')]",
-    )
-
-    @api.depends(
-        "usage",
-        "child_ids",
-        "validated_inventory_ids",
-        "validated_inventory_ids.date",
-        "validated_inventory_ids.state",
-        "validated_inventory_ids.location_ids.usage",
-        "validated_inventory_ids.location_ids.child_ids",
-    )
     def _compute_last_inventory_date(self):
-        """Store date of the last inventory for each leaf location"""
-        for loc in self:
-            if (
-                loc.usage != "view"
-                and not loc.child_ids
-                and loc.validated_inventory_ids
-            ):
-                loc.last_inventory_date = loc.validated_inventory_ids.sorted(
-                    lambda inventory: inventory.date
-                )[-1].date
-            else:
-                loc.last_inventory_date = False
+        for location in self:
+            location_ids = [
+                int(location_id)
+                for location_id in location.parent_path.rstrip("/").split("/")
+            ]
+            last_inventory = self.env["stock.inventory"].search(
+                [("location_ids", "in", location_ids), ("state", "=", "done")],
+                order="date desc",
+                limit=1,
+            )
+            location.last_inventory_date = last_inventory.date

--- a/stock_location_last_inventory_date/tests/test_stock_location.py
+++ b/stock_location_last_inventory_date/tests/test_stock_location.py
@@ -46,10 +46,6 @@ class TestStockLocation(SavepointCase):
         inventory.with_user(stock_user).action_start()
         inventory.with_user(stock_manager).action_validate()
         self.assertEqual(
-            self.leaf_location.with_user(stock_user).validated_inventory_ids.ids,
-            [inventory.id],
-        )
-        self.assertEqual(
             self.leaf_location.with_user(stock_user).last_inventory_date, inventory.date
         )
         try:
@@ -60,8 +56,6 @@ class TestStockLocation(SavepointCase):
 
     def test_leaf_location(self):
         self.assertFalse(self.leaf_location.child_ids)
-        self.assertFalse(self.leaf_location.validated_inventory_ids)
-        self.assertFalse(self.leaf_location.last_inventory_date)
         inventory = self.env["stock.inventory"].create(
             {
                 "name": "Inventory Adjustment",
@@ -71,13 +65,10 @@ class TestStockLocation(SavepointCase):
         )
         inventory.action_start()
         inventory.action_validate()
-        self.assertEqual(self.leaf_location.validated_inventory_ids.ids, [inventory.id])
         self.assertEqual(self.leaf_location.last_inventory_date, inventory.date)
+        self.assertFalse(self.top_location.last_inventory_date)
 
     def test_top_location(self):
-        self.assertTrue(self.top_location.child_ids)
-        self.assertFalse(self.top_location.validated_inventory_ids)
-        self.assertFalse(self.top_location.last_inventory_date)
         inventory = self.env["stock.inventory"].create(
             {
                 "name": "Inventory Adjustment",
@@ -87,5 +78,5 @@ class TestStockLocation(SavepointCase):
         )
         inventory.action_start()
         inventory.action_validate()
-        self.assertEqual(self.top_location.validated_inventory_ids.ids, [inventory.id])
-        self.assertFalse(self.top_location.last_inventory_date)
+        self.assertEqual(self.leaf_location.last_inventory_date, inventory.date)
+        self.assertEqual(self.top_location.last_inventory_date, inventory.date)

--- a/stock_location_last_inventory_date/views/stock_location_views.xml
+++ b/stock_location_last_inventory_date/views/stock_location_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_location_form" model="ir.ui.view">
+        <field name="name">stock.location.last.inventory.date</field>
+        <field name="model">stock.location</field>
+        <field name="inherit_id" ref="stock.view_location_form" />
+        <field name="arch" type="xml">
+            <group name="additional_info" position="inside">
+                <field name="last_inventory_date" />
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The prevoius implementation was only taking into account the last inventory
specific to the location.
This change includes also inventories done on parents location.

Also display the computed last inventory date in the form view.