### PR TITLE
[14.0][FIX] stock_request: default value should not depend on another field

### DIFF
--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -32,13 +32,6 @@ class StockRequest(models.Model):
     def _get_expected_date():
         return fields.Datetime.now()
 
-    def _get_default_expected_date(self):
-        if self.order_id:
-            res = self.order_id.expected_date
-        else:
-            res = self._get_expected_date()
-        return res
-
     name = fields.Char(states={"draft": [("readonly", False)]})
     state = fields.Selection(
         selection=_get_request_states,
@@ -58,7 +51,6 @@ class StockRequest(models.Model):
     )
     expected_date = fields.Datetime(
         "Expected Date",
-        default=lambda s: s._get_default_expected_date(),
         index=True,
         required=True,
         readonly=True,
@@ -371,6 +363,11 @@ class StockRequest(models.Model):
         upd_vals = vals.copy()
         if upd_vals.get("name", "/") == "/":
             upd_vals["name"] = self.env["ir.sequence"].next_by_code("stock.request")
+        if "order_id" in upd_vals:
+            order_id = self.env["stock.request.order"].browse(upd_vals["order_id"])
+            upd_vals["expected_date"] = order_id.expected_date
+        else:
+            upd_vals["expected_date"] = self._get_expected_date()
         return super().create(upd_vals)
 
     def unlink(self):


### PR DESCRIPTION
[One `stock_request` test](https://github.com/OCA/stock-logistics-warehouse/blob/d25a6fdd4fe57581b8eadbf08b92cf7ed0339b14/stock_request/tests/test_stock_request.py#L1057) is failing from time to time, with this traceback:
```
ERROR: TestStockRequestBase.test_cancellation
Traceback (most recent call last):
  File "/home/travis/build/nilshamerlinck/stock-logistics-warehouse/setup/stock_request/odoo/addons/stock_request/tests/test_stock_request.py", line 1057, in test_cancellation
    order = self.request_order.create(vals)
  File "<decorator-gen-205>", line 2, in create
  File "/home/travis/odoo-14.0/odoo/api.py", line 323, in _model_create_single
    return create(self, arg)
  File "/home/travis/build/nilshamerlinck/stock-logistics-warehouse/setup/stock_request/odoo/addons/stock_request/models/stock_request_order.py", line 279, in create
    return super().create(upd_vals)
  File "<decorator-gen-134>", line 2, in create
  File "/home/travis/odoo-14.0/odoo/api.py", line 344, in _model_create_multi
    return create(self, [arg])
  File "/home/travis/odoo-14.0/addons/mail/models/mail_thread.py", line 264, in create
    threads = super(MailThread, self).create(vals_list)
  File "<decorator-gen-64>", line 2, in create
  File "/home/travis/odoo-14.0/odoo/api.py", line 345, in _model_create_multi
    return create(self, arg)
  File "/home/travis/odoo-14.0/odoo/addons/base/models/ir_fields.py", line 534, in create
    recs = super().create(vals_list)
  File "<decorator-gen-13>", line 2, in create
  File "/home/travis/odoo-14.0/odoo/api.py", line 345, in _model_create_multi
    return create(self, arg)
  File "/home/travis/odoo-14.0/odoo/models.py", line 3870, in create
    records = self._create(data_list)
  File "/home/travis/odoo-14.0/odoo/models.py", line 4030, in _create
    for other, data in zip(others, data_list)
  File "/home/travis/odoo-14.0/odoo/fields.py", line 3041, in create
    self.write_batch(record_values, True)
  File "/home/travis/odoo-14.0/odoo/fields.py", line 3067, in write_batch
    return self.write_real(records_commands_list, create)
  File "/home/travis/odoo-14.0/odoo/fields.py", line 3239, in write_real
    flush()
  File "/home/travis/odoo-14.0/odoo/fields.py", line 3203, in flush
    comodel.create(to_create)
  File "<decorator-gen-204>", line 2, in create
  File "/home/travis/odoo-14.0/odoo/api.py", line 326, in _model_create_single
    return self.browse().concat(*(create(self, vals) for vals in arg))
  File "/home/travis/odoo-14.0/odoo/api.py", line 326, in <genexpr>
    return self.browse().concat(*(create(self, vals) for vals in arg))
  File "/home/travis/build/nilshamerlinck/stock-logistics-warehouse/setup/stock_request/odoo/addons/stock_request/models/stock_request.py", line 374, in create
    return super().create(upd_vals)
  File "<decorator-gen-134>", line 2, in create
  File "/home/travis/odoo-14.0/odoo/api.py", line 344, in _model_create_multi
    return create(self, [arg])
  File "/home/travis/odoo-14.0/addons/mail/models/mail_thread.py", line 264, in create
    threads = super(MailThread, self).create(vals_list)
  File "<decorator-gen-64>", line 2, in create
  File "/home/travis/odoo-14.0/odoo/api.py", line 345, in _model_create_multi
    return create(self, arg)
  File "/home/travis/odoo-14.0/odoo/addons/base/models/ir_fields.py", line 534, in create
    recs = super().create(vals_list)
  File "<decorator-gen-13>", line 2, in create
  File "/home/travis/odoo-14.0/odoo/api.py", line 345, in _model_create_multi
    return create(self, arg)
  File "/home/travis/odoo-14.0/odoo/models.py", line 3870, in create
    records = self._create(data_list)
  File "/home/travis/odoo-14.0/odoo/models.py", line 4043, in _create
    records._validate_fields(name for data in data_list for name in data['stored'])
  File "/home/travis/odoo-14.0/odoo/models.py", line 1266, in _validate_fields
    check(self)
  File "/home/travis/build/nilshamerlinck/stock-logistics-warehouse/setup/stock_request/odoo/addons/stock_request/models/stock_request.py", line 233, in check_order_expected_date
    raise ValidationError(_("Expected date must be equal to the order"))
odoo.exceptions.ValidationError: Expected date must be equal to the order
```

The root cause is that [`stock.request.expected_date` default value depends on another field: order_id](https://github.com/OCA/stock-logistics-warehouse/blob/d25a6fdd4fe57581b8eadbf08b92cf7ed0339b14/stock_request/models/stock_request.py#L61).

In the record creation process, default values of fields are [added first](https://github.com/odoo/odoo/blob/f1a5f4f7980faa2a40c386c8f32aa4853833b8f3/odoo/models.py#L3814) and don't take into account other fields values. So `self.order_id` is always empty, and `expected_date` always set to the result of `fields.Datetime.now()`.

We can thus end up in a situation where for example:
- `request.order_id.expected_date = datetime.datetime(2021, 9, 24, 12, 0, 38)`
- while `request.expected_date = datetime.datetime(2021, 9, 24, 12, 0, 39)`
- because `fields.Datetime.now()` has been called a few hundred ms later, hence the 1s difference.

tldr; default values functions should never depend on other fields of the record