### PR TITLE
[FIX] stock_orderpoint_route: avoid missing route_ids field issue

### DIFF
--- a/stock_orderpoint_route/views/stock_warehouse_orderpoint_views.xml
+++ b/stock_orderpoint_route/views/stock_warehouse_orderpoint_views.xml
@@ -17,4 +17,21 @@
             </field>
         </field>
     </record>
+
+    <!-- This is to avoid issue below for any module that inherits tree view of
+        the model `stock.warehouse.orderpoint`.
+        Example: `stock_orderpoint_manual_procurement`
+        Field route_ids used in field route_id default domain
+        ([('id', 'in', route_ids)]) must be present in view but is missing.
+    -->
+    <record id="view_warehouse_orderpoint_tree" model="ir.ui.view">
+        <field name="name">stock.warehouse.orderpoint.tree</field>
+        <field name="model">stock.warehouse.orderpoint</field>
+        <field name="inherit_id" ref="stock.view_warehouse_orderpoint_tree_editable" />
+        <field name="arch" type="xml">
+            <field name="product_uom_name" position="after">
+                <field name="route_ids" invisible="1" />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
This is to avoid issue below for any module that inherits tree view of
the model `stock.warehouse.orderpoint`. Example: `stock_orderpoint_manual_procurement`

Field route_ids used in field route_id default domain
([('id', 'in', route_ids)]) must be present in view but is missing.

The tree view defines `route_id` at https://github.com/odoo/odoo/blob/038816725a988a0ada3d6f8518a436ea46a81eba/addons/stock/views/stock_orderpoint_views.xml#L52