### PR TITLE
[13.0] procurement_auto_create_group: Set partner on created procurement group

### DIFF
--- a/procurement_auto_create_group/README.rst
+++ b/procurement_auto_create_group/README.rst
@@ -84,6 +84,7 @@ Contributors
 * Jordi Ballester <jordi.ballester@forgeflow.com>
 * Lois Rilo <lois.rilo@forgeflow.com>
 * Héctor Villarreal Ortega <hector.villarreal@forgeflow.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/procurement_auto_create_group/__manifest__.py
+++ b/procurement_auto_create_group/__manifest__.py
@@ -1,13 +1,14 @@
 # Copyright 2017-2020 ForgeFlow, S.L.
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Procurement Auto Create Group",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.1.0",
     "development_status": "Production/Stable",
     "license": "AGPL-3",
     "summary": "Allows to configure the system to propose automatically new "
     "procurement groups during the procurement run.",
-    "author": "ForgeFlow," "Odoo Community Association (OCA)",
+    "author": "ForgeFlow, BCIM, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "category": "Warehouse",
     "depends": ["stock"],

--- a/procurement_auto_create_group/models/__init__.py
+++ b/procurement_auto_create_group/models/__init__.py
@@ -1,4 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from . import stock_rule
 from . import procurement_group
+from . import stock_rule

--- a/procurement_auto_create_group/models/procurement_group.py
+++ b/procurement_auto_create_group/models/procurement_group.py
@@ -1,8 +1,12 @@
 # Copyright 2017-2020 ForgeFlow, S.L.
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, models
-from odoo.exceptions import UserError
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
 
 
 class ProcurementGroup(models.Model):
@@ -10,25 +14,27 @@ class ProcurementGroup(models.Model):
 
     @api.model
     def _get_rule(self, product_id, location_id, values):
-        result = super()._get_rule(product_id, location_id, values)
+        rule = super()._get_rule(product_id, location_id, values)
         # If there isn't a date planned in the values it means that this
         # method has been called outside of a procurement process.
         if (
-            result
+            rule
             and not values.get("group_id")
-            and result.auto_create_group
+            and rule.auto_create_group
             and values.get("date_planned")
         ):
             group_data = self._prepare_auto_procurement_group_data()
+            if group_data:
+                _logger.warning(
+                    "DEPRECATED: use _prepare_auto_procurement_group_data "
+                    "on stock rule instead"
+                )
+            group_data.update(rule._prepare_auto_procurement_group_data())
             group = self.env["procurement.group"].create(group_data)
             values["group_id"] = group
-        return result
+        return rule
 
     @api.model
     def _prepare_auto_procurement_group_data(self):
-        name = self.env["ir.sequence"].next_by_code("procurement.group") or False
-        if not name:
-            raise UserError(_("No sequence defined for procurement group."))
-        return {
-            "name": name,
-        }
+        """ Deprecated """
+        return {}

--- a/procurement_auto_create_group/models/stock_rule.py
+++ b/procurement_auto_create_group/models/stock_rule.py
@@ -1,7 +1,9 @@
 # Copyright 2017-2020 ForgeFlow, S.L.
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class StockRule(models.Model):
@@ -13,3 +15,12 @@ class StockRule(models.Model):
     def _onchange_group_propagation_option(self):
         if self.group_propagation_option != "propagate":
             self.auto_create_group = False
+
+    def _prepare_auto_procurement_group_data(self):
+        name = self.env["ir.sequence"].next_by_code("procurement.group") or False
+        if not name:
+            raise UserError(_("No sequence defined for procurement group."))
+        return {
+            "name": name,
+            "partner_id": self.partner_address_id.id,
+        }

--- a/procurement_auto_create_group/readme/CONTRIBUTORS.rst
+++ b/procurement_auto_create_group/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Jordi Ballester <jordi.ballester@forgeflow.com>
 * Lois Rilo <lois.rilo@forgeflow.com>
 * Héctor Villarreal Ortega <hector.villarreal@forgeflow.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/procurement_auto_create_group/tests/test_auto_create.py
+++ b/procurement_auto_create_group/tests/test_auto_create.py
@@ -18,6 +18,8 @@ class TestProcurementAutoCreateGroup(TransactionCase):
         loc_components = self.env.ref("stock.stock_location_components")
         picking_type_id = self.env.ref("stock.picking_type_internal").id
 
+        self.partner = self.env["res.partner"].create({"name": "Partner"})
+
         # Create rules and routes:
         route_auto = self.route_obj.create({"name": "Auto Create Group"})
         self.rule_1 = self.rule_obj.create(
@@ -30,6 +32,7 @@ class TestProcurementAutoCreateGroup(TransactionCase):
                 "picking_type_id": picking_type_id,
                 "location_id": self.location.id,
                 "location_src_id": loc_components.id,
+                "partner_address_id": self.partner.id,
             }
         )
         route_no_auto = self.route_obj.create({"name": "Not Auto Create Group"})
@@ -98,6 +101,11 @@ class TestProcurementAutoCreateGroup(TransactionCase):
         move = self.move_obj.search([("product_id", "=", self.prod_auto.id)])
         self.assertTrue(move)
         self.assertTrue(move.group_id, "Procurement Group not assigned.")
+        self.assertEqual(
+            move.group_id.partner_id,
+            self.partner,
+            "Procurement Group partner missing.",
+        )
 
     def test_03_onchange_method(self):
         """Test onchange method for stock rule."""


### PR DESCRIPTION
When a SO is confirmed, the created procurement group contains the shipping address.
On a stock rule, you can define a shipping address. So if the stock rule is configured to create a new procurement group, that one should also contain the shipping address.
This allows compatibility with the module https://github.com/OCA/stock-logistics-workflow/tree/13.0/stock_picking_group_by_partner_by_carrier
that will regroup delivery moves for a same partner in a same delivery picking.

cc @JordiBForgeFlow @LoisRForgeFlow  

Note for merging: use nobump option (the version has been manually updated)