### PR TITLE
[FIX] stock_request: add delete permission to group_stock_request_user

### DIFF
--- a/stock_request/security/ir.model.access.csv
+++ b/stock_request/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_stock_request_user,stock request user,model_stock_request,group_stock_request_user,1,1,1,
+access_stock_request_user,stock request user,model_stock_request,group_stock_request_user,1,1,1,1
 access_stock_request_manager,stock request manager,model_stock_request,group_stock_request_manager,1,1,1,1
 access_stock_request_stock_user,stock.request stock user,model_stock_request,stock.group_stock_user,1,0,0,0
 access_stock_request_allocation_user,stock request allocation user,model_stock_request_allocation,group_stock_request_user,1,1,1,1


### PR DESCRIPTION
I add delete permissions to the group_stock_request_user, because when creating a stock.request.order, the user could not delete items. 