### PR TITLE
[14.0][FIX] s_inventory_exclude_sublocation: fix tracking on field

### DIFF
--- a/stock_inventory_exclude_sublocation/models/stock_inventory.py
+++ b/stock_inventory_exclude_sublocation/models/stock_inventory.py
@@ -11,7 +11,7 @@ class Inventory(models.Model):
     exclude_sublocation = fields.Boolean(
         string="Exclude Sublocations",
         default=False,
-        track_visibility="onchange",
+        tracking=True,
         readonly=True,
         states={"draft": [("readonly", False)]},
     )


### PR DESCRIPTION
This spawns warnings on Runbot (I don't know if it also makes it red on PR?)