### PR TITLE
[15.0][IMP] stock_warehouse_calendar: upgrade development status

### DIFF
--- a/stock_warehouse_calendar/__manifest__.py
+++ b/stock_warehouse_calendar/__manifest__.py
@@ -12,6 +12,6 @@
     "depends": ["stock", "resource"],
     "data": ["views/stock_warehouse_views.xml"],
     "installable": True,
-    "development_status": "Beta",
+    "development_status": "Production/Stable",
     "maintainers": ["JordiBForgeFlow"],
 }


### PR DESCRIPTION
This module has been used for years in production environments, and some dependent modules cannot be moved as Stable because of that: 

https://github.com/OCA/oca-ci/issues/15

@LoisRForgeFlow 
@JoanMForgeFlow 
@ForgeFlow