### PR TITLE
[11.0][FIX] stock_request: tests

### DIFF
--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -404,8 +404,7 @@ class TestStockRequest(common.TransactionCase):
             })]
         }
         with self.assertRaises(exceptions.ValidationError):
-            self.request_order.sudo(
-                self.stock_request_user).create(vals)
+            self.request_order.create(vals)
 
     def test_stock_request_order_validations_06(self):
         """ Testing the discrepancy in expected dates between


### PR DESCRIPTION
Basically an access error was raising before the validation error. In this case the validation error has nothing to do with the user that triggers it. The admin user will get the error so the test will still be valid as it is now.

@LoisRForgeFlow 