### PR TITLE
[14.0][FIX] stock_order_point_move_link get move values

### DIFF
--- a/stock_orderpoint_move_link/models/stock.py
+++ b/stock_orderpoint_move_link/models/stock.py
@@ -27,8 +27,8 @@ class StockRule(models.Model):
             company_id,
             values,
         )
-        if "orderpoint_id" in values:
+        if "orderpoint_id" in values and values["orderpoint_id"]:
             vals["orderpoint_ids"] = [(4, values["orderpoint_id"].id)]
-        elif "orderpoint_ids" in values:
+        elif "orderpoint_ids" in values and values["orderpoint_ids"]:
             vals["orderpoint_ids"] = [(4, o.id) for o in values["orderpoint_ids"]]
         return vals


### PR DESCRIPTION
The `order_point_id` can be set as an empty recordset by the core.
Which breaks later in a write.