### PR TITLE
[13.0][FIX] stock_secondary_unit: Prevent move_line_ids_without_package field is not editable. 

### DIFF
--- a/stock_secondary_unit/tests/test_stock_secondary_unit.py
+++ b/stock_secondary_unit/tests/test_stock_secondary_unit.py
@@ -16,7 +16,7 @@ class TestProductSecondaryUnit(SavepointCase):
         cls.location_stock = cls.env.ref("stock.stock_location_stock")
         cls.picking_type_in = cls.env.ref("stock.picking_type_in")
         cls.picking_type_out = cls.env.ref("stock.picking_type_out")
-
+        cls.picking_type_out.show_operations = True
         cls.product_uom_kg = cls.env.ref("uom.product_uom_kgm")
         cls.product_uom_ton = cls.env.ref("uom.product_uom_ton")
         cls.product_uom_unit = cls.env.ref("uom.product_uom_unit")


### PR DESCRIPTION
Prevent `move_line_ids_without_package` field is not editable.  (Since https://github.com/odoo/odoo/commit/6f7e9a93048155e403e6cc56d24595c281297124#)

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa