### PR TITLE
[14.0][FIX] stock_location_tray: crash when creating a stock.location

### DIFF
--- a/stock_location_tray/models/stock_location.py
+++ b/stock_location_tray/models/stock_location.py
@@ -188,6 +188,7 @@ class StockLocation(models.Model):
                         "posz": posz,
                         "location_id": location.id,
                         "company_id": location.company_id.id,
+                        "tray_type_id": False,
                     }
                     values.append(subloc_values)
         if values:


### PR DESCRIPTION
Crash: Got a MemoryError when creating a new `stock.location` with tray_type_id set.

How to reproduce:
 - create a Tray Type on a new database
 - Click the "Locations" action on the top right
 - Hit "Create" and enter a new `stock.location` with this tray type

And boom!