### PR TITLE
[14.0][FIX] stock_request: use sudo to run procurements to prevent permission issues

### DIFF
--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -340,7 +340,7 @@ class StockRequest(models.Model):
                         values,
                     )
                 )
-                self.env["procurement.group"].run(procurements)
+                self.env["procurement.group"].sudo().run(procurements)
             except UserError as error:
                 errors.append(error.name)
         if errors:


### PR DESCRIPTION
This fixes the following issue:
If a user makes a request for a product that you need to manufacture, but the user doesn't have permission to
MRP module and you don't want to give them access, it will raise an error that you don't have permission to
see the mrp.bom.