### PR TITLE
[12.0][FIX] stock_available_unreserved: pre_init_hook

### DIFF
--- a/stock_available_unreserved/hooks.py
+++ b/stock_available_unreserved/hooks.py
@@ -37,7 +37,6 @@ def add_field_unreserved_quantity(cr):
             """
             UPDATE stock_quant
             SET unreserved_quantity = quantity - reserved_quantity
-            WHERE reserved_quantity > 0.01
             """
         )
 
@@ -59,6 +58,6 @@ def add_field_contains_unreserved(cr):
         cr.execute(
             """
             UPDATE stock_quant
-            SET contains_unreserved = (reserved_quantity > 0.01);
+            SET contains_unreserved = (unreserved_quantity > 0.0);
             """
         )


### PR DESCRIPTION
Before this commit, unreserved_quantity and contains_unreserved
were not updated at install when there was quantity and not
reserved_quantity.