### PR TITLE
[14.0][FIX] stock_orderpoint_manual_procurement: wrong parameter in _prepare_procurement_values

### DIFF
--- a/stock_orderpoint_manual_procurement/wizards/make_procurement_orderpoint.py
+++ b/stock_orderpoint_manual_procurement/wizards/make_procurement_orderpoint.py
@@ -70,7 +70,7 @@ class MakeProcurementOrderpoint(models.TransientModel):
                 raise ValidationError(_("Quantity must be positive."))
             if not item.orderpoint_id:
                 raise ValidationError(_("No reordering rule found!"))
-            values = item.orderpoint_id._prepare_procurement_values(item.qty)
+            values = item.orderpoint_id._prepare_procurement_values()
             values["date_planned"] = fields.Datetime.to_string(
                 fields.Date.from_string(item.date_planned)
             )


### PR DESCRIPTION
This remained from older odoo versions, but in v14  _prepare_procurement_values doesn't have item quantity as a parameter. Giving  this parameter to the function was setting date_deadline  = item.qty.

@ForgeFlow