### PR TITLE
[13.0][FIX] stock_inventory_preparation_filter: Filtering by lots is adding all lots of products

### DIFF
--- a/stock_inventory_preparation_filter/README.rst
+++ b/stock_inventory_preparation_filter/README.rst
@@ -71,6 +71,7 @@ Contributors
   * Pedro M. Baeza
   * David Vidal
   * Sergio Teruel
+  * Carlos Roca
 
 * Xavier Jimenez <xavier.jimenez@qubiq.es>
 

--- a/stock_inventory_preparation_filter/models/stock_inventory.py
+++ b/stock_inventory_preparation_filter/models/stock_inventory.py
@@ -67,3 +67,9 @@ class StockInventory(models.Model):
             if products:
                 inventory.product_ids = [(6, 0, products.ids)]
         return super()._action_start()
+
+    def _get_inventory_lines_values(self):
+        vals = super()._get_inventory_lines_values()
+        if self.filter == "lots":
+            vals = list(filter(lambda x: x["prod_lot_id"] in self.lot_ids.ids, vals))
+        return vals

--- a/stock_inventory_preparation_filter/readme/CONTRIBUTORS.rst
+++ b/stock_inventory_preparation_filter/readme/CONTRIBUTORS.rst
@@ -4,5 +4,6 @@
   * Pedro M. Baeza
   * David Vidal
   * Sergio Teruel
+  * Carlos Roca
 
 * Xavier Jimenez <xavier.jimenez@qubiq.es>

--- a/stock_inventory_preparation_filter/static/description/index.html
+++ b/stock_inventory_preparation_filter/static/description/index.html
@@ -420,6 +420,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Pedro M. Baeza</li>
 <li>David Vidal</li>
 <li>Sergio Teruel</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 <li>Xavier Jimenez &lt;<a class="reference external" href="mailto:xavier.jimenez&#64;qubiq.es">xavier.jimenez&#64;qubiq.es</a>&gt;</li>


### PR DESCRIPTION
cc @Tecnativa TT34672

Screeenshot inventory:
![imagen](https://user-images.githubusercontent.com/35952655/154665313-7e346aee-0ab2-47e3-876a-2395499a8e3d.png)


Before this patch, if we create a stock inventory for some lots, we get a line for each lot of the products difined on lots.
![imagen](https://user-images.githubusercontent.com/35952655/154665349-948ea776-276d-4731-aa09-3d6945b16b73.png)

After this patch, we get the lines for the lots defined.
![imagen](https://user-images.githubusercontent.com/35952655/154665431-b0aefc8c-958c-48e1-ab31-09547431fdaa.png)

Please @carlosdauden @chienandalu review it