### PR TITLE
[IMP] stock_inventory_preparation_filter: Filtering by lots is adding all lots of products

### DIFF
--- a/stock_inventory_preparation_filter/README.rst
+++ b/stock_inventory_preparation_filter/README.rst
@@ -64,6 +64,7 @@ Contributors
   * Pedro M. Baeza
   * David Vidal
   * Sergio Teruel
+  * Carlos Roca
 
 * Xavier Jimenez <xavier.jimenez@qubiq.es>
 * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/stock_inventory_preparation_filter/models/stock_inventory.py
+++ b/stock_inventory_preparation_filter/models/stock_inventory.py
@@ -75,3 +75,9 @@ class StockInventory(models.Model):
             domain = safe_eval(self.product_domain)
             products = Product.search(domain)
         return products
+
+    def _get_inventory_lines_values(self):
+        vals = super()._get_inventory_lines_values()
+        if self.filter == "lots":
+            vals = list(filter(lambda x: x["prod_lot_id"] in self.lot_ids.ids, vals))
+        return vals

--- a/stock_inventory_preparation_filter/readme/CONTRIBUTORS.rst
+++ b/stock_inventory_preparation_filter/readme/CONTRIBUTORS.rst
@@ -4,6 +4,7 @@
   * Pedro M. Baeza
   * David Vidal
   * Sergio Teruel
+  * Carlos Roca
 
 * Xavier Jimenez <xavier.jimenez@qubiq.es>
 * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/stock_inventory_preparation_filter/static/description/index.html
+++ b/stock_inventory_preparation_filter/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Extended Inventory Preparation Filters</title>
 <style type="text/css">
 
@@ -411,6 +411,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Pedro M. Baeza</li>
 <li>David Vidal</li>
 <li>Sergio Teruel</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 <li>Xavier Jimenez &lt;<a class="reference external" href="mailto:xavier.jimenez&#64;qubiq.es">xavier.jimenez&#64;qubiq.es</a>&gt;</li>


### PR DESCRIPTION
Before this patch, if we create a stock inventory for some lots, we get a line for each lot of the products difined on lots.

After this patch, we get the lines for the lots defined.

cc @Tecnativa TT34672

fw-por of https://github.com/OCA/stock-logistics-warehouse/pull/1375