### PR TITLE
[13.0][ADD]: account_move_line_stock_info script post_install for update references on new column

### DIFF
--- a/account_move_line_stock_info/__init__.py
+++ b/account_move_line_stock_info/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from .hooks import post_init_hook

--- a/account_move_line_stock_info/__manifest__.py
+++ b/account_move_line_stock_info/__manifest__.py
@@ -14,4 +14,5 @@
         "views/account_move_line_view.xml",
         "views/stock_move_view.xml",
     ],
+    "post_init_hook": "post_init_hook",
 }

--- a/account_move_line_stock_info/hooks.py
+++ b/account_move_line_stock_info/hooks.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Carlos Lopez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def post_init_hook(cr, registry):
+
+    """ INIT stock_move_id references in acount move line from account_move"""
+    # FOR stock moves
+    cr.execute(
+        """
+        UPDATE account_move_line aml
+            SET stock_move_id = am.stock_move_id
+        FROM account_move am
+        WHERE am.id = aml.move_id
+            AND am.stock_move_id IS NOT NULL AND aml.stock_move_id IS NULL;
+    """
+    )


### PR DESCRIPTION
When install module on database with data, new column is NULL, purpose is FILL column with data

Inspired by https://github.com/OCA/account-financial-tools/blob/13.0/account_move_line_sale_info/hooks.py