### PR TITLE
[14.0][IMP] account_move_line_stock_info: Add init hook

### DIFF
--- a/account_move_line_stock_info/__init__.py
+++ b/account_move_line_stock_info/__init__.py
@@ -1,3 +1,2 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
 from . import models
+from .hooks import post_init_hook

--- a/account_move_line_stock_info/__manifest__.py
+++ b/account_move_line_stock_info/__manifest__.py
@@ -1,8 +1,8 @@
-# © 2016 ForgeFlow S.L.
+# Copyright 2016-2022 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Account Move Line Stock Info",
-    "version": "14.0.1.0.1",
+    "version": "14.0.2.1.0",
     "depends": ["stock_account"],
     "author": "ForgeFlow," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
@@ -14,4 +14,5 @@
         "views/account_move_line_view.xml",
         "views/stock_move_view.xml",
     ],
+    "post_init_hook": "post_init_hook",
 }

--- a/account_move_line_stock_info/hooks.py
+++ b/account_move_line_stock_info/hooks.py
@@ -1,0 +1,16 @@
+# Copyright 2022 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def post_init_hook(cr, registry):
+
+    """INIT stock references in acount move line"""
+    # FOR stock moves
+    cr.execute(
+        """
+        UPDATE account_move_line aml SET stock_move_id = am.stock_move_id
+        FROM account_move am
+        WHERE am.id = aml.move_id
+        AND am.stock_move_id IS NOT NULL;
+    """
+    )

--- a/account_move_line_stock_info/migrations/14.0.2.1.0/pre-migration.py
+++ b/account_move_line_stock_info/migrations/14.0.2.1.0/pre-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2020 ForgeFlow S.L. (https://www.forgeflow.com)
+# Part of ForgeFlow. See LICENSE file for full copyright and licensing details.
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+from odoo.addons.account_move_line_stock_info.hooks import post_init_hook
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Trigger again the post_init_hook")
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    post_init_hook(cr, env.registry)


### PR DESCRIPTION
We want to make sure that we move the stock_move_id from the account.move
to the account.move.line

@NuriaXForgeFlow @AaronHForgeFlow 