### PR TITLE
[ADD] optional confirmation done messages on stock request

### DIFF
--- a/stock_request/models/res_company.py
+++ b/stock_request/models/res_company.py
@@ -12,3 +12,6 @@ class ResCompany(models.Model):
     stock_request_allow_virtual_loc = fields.Boolean(
         string="Allow Virtual locations on Stock Requests"
     )
+
+    stock_request_send_confirm_message = fields.Boolean(string='Send Confirm Done messages on Stock Requests',
+                                                        default=True)

--- a/stock_request/models/res_config_settings.py
+++ b/stock_request/models/res_config_settings.py
@@ -27,6 +27,9 @@ class ResConfigSettings(models.TransientModel):
         string="Stock Requests Analytic integration"
     )
 
+    stock_request_send_confirm_message = fields.Boolean(related='company_id.stock_request_send_confirm_message',
+                                                        readonly=False)
+
     module_stock_request_submit = fields.Boolean(
         string="Submitted state in Stock Requests"
     )

--- a/stock_request/models/stock_move_line.py
+++ b/stock_request/models/stock_move_line.py
@@ -59,12 +59,13 @@ class StockMoveLine(models.Model):
                     to_allocate_qty -= allocated_qty
                 if allocated_qty:
                     request = allocation.stock_request_id
-                    message_data = self._prepare_message_data(
-                        ml, request, allocated_qty
-                    )
-                    message = self._stock_request_confirm_done_message_content(
-                        message_data
-                    )
-                    request.message_post(body=message, subtype_xmlid="mail.mt_comment")
+                    if ml.company_id.stock_request_send_confirm_message:
+                        message_data = self._prepare_message_data(
+                            ml, request, allocated_qty
+                        )
+                        message = self._stock_request_confirm_done_message_content(
+                            message_data
+                        )
+                        request.message_post(body=message, subtype_xmlid="mail.mt_comment")
                     request.check_done()
         return res

--- a/stock_request/views/res_config_settings_views.xml
+++ b/stock_request/views/res_config_settings_views.xml
@@ -60,6 +60,20 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-xs-12 col-md-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="stock_request_send_confirm_message"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label
+                                    string="Send Confirm Done messages"
+                                    for="stock_request_send_confirm_message"
+                                />
+                                <div class="text-muted">
+                                    Send confirm done messages in Stock Request chatters.
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <h2>Purchases</h2>
                     <div


### PR DESCRIPTION
Adds parameter in res.config.settings to enable sending confirmation done messages in stock request chatter.

