### PR TITLE
[14.0][FIX] stock_orderpoint_route: avoid missing route_ids field issue (bis)

### DIFF
--- a/stock_orderpoint_route/views/stock_warehouse_orderpoint_views.xml
+++ b/stock_orderpoint_route/views/stock_warehouse_orderpoint_views.xml
@@ -34,4 +34,19 @@
             </field>
         </field>
     </record>
+    <record id="view_warehouse_orderpoint_tree_editable_config" model="ir.ui.view">
+        <field
+            name="name"
+        >stock.warehouse.orderpoint.tree.editable.config.inherit</field>
+        <field name="model">stock.warehouse.orderpoint</field>
+        <field
+            name="inherit_id"
+            ref="stock.view_warehouse_orderpoint_tree_editable_config"
+        />
+        <field name="arch" type="xml">
+            <field name="product_uom_name" position="after">
+                <field name="route_ids" invisible="1" />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Complete the fix done in #1266 

cc @hailangvn @LoisRForgeFlow 