### PR TITLE
[14.0][FIX] stock_available_mrp: normal BoM available to promise

### DIFF
--- a/stock_available_mrp/README.rst
+++ b/stock_available_mrp/README.rst
@@ -37,14 +37,24 @@ with the components available to promise.
 .. contents::
    :local:
 
+Usage
+=====
+
+It's possible to avoid adding potential stock to available to promise stock at Bill of
+Materials level. This is interesting in case that sum is missleading due to uncertain
+manufacturing processes. To do so:
+
+- Go to that specific Bill of Materials and in the Miscellaneous tab set the option
+  **Avoid adding potential to available to promise** on.
+
 Known issues / Roadmap
 ======================
 
 Known issues
 ~~~~~~~~~~~~
-The manufacturing delays are not taken into account : this module assumes that
+The manufacturing delays are not taken into account: this module assumes that
 if you have components in stock goods, you can manufacture finished goods
-quickly enough.
+quickly enough. This can be overriden at BoM level though.
 
 As a consequence, and to avoid overestimating, **only the first level** of Bill
 of Materials is considered.
@@ -113,6 +123,7 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Víctor Martínez
+  * David Vidal
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_available_mrp/__manifest__.py
+++ b/stock_available_mrp/__manifest__.py
@@ -7,6 +7,7 @@
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "category": "Hidden",
     "depends": ["stock_available", "mrp"],
+    "data": ["views/mrp_bom_views.xml"],
     "demo": ["demo/mrp_data.xml"],
     "license": "AGPL-3",
     "installable": True,

--- a/stock_available_mrp/models/__init__.py
+++ b/stock_available_mrp/models/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2014 Numérigraphe SARL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
+from . import mrp_bom
 from . import product_product

--- a/stock_available_mrp/models/mrp_bom.py
+++ b/stock_available_mrp/models/mrp_bom.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import fields, models
+
+
+class MrpBom(models.Model):
+    _inherit = "mrp.bom"
+
+    add_potential_exception = fields.Boolean(
+        string="Avoid adding potential to available to promise",
+        help="If potential qty added to available to promise is set in the company "
+        "we can override this option for single BoMs",
+    )

--- a/stock_available_mrp/readme/CONTRIBUTORS.rst
+++ b/stock_available_mrp/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Víctor Martínez
+  * David Vidal

--- a/stock_available_mrp/readme/ROADMAP.rst
+++ b/stock_available_mrp/readme/ROADMAP.rst
@@ -1,8 +1,8 @@
 Known issues
 ~~~~~~~~~~~~
-The manufacturing delays are not taken into account : this module assumes that
+The manufacturing delays are not taken into account: this module assumes that
 if you have components in stock goods, you can manufacture finished goods
-quickly enough.
+quickly enough. This can be overriden at BoM level though.
 
 As a consequence, and to avoid overestimating, **only the first level** of Bill
 of Materials is considered.

--- a/stock_available_mrp/readme/USAGE.rst
+++ b/stock_available_mrp/readme/USAGE.rst
@@ -1,0 +1,6 @@
+It's possible to avoid adding potential stock to available to promise stock at Bill of
+Materials level. This is interesting in case that sum is missleading due to uncertain
+manufacturing processes. To do so:
+
+- Go to that specific Bill of Materials and in the Miscellaneous tab set the option
+  **Avoid adding potential to available to promise** on.

--- a/stock_available_mrp/static/description/index.html
+++ b/stock_available_mrp/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Consider the production potential is available to promise</title>
 <style type="text/css">
 
@@ -377,28 +377,39 @@ with the components available to promise.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#known-issues-roadmap" id="id1">Known issues / Roadmap</a><ul>
-<li><a class="reference internal" href="#known-issues" id="id2">Known issues</a></li>
-<li><a class="reference internal" href="#removed-features" id="id3">Removed features</a></li>
-<li><a class="reference internal" href="#roadmap" id="id4">Roadmap</a></li>
+<li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a><ul>
+<li><a class="reference internal" href="#known-issues" id="id3">Known issues</a></li>
+<li><a class="reference internal" href="#removed-features" id="id4">Removed features</a></li>
+<li><a class="reference internal" href="#roadmap" id="id5">Roadmap</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="id5">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id6">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id7">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id8">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id9">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id6">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id7">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id8">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id9">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id10">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="usage">
+<h1><a class="toc-backref" href="#id1">Usage</a></h1>
+<p>It’s possible to avoid adding potential stock to available to promise stock at Bill of
+Materials level. This is interesting in case that sum is missleading due to uncertain
+manufacturing processes. To do so:</p>
+<ul class="simple">
+<li>Go to that specific Bill of Materials and in the Miscellaneous tab set the option
+<strong>Avoid adding potential to available to promise</strong> on.</li>
+</ul>
+</div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
 <div class="section" id="known-issues">
-<h2><a class="toc-backref" href="#id2">Known issues</a></h2>
-<p>The manufacturing delays are not taken into account : this module assumes that
+<h2><a class="toc-backref" href="#id3">Known issues</a></h2>
+<p>The manufacturing delays are not taken into account: this module assumes that
 if you have components in stock goods, you can manufacture finished goods
-quickly enough.</p>
+quickly enough. This can be overriden at BoM level though.</p>
 <p>As a consequence, and to avoid overestimating, <strong>only the first level</strong> of Bill
 of Materials is considered.</p>
 <p>However Sets (a.k.a “phantom” BoMs) are taken into account: if a component must
@@ -410,7 +421,7 @@ example, even if you actually have enough components to make 10 iPads 16Go AND
 42 iPads 32Go, we’ll consider that you can promise only 42 iPads.</p>
 </div>
 <div class="section" id="removed-features">
-<h2><a class="toc-backref" href="#id3">Removed features</a></h2>
+<h2><a class="toc-backref" href="#id4">Removed features</a></h2>
 <p>Previous versions of this module used to let programmers demand to get the
 potential quantity in an arbitrary Unit of Measure using the <cite>context</cite>. This
 feature was present in the standard computations too until v8.0, but it has
@@ -419,7 +430,7 @@ been dropped from the standard from v8.0 on.</p>
 the product’s main Unit of Measure too.</p>
 </div>
 <div class="section" id="roadmap">
-<h2><a class="toc-backref" href="#id4">Roadmap</a></h2>
+<h2><a class="toc-backref" href="#id5">Roadmap</a></h2>
 <p>Possible improvements for future versions:</p>
 <ul class="simple">
 <li>Take manufacturing delays into account: we should not promise goods to
@@ -435,7 +446,7 @@ manufacturing.</li>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id5">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id6">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/stock-logistics-warehouse/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -443,15 +454,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id6">Credits</a></h1>
+<h1><a class="toc-backref" href="#id7">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id7">Authors</a></h2>
+<h2><a class="toc-backref" href="#id8">Authors</a></h2>
 <ul class="simple">
 <li>Numérigraphe</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id8">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id9">Contributors</a></h2>
 <ul class="simple">
 <li>Loïc Bellier (Numérigraphe) &lt;<a class="reference external" href="mailto:lb&#64;numerigraphe.com">lb&#64;numerigraphe.com</a>&gt;</li>
 <li>Lionel Sausin (Numérigraphe) &lt;<a class="reference external" href="mailto:ls&#64;numerigraphe.com">ls&#64;numerigraphe.com</a>&gt;</li>
@@ -461,12 +472,13 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Florian da Costa &lt;<a class="reference external" href="mailto:florian.dacosta&#64;akretion.com">florian.dacosta&#64;akretion.com</a>&gt;</li>
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Víctor Martínez</li>
+<li>David Vidal</li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id9">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id10">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/stock_available_mrp/views/mrp_bom_views.xml
+++ b/stock_available_mrp/views/mrp_bom_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="mrp_bom_view_notes_form" model="ir.ui.view">
+        <field name="model">mrp.bom</field>
+        <field name="inherit_id" ref="mrp.mrp_bom_form_view" />
+        <field name="arch" type="xml">
+            <field name="picking_type_id" position="after">
+                <field
+                    name="add_potential_exception"
+                    attrs="{'invisible': [('type', '=', 'phantom')]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Normal BoM products (those which are manufactured) are regular stored
products and their immediately_usable_qty will be summed with potential
stock. This was the expected behavior of the module and it was lost at
some point.

Phantom BoM products (kits) don't have real stock so their available to
promise quantity will be the same as the potential.

As an improvement, we've added the possibility to override the sum of
potential and available to promise. In some cases such addition doesn't
make sense as we don't know how long can take to manufacture those potential
units.

cc @Tecnativa TT35841

fw-port of 

- [x] https://github.com/OCA/stock-logistics-warehouse/pull/1403

please @chienandalu @victoralmau 