### PR TITLE
[14.0][IMP] scrap_reason_code (Require Reason Code & Scrap Location)

### DIFF
--- a/scrap_reason_code/views/reason_code_view.xml
+++ b/scrap_reason_code/views/reason_code_view.xml
@@ -14,7 +14,7 @@
                     <field name="description" />
                 </group>
                 <group>
-                    <field name="location_id" />
+                    <field name="location_id" required="1" />
                 </group>
             </form>
         </field>

--- a/scrap_reason_code/views/stock_scrap_views.xml
+++ b/scrap_reason_code/views/stock_scrap_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="stock.stock_scrap_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//group/group" position='inside'>
-                <field name="reason_code_id" />
+                <field name="reason_code_id" required="1" />
             </xpath>
         </field>
     </record>
@@ -27,7 +27,7 @@
         <field name="inherit_id" ref="stock.stock_scrap_form_view2" />
         <field name="arch" type="xml">
             <xpath expr="//group/group" position='inside'>
-                <field name="reason_code_id" />
+                <field name="reason_code_id" required="1" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
If you try to perform a scrap without a reason code or the reason code doesn't have a scrap location, it will give an error to the user that a mandatory field is needed. This is easily solved by requiring the reason and scrap location on the reason.