### PR TITLE
[FIX] scrap_reason_code (Location Not Set)

### DIFF
--- a/scrap_reason_code/models/stock_scrap.py
+++ b/scrap_reason_code/models/stock_scrap.py
@@ -25,21 +25,23 @@ class StockScrap(models.Model):
 
     def write(self, vals):
         if "reason_code_id" in vals:
-            vals.update(
-                {
-                    "scrap_location_id": self.env["scrap.reason.code"]
-                    .browse(vals.get("reason_code_id"))
-                    .location_id
-                }
+            location_id = (
+                self.env["scrap.reason.code"]
+                .browse(vals.get("reason_code_id"))
+                .location_id
             )
+            if location_id:
+                vals.update({"scrap_location_id": location_id})
         return super(StockScrap, self).write(vals)
 
     @api.model
     def create(self, vals):
         if "reason_code_id" in vals:
-            vals["scrap_location_id"] = (
+            location_id = (
                 self.env["scrap.reason.code"]
                 .browse(vals.get("reason_code_id"))
-                .location_id.id
+                .location_id
             )
+            if location_id:
+                vals["scrap_location_id"] = location_id.id
         return super(StockScrap, self).create(vals)

--- a/scrap_reason_code/models/stock_scrap.py
+++ b/scrap_reason_code/models/stock_scrap.py
@@ -25,23 +25,23 @@ class StockScrap(models.Model):
 
     def write(self, vals):
         if "reason_code_id" in vals:
-            scrap_loc = (
+            location_id = (
                 self.env["scrap.reason.code"]
                 .browse(vals.get("reason_code_id"))
                 .location_id
             )
-            if scrap_loc:
-                vals.update({"scrap_location_id": scrap_loc})
+            if location_id:
+                vals.update({"scrap_location_id": location_id})
         return super(StockScrap, self).write(vals)
 
     @api.model
     def create(self, vals):
         if "reason_code_id" in vals:
-            scrap_loc = (
+            location_id = (
                 self.env["scrap.reason.code"]
                 .browse(vals.get("reason_code_id"))
                 .location_id
             )
-            if scrap_loc:
-                vals["scrap_location_id"] = scrap_loc.id
+            if location_id:
+                vals["scrap_location_id"] = location_id.id
         return super(StockScrap, self).create(vals)

--- a/scrap_reason_code/models/stock_scrap.py
+++ b/scrap_reason_code/models/stock_scrap.py
@@ -25,21 +25,23 @@ class StockScrap(models.Model):
 
     def write(self, vals):
         if "reason_code_id" in vals:
-            vals.update(
-                {
-                    "scrap_location_id": self.env["scrap.reason.code"]
-                    .browse(vals.get("reason_code_id"))
-                    .location_id
-                }
+            scrap_loc = (
+                self.env["scrap.reason.code"]
+                .browse(vals.get("reason_code_id"))
+                .location_id
             )
+            if scrap_loc:
+                vals.update({"scrap_location_id": scrap_loc})
         return super(StockScrap, self).write(vals)
 
     @api.model
     def create(self, vals):
         if "reason_code_id" in vals:
-            vals["scrap_location_id"] = (
+            scrap_loc = (
                 self.env["scrap.reason.code"]
                 .browse(vals.get("reason_code_id"))
-                .location_id.id
+                .location_id
             )
+            if scrap_loc:
+                vals["scrap_location_id"] = scrap_loc.id
         return super(StockScrap, self).create(vals)


### PR DESCRIPTION
Currently the reason code and scrap location on the code has to be set otherwise an error is generated stating the location is required.
This fixes that so if the reason code is not used or there is not a location on the code then the location on the default scrap location on the order is used, otherwise it will use the code's location.