### PR TITLE
[14.0][FIX] stock_picking_cancel_confirm: cancel pickings without lines

### DIFF
--- a/stock_picking_cancel_confirm/README.rst
+++ b/stock_picking_cancel_confirm/README.rst
@@ -53,7 +53,10 @@ Authors
 Contributors
 ~~~~~~~~~~~~
 
-* Kitti U. <kittiu@ecosoft.co.th>
+* `Ecosoft <http://ecosoft.co.th>`__:
+
+  * Kitti Upariphutthiphong. <kittiu@ecosoft.co.th>
+  * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_picking_cancel_confirm/models/stock_picking.py
+++ b/stock_picking_cancel_confirm/models/stock_picking.py
@@ -12,4 +12,9 @@ class StockPicking(models.Model):
     def action_cancel(self):
         if not self.filtered("cancel_confirm"):
             return self.open_cancel_confirm_wizard()
-        return super().action_cancel()
+        res = super().action_cancel()
+        # Ensure to cancel the picking w/o moves that wasn't cancelled by odoo core
+        self.filtered(lambda l: l.state != "cancel" and not l.move_lines).write(
+            {"state": "cancel"}
+        )
+        return res

--- a/stock_picking_cancel_confirm/readme/CONTRIBUTORS.rst
+++ b/stock_picking_cancel_confirm/readme/CONTRIBUTORS.rst
@@ -1,1 +1,4 @@
-* Kitti U. <kittiu@ecosoft.co.th>
+* `Ecosoft <http://ecosoft.co.th>`__:
+
+  * Kitti Upariphutthiphong. <kittiu@ecosoft.co.th>
+  * Pimolnat Suntian <pimolnats@ecosoft.co.th>

--- a/stock_picking_cancel_confirm/static/description/index.html
+++ b/stock_picking_cancel_confirm/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Stock Picking Cancel Confirm</title>
 <style type="text/css">
 
@@ -400,7 +400,11 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#id4">Contributors</a></h2>
 <ul class="simple">
-<li>Kitti U. &lt;<a class="reference external" href="mailto:kittiu&#64;ecosoft.co.th">kittiu&#64;ecosoft.co.th</a>&gt;</li>
+<li><a class="reference external" href="http://ecosoft.co.th">Ecosoft</a>:<ul>
+<li>Kitti Upariphutthiphong. &lt;<a class="reference external" href="mailto:kittiu&#64;ecosoft.co.th">kittiu&#64;ecosoft.co.th</a>&gt;</li>
+<li>Pimolnat Suntian &lt;<a class="reference external" href="mailto:pimolnats&#64;ecosoft.co.th">pimolnats&#64;ecosoft.co.th</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
This pull request fix is about canceled pickings without lines.

**Before:**  Pickings not cancelled
![cancel_picking](https://user-images.githubusercontent.com/51266019/171555815-24d32a09-ba43-4d85-afe9-9a57062ec373.gif)

**After:** Pickings cancelled
![cancel_picking_2](https://user-images.githubusercontent.com/51266019/171555804-1726a0b7-d313-497b-af54-39e9f75661a2.gif)
