### PR TITLE
stock_mts_mto_rule: remove useless constraint

### DIFF
--- a/stock_mts_mto_rule/models/stock_rule.py
+++ b/stock_mts_mto_rule/models/stock_rule.py
@@ -25,16 +25,6 @@ class StockRule(models.Model):
                         "No MTS or MTO rule configured on procurement " "rule: %s!"
                     ) % (rule.name,)
                     raise ValidationError(msg)
-                if (
-                    rule.mts_rule_id.location_src_id.id
-                    != rule.mto_rule_id.location_src_id.id
-                ):
-                    msg = _(
-                        "Inconsistency between the source locations of "
-                        "the mts and mto rules linked to the procurement "
-                        "rule: %s! It should be the same."
-                    ) % (rule.name,)
-                    raise ValidationError(msg)
 
     def get_mto_qty_to_order(self, product, product_qty, product_uom, values):
         self.ensure_one()

--- a/stock_mts_mto_rule/tests/test_mto_mts_route.py
+++ b/stock_mts_mto_rule/tests/test_mto_mts_route.py
@@ -150,8 +150,6 @@ class TestMtoMtsRoute(TransactionCase):
         )
         with self.assertRaises(exceptions.ValidationError):
             rule.write({"mts_rule_id": False})
-        with self.assertRaises(exceptions.ValidationError):
-            rule.write({"mts_rule_id": self.dummy_rule.id})
 
     def test_mts_mto_route_mto_removed(self):
         self.env.ref("stock_mts_mto_rule.route_mto_mts").unlink()


### PR DESCRIPTION
Having the same src location is not needed and maybe wanted in some case
For example the Manufacturing can be done in an other warehouse

@florian-dacosta  @michotm 