### PR TITLE
[13.0][FIX] sale_stock_available_info_popup: immediately_usable_qty_today triggers

### DIFF
--- a/sale_stock_available_info_popup/models/sale_order.py
+++ b/sale_stock_available_info_popup/models/sale_order.py
@@ -13,7 +13,13 @@ class SaleOrderLine(models.Model):
         compute="_compute_immediately_usable_qty_today"
     )
 
-    @api.depends("product_id", "product_uom_qty")
+    @api.depends(
+        "product_id",
+        "product_uom_qty",
+        "order_id.commitment_date",
+        "order_id.date_order",
+        "warehouse_id",
+    )
     def _compute_immediately_usable_qty_today(self):
         qty_processed_per_product = defaultdict(lambda: 0)
         self.immediately_usable_qty_today = False

--- a/sale_stock_available_info_popup/readme/CONTRIBUTORS.rst
+++ b/sale_stock_available_info_popup/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
   * Ernesto Tejeda
   * Pedro M. Baeza
   * Víctor Martínez
+  * César A. Sánchez


### PR DESCRIPTION
Add missing triggers of computational field immediately_usable_qty_today


 TT38197