### PR TITLE
[13.0][FIX]stock_location_route_description: name_get calculation

### DIFF
--- a/stock_location_route_description/models/stock_location_route.py
+++ b/stock_location_route_description/models/stock_location_route.py
@@ -10,16 +10,14 @@ class StockLocationRoute(models.Model):
     description = fields.Char(translate=True)
 
     def name_get(self):
-        result = []
         if self.env.context.get("show_description", False):
+            result = []
             for rec in self:
+                name = ""
                 if rec.description:
-                    rec.display_name = rec.name + ": " + rec.description
+                    name = rec.name + ": " + rec.description
                 else:
-                    rec.display_name = rec.name
-                result.append((rec.id, rec.display_name))
-        else:
-            for rec in self:
-                rec.display_name = rec.name
-            return super(StockLocationRoute, self).name_get()
-        return result
+                    name = rec.name
+                result.append((rec.id, name))
+            return result
+        return super().name_get()

--- a/stock_location_route_description/tests/test_stock_location_route_description.py
+++ b/stock_location_route_description/tests/test_stock_location_route_description.py
@@ -7,7 +7,6 @@ from odoo.tests.common import TransactionCase
 class TestStockLocationRouteDescription(TransactionCase):
     def setUp(self, *args, **kwargs):
         super(TestStockLocationRouteDescription, self).setUp(*args, **kwargs)
-
         self.model_stock_location_route = self.env["stock.location.route"]
 
     def test_display_name_stock_location_route(self):
@@ -18,6 +17,6 @@ class TestStockLocationRouteDescription(TransactionCase):
             {"name": "Test Route", "description": "Test Description"}
         )
         self.assertEqual(route.display_name, route.name)
-        route.with_context(show_description=True).name_get()
         name_description = route.name + ": " + route.description
+        route.with_context(show_description=True)._compute_display_name()
         self.assertEqual(route.display_name, name_description)


### PR DESCRIPTION
Fix the computation of the resulting name for the routes.
cc @ForgeFlow