### PR TITLE
[13.0] stock_available: Update models/product_template.py

### DIFF
--- a/stock_available/models/product_template.py
+++ b/stock_available/models/product_template.py
@@ -31,7 +31,7 @@ class ProductTemplate(models.Model):
                 [
                     variants_dict[p.id]["immediately_usable_qty"]
                     - variants_dict[p.id]["potential_qty"]
-                    for p in template.product_variant_ids
+                    for p in template.product_variant_ids if p.immediately_usable_qty > 0 #negative quantities should not have any impact on availability
                 ]
             )
             potential_qty = max(

--- a/stock_available/models/product_template.py
+++ b/stock_available/models/product_template.py
@@ -31,7 +31,8 @@ class ProductTemplate(models.Model):
                 [
                     variants_dict[p.id]["immediately_usable_qty"]
                     - variants_dict[p.id]["potential_qty"]
-                    for p in template.product_variant_ids if p.immediately_usable_qty > 0 #negative quantities should not have any impact on availability
+                    for p in template.product_variant_ids
+                    if p.immediately_usable_qty > 0 #negative quantities should not have any impact on availability
                 ]
             )
             potential_qty = max(


### PR DESCRIPTION
Negative quantities on any variant should not have any impact on product.template availability at all.

Example:
We have a t-shirt in two colors with following availabilities:
red - 1 piece in stock
white - 0 pieces in stock.

Someone pre-order a white t-shirt and qty will be -1.

Result:
t-shirt (product.template) immediately_usable_qty = 0
red t-shirt (product variant of the same product.template) immediately_usable_qty = 1
white t-shirt (product variant of the same product.template) immediately_usable_qty = -1 - MUST be purchased from supplier OR cancel the sale order BUT should not affect product.template available qty.