### PR TITLE
[13.0][IMP] account_move_line_stock_info: show stock move in list view

### DIFF
--- a/account_move_line_stock_info/models/stock_move.py
+++ b/account_move_line_stock_info/models/stock_move.py
@@ -8,7 +8,7 @@ class StockMove(models.Model):
     _inherit = "stock.move"
 
     account_move_line_ids = fields.One2many(
-        comodel_name="account.move.line", inverse_name="stock_move_id", copy=False
+        comodel_name="account.move.line", inverse_name="stock_move_id", copy=False,
     )
 
     @api.model

--- a/account_move_line_stock_info/tests/test_account_move_line_stock_move.py
+++ b/account_move_line_stock_info/tests/test_account_move_line_stock_move.py
@@ -59,7 +59,7 @@ class TestAccountMoveLineStockInfo(TransactionCase):
         )
 
     def _create_user(self, login, groups, company):
-        """ Create a user."""
+        """Create a user."""
         group_ids = [group.id for group in groups]
         user = self.res_users_model.with_context({"no_reset_password": True}).create(
             {

--- a/account_move_line_stock_info/views/account_move_line_view.xml
+++ b/account_move_line_stock_info/views/account_move_line_view.xml
@@ -6,8 +6,23 @@
         <field name="inherit_id" ref="account.view_move_line_form" />
         <field name="arch" type="xml">
             <field name="quantity" position="before">
-                <field name="stock_move_id" />
+                <field name="stock_move_id" groups="stock.group_stock_user" />
             </field>
         </field>
     </record>
+    <record id="view_move_line_tree" model="ir.ui.view">
+        <field name="name">account.move.line.treee</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_tree" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="before">
+                <field
+                    name="stock_move_id"
+                    groups="stock.group_stock_user"
+                    optional="hide"
+                />
+            </field>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Put the stock move in the journal item tree view. I think it is very useful when analyzing the journal items of a stock transfer:
![image](https://user-images.githubusercontent.com/19620251/186921229-2ac5fc0c-f145-4d91-8d12-1c0cf346f73d.png)

Also, some pre-commit fixes included
Also, restrict the stock move views to stock users

cc @ForgeFlow