### PR TITLE
[14.0][DCK] stock_packaging_calculator: Change development_status key to Beta

### DIFF
--- a/stock_packaging_calculator/__manifest__.py
+++ b/stock_packaging_calculator/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Stock packaging calculator",
     "summary": "Compute product quantity to pick by packaging",
     "version": "14.0.1.2.0",
-    "development_status": "Alpha",
+    "development_status": "Beta",
     "category": "Warehouse Management",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "author": "Camptocamp, Odoo Community Association (OCA)",


### PR DESCRIPTION
Change `development_status` key to Beta

Related to https://github.com/OCA/product-attribute/pull/1143

Please @pedrobaeza can you review it?

@Tecnativa 