### PR TITLE
[15.0][FIX] stock_move_location: Bug on onchange origin location

### DIFF
--- a/stock_move_location/README.rst
+++ b/stock_move_location/README.rst
@@ -114,6 +114,7 @@ Contributors
   * João Marques
 * Jacques-Etienne Baudoux <je@bcim.be>
 * Iryna Vyshnevska <i.vyshnevska@mobilunity.com>
+* Alexei Rivera <arivera@archeti.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_move_location/readme/CONTRIBUTORS.rst
+++ b/stock_move_location/readme/CONTRIBUTORS.rst
@@ -10,3 +10,4 @@
   * João Marques
 * Jacques-Etienne Baudoux <je@bcim.be>
 * Iryna Vyshnevska <i.vyshnevska@mobilunity.com>
+* Alexei Rivera <arivera@archeti.com>

--- a/stock_move_location/static/description/index.html
+++ b/stock_move_location/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Move Stock Location</title>
 <style type="text/css">
 
@@ -461,6 +461,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </li>
 <li>Jacques-Etienne Baudoux &lt;<a class="reference external" href="mailto:je&#64;bcim.be">je&#64;bcim.be</a>&gt;</li>
 <li>Iryna Vyshnevska &lt;<a class="reference external" href="mailto:i.vyshnevska&#64;mobilunity.com">i.vyshnevska&#64;mobilunity.com</a>&gt;</li>
+<li>Alexei Rivera &lt;<a class="reference external" href="mailto:arivera&#64;archeti.com">arivera&#64;archeti.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_move_location/tests/test_move_location.py
+++ b/stock_move_location/tests/test_move_location.py
@@ -64,6 +64,30 @@ class TestMoveLocation(TestsCommon):
         wizard._onchange_origin_location_id()
         self.assertEqual(len(wizard.stock_move_location_line_ids), 0)
 
+    def test_wizard_onchange_origin_location(self):
+        """Test a product that have existing quants with undefined quantity."""
+
+        product_not_available = self.env["product.product"].create(
+            {"name": "Mango", "type": "product", "tracking": "none"}
+        )
+        self.quant_obj.create(
+            {
+                "product_id": product_not_available.id,
+                "location_id": self.internal_loc_1.id,
+            }
+        )
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        wizard.onchange_origin_location()
+        # we check there is no line for product_not_available
+        self.assertEqual(
+            len(
+                wizard.stock_move_location_line_ids.filtered(
+                    lambda x: x.product_id.id == product_not_available.id
+                )
+            ),
+            0,
+        )
+
     def test_planned_transfer(self):
         """Test planned transfer."""
         wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)

--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -294,8 +294,8 @@ class StockMoveLocationWizard(models.TransientModel):
             product_data.append(
                 {
                     "product_id": product.id,
-                    "move_quantity": group.get("quantity"),
-                    "max_quantity": group.get("quantity"),
+                    "move_quantity": group.get("quantity") or 0,
+                    "max_quantity": group.get("quantity") or 0,
                     "reserved_quantity": group.get("reserved_quantity"),
                     "origin_location_id": self.origin_location_id.id,
                     "destination_location_id": location_dest_id,


### PR DESCRIPTION
This PR fix a bug that may occurs when changing the origin location:

`File "/home/user/workspace/odoo_code/odoo/odoo/models.py", line 6475, in onchange
    record._onchange_eval(name, field_onchange[name], result)
  File "/home/user/workspace/odoo_code/odoo/odoo/models.py", line 6208, in _onchange_eval
    method_res = method(self)
  File "/home/user/workspace/oca/15.0/stock-logistics-warehouse/stock_move_location/wizard/stock_move_location.py", line 322, in onchange_origin_location
    if line_val.get("max_quantity") <= 0:
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/user/workspace/odoo_code/odoo/odoo/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/user/workspace/odoo_code/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: '<=' not supported between instances of 'NoneType' and 'int'`

As we can see in the error log, group.get("quantity") may be None

regards