### PR TITLE
[14.0][FIX] stock_quant_reservation_info: only reservations from internal locations

### DIFF
--- a/stock_quant_reservation_info/models/stock_quant.py
+++ b/stock_quant_reservation_info/models/stock_quant.py
@@ -26,6 +26,7 @@ class StockQuant(models.Model):
             "domain": [
                 ("product_id", "=", self.product_id.id),
                 ("product_uom_qty", ">", 0),
+                ("location_id.usage", "=", "internal"),
             ],
         }
         return action


### PR DESCRIPTION
Previously when seeing the reservations of the product, all reservations were being added, we just want the ones that come from internal locations (the ones that are being counted on product views).

@ForgeFlow