### PR TITLE
[15.0][IMP] stock_request: Show error in stock.request.order in the "Confirm" or "Submit" buttons if there are no items.

### DIFF
--- a/stock_request/i18n/es.po
+++ b/stock_request/i18n/es.po
@@ -9,16 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-02 03:44+0000\n"
-"PO-Revision-Date: 2021-05-26 18:47+0000\n"
+"POT-Creation-Date: 2022-10-21 09:10+0000\n"
+"PO-Revision-Date: 2022-10-21 11:11+0200\n"
 "Last-Translator: JrAdhoc <jr@adhoc.com.ar>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: stock_request
 #: code:addons/stock_request/models/stock_move_line.py:0
@@ -54,7 +54,7 @@ msgstr "Actividades"
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__activity_exception_decoration
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__activity_exception_decoration
 msgid "Activity Exception Decoration"
-msgstr ""
+msgstr "Actividad Excepción Decoración"
 
 #. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__activity_state
@@ -68,7 +68,7 @@ msgstr "Estado de Actividad"
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__activity_type_icon
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__activity_type_icon
 msgid "Activity Type Icon"
-msgstr ""
+msgstr "Icono de tipo de actividad"
 
 #. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.res_config_settings_view_form
@@ -197,7 +197,6 @@ msgstr "Creado el"
 
 #. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_search
-#, fuzzy
 msgid "Current requests"
 msgstr "Solicitudes de existencias"
 
@@ -277,7 +276,7 @@ msgstr "La fecha prevista debe ser la misma que la del pedido"
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_order_search
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_search
 msgid "Finished"
-msgstr ""
+msgstr "Terminado"
 
 #. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__message_follower_ids
@@ -298,7 +297,7 @@ msgstr "Seguidores (Socios)"
 #: model:ir.model.fields,help:stock_request.field_stock_request_abstract__activity_type_icon
 #: model:ir.model.fields,help:stock_request.field_stock_request_order__activity_type_icon
 msgid "Font awesome icon e.g. fa-tasks"
-msgstr ""
+msgstr "Icono de Font Awesome ej. fa-tasks"
 
 #. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_order_search
@@ -330,14 +329,14 @@ msgstr "ID"
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__activity_exception_icon
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__activity_exception_icon
 msgid "Icon"
-msgstr ""
+msgstr "Icono"
 
 #. module: stock_request
 #: model:ir.model.fields,help:stock_request.field_stock_request__activity_exception_icon
 #: model:ir.model.fields,help:stock_request.field_stock_request_abstract__activity_exception_icon
 #: model:ir.model.fields,help:stock_request.field_stock_request_order__activity_exception_icon
 msgid "Icon to indicate an exception activity."
-msgstr ""
+msgstr "Icono para indicar una actividad de excepción."
 
 #. module: stock_request
 #: model:ir.model.fields,help:stock_request.field_stock_request__message_needaction
@@ -443,7 +442,7 @@ msgstr "Responsable"
 #. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.res_config_settings_view_form
 msgid "Manufacturing"
-msgstr ""
+msgstr "Orden de producción"
 
 #. module: stock_request
 #: model:ir.ui.menu,name:stock_request.menu_stock_request_master_data
@@ -482,7 +481,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__my_activity_date_deadline
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__my_activity_date_deadline
 msgid "My Activity Deadline"
-msgstr ""
+msgstr "Mi fecha de límite de actividad"
 
 #. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__name
@@ -528,16 +527,15 @@ msgstr "Numero de Acciones"
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__message_has_error_counter
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__message_has_error_counter
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__message_has_error_counter
-#, fuzzy
 msgid "Number of errors"
-msgstr "Número de error"
+msgstr "Número de errores"
 
 #. module: stock_request
 #: model:ir.model.fields,help:stock_request.field_stock_request__message_needaction_counter
 #: model:ir.model.fields,help:stock_request.field_stock_request_abstract__message_needaction_counter
 #: model:ir.model.fields,help:stock_request.field_stock_request_order__message_needaction_counter
 msgid "Number of messages which requires an action"
-msgstr "Número de mensajes que requieren una acción."
+msgstr "Número de mensajes que requieren una acción"
 
 #. module: stock_request
 #: model:ir.model.fields,help:stock_request.field_stock_request__message_has_error_counter
@@ -632,7 +630,7 @@ msgstr "Compras"
 #. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__qty_cancelled
 msgid "Qty Cancelled"
-msgstr ""
+msgstr "Cant. cancelada"
 
 #. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__qty_done
@@ -653,7 +651,7 @@ msgstr "Cantidad"
 #. module: stock_request
 #: model:ir.model.fields,help:stock_request.field_stock_request__qty_cancelled
 msgid "Quantity cancelled"
-msgstr ""
+msgstr "Cantidad cancelada"
 
 #. module: stock_request
 #: model:ir.model.fields,help:stock_request.field_stock_request__qty_done
@@ -774,9 +772,8 @@ msgstr "Rutas"
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__message_has_sms_error
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__message_has_sms_error
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__message_has_sms_error
-#, fuzzy
 msgid "SMS Delivery error"
-msgstr "Mensaje de Entrega de error"
+msgstr "Error de entrega de SMS"
 
 #. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.res_config_settings_view_form
@@ -937,7 +934,6 @@ msgstr "Integración de solicitudes de existencias con tarjetas Kanbans"
 
 #. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_order_search
-#, fuzzy
 msgid "Stock Requests Order Search"
 msgstr "Buscar solicitudes de existencias"
 
@@ -1003,6 +999,12 @@ msgstr "La política de albaranes debe coincidir"
 #. module: stock_request
 #: code:addons/stock_request/models/stock_request_order.py:0
 #, python-format
+msgid "There should be at least one request item for confirming the order."
+msgstr "Debe haber al menos un elemento de solicitud para confirmar el pedido."
+
+#. module: stock_request
+#: code:addons/stock_request/models/stock_request_order.py:0
+#, python-format
 msgid "This action only works in the context of products"
 msgstr "Esta acción solo funciona en el contexto de productos"
 
@@ -1022,7 +1024,7 @@ msgstr "Transferencias"
 #: model:ir.model.fields,help:stock_request.field_stock_request_abstract__activity_exception_decoration
 #: model:ir.model.fields,help:stock_request.field_stock_request_order__activity_exception_decoration
 msgid "Type of the exception activity on record."
-msgstr ""
+msgstr "Tipo de actividad de excepción registrada."
 
 #. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__message_unread
@@ -1176,27 +1178,3 @@ msgid ""
 msgstr ""
 "Debe seleccionada una unidad de medida de producto de la misma categoría que "
 "la unidad de medida por defecto del producto"
-
-#~ msgid "Archived"
-#~ msgstr "Archivado"
-
-#~ msgid "If checked new messages require your attention."
-#~ msgstr "Si está marcado, los nuevos mensajes requieren su atención."
-
-#~ msgid "Overdue"
-#~ msgstr "Atrasado"
-
-#~ msgid "Planned"
-#~ msgstr "Planificado"
-
-#~ msgid "Today"
-#~ msgstr "Hoy"
-
-#~ msgid "Packing Operation"
-#~ msgstr "Operación de empaquetado"
-
-#~ msgid "Procurement Rule"
-#~ msgstr "Regla de abastecimiento"
-
-#~ msgid "Orders"
-#~ msgstr "Pedidos"

--- a/stock_request/i18n/es.po
+++ b/stock_request/i18n/es.po
@@ -23,8 +23,12 @@ msgstr ""
 #. module: stock_request
 #: code:addons/stock_request/models/stock_move_line.py:0
 #, python-format
-msgid "<li><b>%s</b>: Transferred quantity %s %s</li>"
-msgstr "<li><b>%s</b>: Cantidad transferida %s %s</li>"
+msgid ""
+"<li><b>%(product_name)s</b>: Transferred quantity "
+"%(product_qty)s%(product_uom)s</li>"
+msgstr ""
+"<li><b>%(product_name)s</b>: Cantidad transferida "
+"%(product_qty)s%(product_uom)s</li>"
 
 #. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__message_needaction
@@ -166,6 +170,18 @@ msgid "Confirm"
 msgstr "Confirmar"
 
 #. module: stock_request
+#: model_terms:ir.ui.view,arch_db:stock_request.res_config_settings_view_form
+msgid "Confirm button type"
+msgstr "Tipo de botón de confirmación"
+
+#. module: stock_request
+#: model:ir.model.fields,field_description:stock_request.field_res_company__stock_request_confirm_user_permission
+#: model:ir.model.fields,field_description:stock_request.field_res_config_settings__stock_request_confirm_user_permission
+#: model:ir.model.fields,field_description:stock_request.field_stock_request_order__stock_request_confirm_user_permission
+msgid "Confirm type button in Stock Requests"
+msgstr "Tipo de botón de confirmación en solicitudes de stock"
+
+#. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__create_uid
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_allocation__create_uid
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__create_uid
@@ -198,20 +214,9 @@ msgid "Delivery Orders"
 msgstr "Pedidos de entrega"
 
 #. module: stock_request
-#: model:ir.model.fields,field_description:stock_request.field_procurement_group__display_name
-#: model:ir.model.fields,field_description:stock_request.field_res_company__display_name
-#: model:ir.model.fields,field_description:stock_request.field_res_config_settings__display_name
-#: model:ir.model.fields,field_description:stock_request.field_stock_location__display_name
-#: model:ir.model.fields,field_description:stock_request.field_stock_location_route__display_name
-#: model:ir.model.fields,field_description:stock_request.field_stock_move__display_name
-#: model:ir.model.fields,field_description:stock_request.field_stock_move_line__display_name
-#: model:ir.model.fields,field_description:stock_request.field_stock_picking__display_name
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__display_name
-#: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__display_name
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_allocation__display_name
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__display_name
-#: model:ir.model.fields,field_description:stock_request.field_stock_rule__display_name
-#: model:ir.model.fields,field_description:stock_request.field_stock_warehouse__display_name
 msgid "Display Name"
 msgstr "Nombre mostrado"
 
@@ -282,13 +287,6 @@ msgid "Followers"
 msgstr "Seguidores"
 
 #. module: stock_request
-#: model:ir.model.fields,field_description:stock_request.field_stock_request__message_channel_ids
-#: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__message_channel_ids
-#: model:ir.model.fields,field_description:stock_request.field_stock_request_order__message_channel_ids
-msgid "Followers (Channels)"
-msgstr "Seguidores (Canales)"
-
-#. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__message_partner_ids
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__message_partner_ids
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__message_partner_ids
@@ -314,20 +312,16 @@ msgid "Group Stock Request Order"
 msgstr "Agrupa las solicitudes en pedidos"
 
 #. module: stock_request
-#: model:ir.model.fields,field_description:stock_request.field_procurement_group__id
-#: model:ir.model.fields,field_description:stock_request.field_res_company__id
-#: model:ir.model.fields,field_description:stock_request.field_res_config_settings__id
-#: model:ir.model.fields,field_description:stock_request.field_stock_location__id
-#: model:ir.model.fields,field_description:stock_request.field_stock_location_route__id
-#: model:ir.model.fields,field_description:stock_request.field_stock_move__id
-#: model:ir.model.fields,field_description:stock_request.field_stock_move_line__id
-#: model:ir.model.fields,field_description:stock_request.field_stock_picking__id
+#: model:ir.model.fields,field_description:stock_request.field_stock_request__has_message
+#: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__has_message
+#: model:ir.model.fields,field_description:stock_request.field_stock_request_order__has_message
+msgid "Has Message"
+msgstr "Tiene mensaje"
+
+#. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__id
-#: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__id
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_allocation__id
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__id
-#: model:ir.model.fields,field_description:stock_request.field_stock_rule__id
-#: model:ir.model.fields,field_description:stock_request.field_stock_warehouse__id
 msgid "ID"
 msgstr "ID"
 
@@ -399,20 +393,9 @@ msgid "Kanban"
 msgstr "Kanban"
 
 #. module: stock_request
-#: model:ir.model.fields,field_description:stock_request.field_procurement_group____last_update
-#: model:ir.model.fields,field_description:stock_request.field_res_company____last_update
-#: model:ir.model.fields,field_description:stock_request.field_res_config_settings____last_update
-#: model:ir.model.fields,field_description:stock_request.field_stock_location____last_update
-#: model:ir.model.fields,field_description:stock_request.field_stock_location_route____last_update
-#: model:ir.model.fields,field_description:stock_request.field_stock_move____last_update
-#: model:ir.model.fields,field_description:stock_request.field_stock_move_line____last_update
-#: model:ir.model.fields,field_description:stock_request.field_stock_picking____last_update
 #: model:ir.model.fields,field_description:stock_request.field_stock_request____last_update
-#: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract____last_update
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_allocation____last_update
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order____last_update
-#: model:ir.model.fields,field_description:stock_request.field_stock_rule____last_update
-#: model:ir.model.fields,field_description:stock_request.field_stock_warehouse____last_update
 msgid "Last Modified on"
 msgstr "Última Modificación el"
 
@@ -451,6 +434,11 @@ msgstr "La ubicación debe ser la misma que la del pedido"
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__message_main_attachment_id
 msgid "Main Attachment"
 msgstr "Adjunto Principal"
+
+#. module: stock_request
+#: model:ir.model.fields.selection,name:stock_request.selection__res_company__stock_request_confirm_user_permission__manager
+msgid "Manager"
+msgstr "Responsable"
 
 #. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.res_config_settings_view_form
@@ -717,8 +705,10 @@ msgstr "Cantidad real"
 #. module: stock_request
 #: code:addons/stock_request/models/stock_move_line.py:0
 #, python-format
-msgid "Receipt confirmation %s for your Request %s"
-msgstr "Confirmación de la recepción %s de la solicitud %s"
+msgid "Receipt confirmation %(picking_name)s for your Request %(request_name)s"
+msgstr ""
+"Confirmación de la recepción %(picking_name)s de la solicitud "
+"%(request_name)s"
 
 #. module: stock_request
 #: model:ir.model.fields.selection,name:stock_request.selection__stock_request__picking_policy__one
@@ -739,6 +729,12 @@ msgid "Request Stock"
 msgstr "Solicitud de Existencias"
 
 #. module: stock_request
+#: model:ir.model.fields,field_description:stock_request.field_stock_request__requested_by
+#: model:ir.model.fields,field_description:stock_request.field_stock_request_order__requested_by
+msgid "Requested By"
+msgstr "Solicitado por"
+
+#. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_allocation__requested_product_qty
 msgid "Requested Quantity"
 msgstr "Cantidad solicitada"
@@ -747,12 +743,6 @@ msgstr "Cantidad solicitada"
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_allocation__requested_product_uom_qty
 msgid "Requested Quantity (UoM)"
 msgstr "Cantidad Solicitada (UdM)"
-
-#. module: stock_request
-#: model:ir.model.fields,field_description:stock_request.field_stock_request__requested_by
-#: model:ir.model.fields,field_description:stock_request.field_stock_request_order__requested_by
-msgid "Requested by"
-msgstr "Solicitado por"
 
 #. module: stock_request
 #: code:addons/stock_request/models/stock_request.py:0
@@ -787,6 +777,13 @@ msgstr "Rutas"
 #, fuzzy
 msgid "SMS Delivery error"
 msgstr "Mensaje de Entrega de error"
+
+#. module: stock_request
+#: model_terms:ir.ui.view,arch_db:stock_request.res_config_settings_view_form
+msgid "Select users' permission to use Confirm button in Stock Request."
+msgstr ""
+"Seleccione el permiso de los usuarios para utilizar el botón de confirmar en "
+"las solicitudes de existencias."
 
 #. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_order_form
@@ -865,7 +862,6 @@ msgstr "Asignación de solicitud de existencias"
 #. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.view_move_form
 #: model_terms:ir.ui.view,arch_db:stock_request.view_stock_request_allocation_form
-#: model_terms:ir.ui.view,arch_db:stock_request.view_stock_request_allocation_tree
 msgid "Stock Request Allocations"
 msgstr "Asignaciones de solicitud de existencias"
 
@@ -926,7 +922,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_search
 #: model_terms:ir.ui.view,arch_db:stock_request.view_picking_form
 #: model_terms:ir.ui.view,arch_db:stock_request.view_stock_request_form
-#: model_terms:ir.ui.view,arch_db:stock_request.view_stock_request_tree
 msgid "Stock Requests"
 msgstr "Solicitudes de existencias"
 
@@ -968,7 +963,6 @@ msgstr "Solicitud de existencias"
 
 #. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__stock_request_count
-#: model_terms:ir.ui.view,arch_db:stock_request.stock_request_order_tree
 msgid "Stock requests"
 msgstr "Solicitudes de existencias"
 
@@ -994,11 +988,11 @@ msgstr "La compañía de la solicitud debe coincidir con la del almacén."
 #: code:addons/stock_request/models/stock_move_line.py:0
 #, python-format
 msgid ""
-"The following requested items from Stock Request %s have now been received "
-"in %s using Picking %s:"
+"The following requested items from Stock Request %(request_name)s have now "
+"been received in %(location_name)s using Picking %(picking_name)s:"
 msgstr ""
-"Los siguientes elementos de la solicitud %s se ha recibido en %s con el "
-"albarán %s:"
+"Los siguientes elementos de la solicitud %(request_name)ss se ha recibido en "
+"%(location_name)s con el albarán %(picking_name)s:"
 
 #. module: stock_request
 #: code:addons/stock_request/models/stock_request.py:0
@@ -1029,16 +1023,6 @@ msgstr "Transferencias"
 #: model:ir.model.fields,help:stock_request.field_stock_request_order__activity_exception_decoration
 msgid "Type of the exception activity on record."
 msgstr ""
-
-#. module: stock_request
-#: code:addons/stock_request/models/stock_request_order.py:0
-#, python-format
-msgid ""
-"Unfortunately it seems you do not have the necessary rights for creating "
-"stock requests. Please contact your administrator."
-msgstr ""
-"No tiene los permisos necesarios para crear una solicitud de existencias. "
-"Por favor, contacte con su administrador."
 
 #. module: stock_request
 #: model:ir.model.fields,field_description:stock_request.field_stock_request__message_unread
@@ -1073,6 +1057,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock_request.res_config_settings_view_form
 msgid "Use Purchases with Stock Requests"
 msgstr "Usar Compras con las Solicitudes de Existencias"
+
+#. module: stock_request
+#: model:ir.model.fields.selection,name:stock_request.selection__res_company__stock_request_confirm_user_permission__user
+msgid "User"
+msgstr "Usuario"
 
 #. module: stock_request
 #: model:ir.model,name:stock_request.model_stock_warehouse

--- a/stock_request/i18n/stock_request.pot
+++ b/stock_request/i18n/stock_request.pot
@@ -6,11 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-<<<<<<< HEAD
-=======
 "POT-Creation-Date: 2022-10-24 14:22+0000\n"
 "PO-Revision-Date: 2022-10-24 14:22+0000\n"
->>>>>>> eeb79e47e (confirm)
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -969,6 +966,12 @@ msgstr ""
 #: code:addons/stock_request/models/stock_request.py:0
 #, python-format
 msgid "The picking policy must be equal to the order"
+msgstr ""
+
+#. module: stock_request
+#: code:addons/stock_request/models/stock_request_order.py:0
+#, python-format
+msgid "There should be at least one request item for confirming the order."
 msgstr ""
 
 #. module: stock_request

--- a/stock_request/i18n/stock_request.pot
+++ b/stock_request/i18n/stock_request.pot
@@ -6,6 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+<<<<<<< HEAD
+=======
+"POT-Creation-Date: 2022-10-24 14:22+0000\n"
+"PO-Revision-Date: 2022-10-24 14:22+0000\n"
+>>>>>>> eeb79e47e (confirm)
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -154,6 +159,18 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_order_form
 #: model_terms:ir.ui.view,arch_db:stock_request.view_stock_request_form
 msgid "Confirm"
+msgstr ""
+
+#. module: stock_request
+#: model_terms:ir.ui.view,arch_db:stock_request.res_config_settings_view_form
+msgid "Confirm button type"
+msgstr ""
+
+#. module: stock_request
+#: model:ir.model.fields,field_description:stock_request.field_res_company__stock_request_confirm_user_permission
+#: model:ir.model.fields,field_description:stock_request.field_res_config_settings__stock_request_confirm_user_permission
+#: model:ir.model.fields,field_description:stock_request.field_stock_request_order__stock_request_confirm_user_permission
+msgid "Confirm type button in Stock Requests"
 msgstr ""
 
 #. module: stock_request
@@ -407,6 +424,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_abstract__message_main_attachment_id
 #: model:ir.model.fields,field_description:stock_request.field_stock_request_order__message_main_attachment_id
 msgid "Main Attachment"
+msgstr ""
+
+#. module: stock_request
+#: model:ir.model.fields.selection,name:stock_request.selection__res_company__stock_request_confirm_user_permission__manager
+msgid "Manager"
 msgstr ""
 
 #. module: stock_request
@@ -738,6 +760,11 @@ msgid "SMS Delivery error"
 msgstr ""
 
 #. module: stock_request
+#: model_terms:ir.ui.view,arch_db:stock_request.res_config_settings_view_form
+msgid "Select users' permission to use Confirm button in Stock Request."
+msgstr ""
+
+#. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_order_form
 #: model_terms:ir.ui.view,arch_db:stock_request.view_stock_request_form
 msgid "Set to Draft"
@@ -1000,6 +1027,11 @@ msgstr ""
 #. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.res_config_settings_view_form
 msgid "Use Purchases with Stock Requests"
+msgstr ""
+
+#. module: stock_request
+#: model:ir.model.fields.selection,name:stock_request.selection__res_company__stock_request_confirm_user_permission__user
+msgid "User"
 msgstr ""
 
 #. module: stock_request

--- a/stock_request/models/res_company.py
+++ b/stock_request/models/res_company.py
@@ -12,3 +12,11 @@ class ResCompany(models.Model):
     stock_request_allow_virtual_loc = fields.Boolean(
         string="Allow Virtual locations on Stock Requests"
     )
+    stock_request_confirm_user_permission = fields.Selection(
+        selection=[
+            ("user", "User"),
+            ("manager", "Manager"),
+        ],
+        default="user",
+        string="Confirm type button in Stock Requests",
+    )

--- a/stock_request/models/res_config_settings.py
+++ b/stock_request/models/res_config_settings.py
@@ -33,6 +33,10 @@ class ResConfigSettings(models.TransientModel):
 
     module_stock_request_mrp = fields.Boolean(string="Stock Request for Manufacturing")
 
+    stock_request_confirm_user_permission = fields.Selection(
+        related="company_id.stock_request_confirm_user_permission", readonly=False
+    )
+
     # Dependencies
     @api.onchange("stock_request_allow_virtual_loc")
     def _onchange_stock_request_allow_virtual_loc(self):

--- a/stock_request/models/stock_request_order.py
+++ b/stock_request/models/stock_request_order.py
@@ -132,6 +132,9 @@ class StockRequestOrder(models.Model):
     stock_request_count = fields.Integer(
         string="Stock requests", compute="_compute_stock_request_count", readonly=True
     )
+    stock_request_confirm_user_permission = fields.Selection(
+        related="company_id.stock_request_confirm_user_permission"
+    )
 
     _sql_constraints = [
         ("name_uniq", "unique(name, company_id)", "Stock Request name must be unique")

--- a/stock_request/models/stock_request_order.py
+++ b/stock_request/models/stock_request_order.py
@@ -223,6 +223,10 @@ class StockRequestOrder(models.Model):
                 line.procurement_group_id = self.procurement_group_id
 
     def action_confirm(self):
+        if not self.stock_request_ids:
+            raise UserError(
+                _("There should be at least one request item for confirming the order.")
+            )
         self.mapped("stock_request_ids").action_confirm()
         self.write({"state": "open"})
         return True

--- a/stock_request/views/res_config_settings_views.xml
+++ b/stock_request/views/res_config_settings_views.xml
@@ -60,6 +60,19 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-xs-12 col-md-6 o_setting_box">
+                            <div class="o_setting_left_pane" />
+                            <div class="o_setting_right_pane">
+                                <label
+                                    string="Confirm button type"
+                                    for="stock_request_confirm_user_permission"
+                                />
+                                <div class="text-muted">
+                                    Select users' permission to use Confirm button in Stock Request.
+                                </div>
+                                <field name="stock_request_confirm_user_permission" />
+                            </div>
+                        </div>
                     </div>
                     <h2>Purchases</h2>
                     <div

--- a/stock_request/views/stock_request_order_views.xml
+++ b/stock_request/views/stock_request_order_views.xml
@@ -22,7 +22,15 @@
                         name="action_confirm"
                         string="Confirm"
                         type="object"
-                        attrs="{'invisible': [('state', 'not in', ['draft'])]}"
+                        attrs="{'invisible': ['|', ('state', 'not in', ['draft']), ('stock_request_confirm_user_permission', '!=', 'user')]}"
+                        groups="stock_request.group_stock_request_user"
+                    />
+                    <button
+                        name="action_confirm"
+                        string="Confirm"
+                        type="object"
+                        attrs="{'invisible': ['|', ('state', 'not in', ['draft']), ('stock_request_confirm_user_permission', '!=', 'manager')]}"
+                        groups="stock_request.group_stock_request_manager"
                     />
                     <button
                         name="action_cancel"
@@ -36,6 +44,7 @@
                         type="object"
                         string="Set to Draft"
                     />
+                    <field name="stock_request_confirm_user_permission" invisible="1" />
                     <field name="state" widget="statusbar" />
                 </header>
                 <sheet>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/1511

Changes done:
- [x] Show error in `stock.request.order` in the "_Confirm_" or "_Submit_" buttons if there are no items.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT39761