### PR TITLE
[FIX] stock_request: add sudo to allow stock ops without stock request access

### DIFF
--- a/stock_request/models/stock_move.py
+++ b/stock_request/models/stock_move.py
@@ -74,5 +74,5 @@ class StockMove(models.Model):
 
     def _action_done(self, cancel_backorder=False):
         res = super()._action_done(cancel_backorder=cancel_backorder)
-        self.mapped("allocation_ids.stock_request_id").check_done()
+        self.mapped("allocation_ids.stock_request_id").sudo().check_done()
         return res


### PR DESCRIPTION
For the moment, if we confirm a stock operation without access to related stock request, we got an error.