### PR TITLE
[11.0][FIX] stock_move_location: _get_available_quantity has to return a tuple

### DIFF
--- a/stock_move_location/wizard/stock_move_location_line.py
+++ b/stock_move_location/wizard/stock_move_location_line.py
@@ -122,7 +122,7 @@ class StockMoveLocationWizardLine(models.TransientModel):
         more than exists."""
         self.ensure_one()
         if not self.product_id:
-            return 0
+            return 0, 0
         if self.env.context.get("planned"):
             # for planned transfer we don't care about the amounts at all
             return self.move_quantity, 0
@@ -139,10 +139,10 @@ class StockMoveLocationWizardLine(models.TransientModel):
         if not available_qty:
             # if it is immediate transfer and product doesn't exist in that
             # location -> make the transfer of 0.
-            return 0
+            return 0, 0
         rounding = self.product_uom_id.rounding
         available_qty_lt_move_qty = self._compare(
             available_qty, self.move_quantity, rounding) == -1
         if available_qty_lt_move_qty:
-            return available_qty
+            return 0, available_qty
         return 0, self.move_quantity


### PR DESCRIPTION
**Problem**
_get_available_quantity() returns non tuple in some cases

**How to reproduce**
1. Run Move To Location
2. Add Product, wich is not on stock
3. Click Confirm
4. Error "int is not iterable" occurs

Was already fixed in 13.0, but not in  11.0, 12.0, 14.0, 15.0