### PR TITLE
[14.0][IMP] stock_cycle_count: add auto start adjustment option

### DIFF
--- a/stock_cycle_count/__manifest__.py
+++ b/stock_cycle_count/__manifest__.py
@@ -21,6 +21,7 @@
         "views/stock_warehouse_view.xml",
         "views/stock_inventory_view.xml",
         "views/stock_location_view.xml",
+        "views/res_config_settings_view.xml",
         "data/cycle_count_sequence.xml",
         "data/cycle_count_ir_cron.xml",
         "reports/stock_location_accuracy_report.xml",

--- a/stock_cycle_count/models/__init__.py
+++ b/stock_cycle_count/models/__init__.py
@@ -4,3 +4,5 @@ from . import stock_location
 from . import stock_inventory
 from . import stock_warehouse
 from . import stock_move
+from . import res_company
+from . import res_config_settings

--- a/stock_cycle_count/models/res_company.py
+++ b/stock_cycle_count/models/res_company.py
@@ -1,0 +1,21 @@
+from odoo import fields, models
+
+
+class Company(models.Model):
+    _inherit = "res.company"
+
+    auto_start_inventory_from_cycle_count = fields.Boolean(
+        string="Auto Start Inventory Adjustment from Cycle Count",
+        help="If enabled, confirming a Cycle Count will "
+        "start the related Inventory Adjustment.",
+    )
+
+    inventory_adjustment_counted_quantities = fields.Selection(
+        selection=[
+            ("counted", "Default to stock on hand"),
+            ("zero", "Default to zero"),
+        ],
+        string="Inventory Adjustment Counted quantities from Cycle Count",
+        help="If enabled, confirming a Cycle Count will start the related "
+        "Inventory Adjustment.",
+    )

--- a/stock_cycle_count/models/res_config_settings.py
+++ b/stock_cycle_count/models/res_config_settings.py
@@ -1,0 +1,27 @@
+# Copyright 2019 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    auto_start_inventory_from_cycle_count = fields.Boolean(
+        related="company_id.auto_start_inventory_from_cycle_count",
+        string="Auto Start Inventory Adjustment from Cycle Count",
+        help="If enabled, confirming a Cycle Count will start the "
+        "related Inventory Adjustment.",
+        readonly=False,
+    )
+
+    inventory_adjustment_counted_quantities = fields.Selection(
+        related="company_id.inventory_adjustment_counted_quantities",
+        selection=[
+            ("counted", "Default to stock on hand"),
+            ("zero", "Default to zero"),
+        ],
+        string="Inventory Adjustment Counted quantities from Cycle Count",
+        help="If enabled, confirming a Cycle Count will start the related "
+        "Inventory Adjustment.",
+        readonly=False,
+    )

--- a/stock_cycle_count/models/stock_cycle_count.py
+++ b/stock_cycle_count/models/stock_cycle_count.py
@@ -94,7 +94,12 @@ class StockCycleCount(models.Model):
             raise UserError(_("You can only confirm cycle counts in state 'Planned'."))
         for rec in self:
             data = rec._prepare_inventory_adjustment()
-            self.env["stock.inventory"].create(data)
+            inv = self.env["stock.inventory"].create(data)
+            if self.company_id.auto_start_inventory_from_cycle_count:
+                inv.prefill_counted_quantity = (
+                    self.company_id.inventory_adjustment_counted_quantities
+                )
+                inv.action_start()
         self.write({"state": "open"})
         return True
 

--- a/stock_cycle_count/models/stock_inventory.py
+++ b/stock_cycle_count/models/stock_inventory.py
@@ -37,6 +37,14 @@ class StockInventory(models.Model):
         group_operator="avg",
     )
 
+    def _get_default_counted_quantitites(self):
+        company_id = self.env.context.get("default_company_id", self.env.company)
+        return company_id.inventory_adjustment_counted_quantities or "counted"
+
+    prefill_counted_quantity = fields.Selection(
+        default=_get_default_counted_quantitites
+    )
+
     def _update_cycle_state(self):
         for inv in self:
             if inv.cycle_count_id and inv.state == "done":

--- a/stock_cycle_count/views/res_config_settings_view.xml
+++ b/stock_cycle_count/views/res_config_settings_view.xml
@@ -1,0 +1,58 @@
+<odoo>
+    <record id="res_config_settings_view_form_cycle_adjustment" model="ir.ui.view">
+        <field
+            name="name"
+        >res.config.settings.view.form.inherit.cycle.adjustment</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div name="barcode_setting_container" position="after">
+                <h2>Cycle Count</h2>
+                <div
+                    class="row mt16 o_settings_container"
+                    name="cycle_count_setting_container"
+                >
+                    <div
+                        class="col-12 col-lg-6 o_setting_box"
+                        id="cycle_count_id"
+                        title="Cycle Count"
+                    >
+                        <div class="o_setting_left_pane">
+                            <field name="auto_start_inventory_from_cycle_count" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="auto_start_inventory_from_cycle_count" />
+                            <span
+                                class="fa fa-lg fa-building-o"
+                                title="Values set here are company-specific."
+                                aria-label="Values set here are company-specific."
+                                groups="base.group_multi_company"
+                                role="img"
+                            />
+                            <div class="text-muted">
+                                If enabled, confirming a Cycle Count will start the related Inventory Adjustment.
+                            </div>
+                        </div>
+                    </div>
+                    <div
+                        class="col-lg-6 col-lg-6 o_setting_box"
+                        id="default_counted_quantities"
+                    >
+                        <div class="o_setting_left_pane">
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label
+                                for="inventory_adjustment_counted_quantities"
+                                string="Default Counted Quantity Mode"
+                            />
+                            <field name="inventory_adjustment_counted_quantities" />
+                            <div class="text-muted">
+                                Sets default counted quanities in Inventory Adjustments
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When confirming a Cycle Count, the inventory adjustment automatically starts, and also can set the default counted quantity type (on hand or zero).

@ForgeFlow