### PR TITLE
[14.0][IMP] stock_quant_reservation_info_mrp: add link in form view

### DIFF
--- a/stock_quant_reservation_info_mrp/views/stock_move_line.xml
+++ b/stock_quant_reservation_info_mrp/views/stock_move_line.xml
@@ -1,6 +1,6 @@
 <odoo>
     <record id="view_stock_move_line_reserved_info_tree" model="ir.ui.view">
-        <field name="name">stock.move.line.tree.reserved.info</field>
+        <field name="name">stock.move.line.tree.reserved.info.mrp</field>
         <field name="model">stock.move.line</field>
         <field
             name="inherit_id"
@@ -18,6 +18,21 @@
                     attrs="{'invisible': [('production_id', '=', False)]}"
                 />
             </button>
+        </field>
+    </record>
+
+    <record id="view_stock_move_line_reserved_info_form" model="ir.ui.view">
+        <field name="name">stock.move.line.form.reserved.info.mrp</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_move_line_form" />
+        <field name="arch" type="xml">
+            <field name="origin" position="after">
+                <field
+                    name="production_id"
+                    string="Manufacturing Order"
+                    attrs="{'invisible': [('production_id', '=', False)]}"
+                />
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
It just adds a link to MO in stock.move form view, usually you can miss click on button in tree view so having the link here doesn't hurt anyone.


@ForgeFlow 