### PR TITLE
[14.0][IMP] stock_cycle_count: Add responsible_id to stock.inventory, linked with cycle count

### DIFF
--- a/stock_cycle_count/models/stock_cycle_count.py
+++ b/stock_cycle_count/models/stock_cycle_count.py
@@ -82,6 +82,7 @@ class StockCycleCount(models.Model):
             "cycle_count_id": self.id,
             "location_ids": [(4, self.location_id.id)],
             "exclude_sublocation": True,
+            "responsible_id": self.responsible_id.id,
         }
 
     @api.model

--- a/stock_cycle_count/models/stock_inventory.py
+++ b/stock_cycle_count/models/stock_inventory.py
@@ -36,6 +36,11 @@ class StockInventory(models.Model):
         store=True,
         group_operator="avg",
     )
+    responsible_id = fields.Many2one(
+        comodel_name="res.users",
+        tracking=True,
+        help="Specific responsible of Inventory Adjustment.",
+    )
 
     def _get_default_counted_quantitites(self):
         company_id = self.env.context.get("default_company_id", self.env.company)

--- a/stock_cycle_count/views/stock_inventory_view.xml
+++ b/stock_cycle_count/views/stock_inventory_view.xml
@@ -9,6 +9,7 @@
         <field name="arch" type="xml">
             <field name="date" position="after">
                 <field name="location_ids" />
+                <field name="responsible_id" widget="many2one_avatar_employee" />
                 <field name="cycle_count_id" />
                 <field name="inventory_accuracy" />
             </field>
@@ -21,6 +22,7 @@
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <field name="cycle_count_id" />
+                <field name="responsible_id" />
                 <label for="inventory_accuracy" />
                 <div>
                     <field name="inventory_accuracy" class="oe_inline" /> %
@@ -35,6 +37,12 @@
         <field name="arch" type="xml">
             <field name="product_ids" position="after">
                 <field name="location_ids" />
+                <field name="responsible_id" />
+                <filter
+                    string="My Adjustments"
+                    name="my_adjustments"
+                    domain="[('responsible_id', '=', uid)]"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This module adds responsible in stock.inventory and inherits from stock.cycle.count. Not added the field in stock.inventory because it disappears in 15.0.


@ForgeFlow