### PR TITLE
[14.0][ADD] product_route_profile_internal_resupply

### DIFF
--- a/product_route_profile_internal_resupply/__init__.py
+++ b/product_route_profile_internal_resupply/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_route_profile_internal_resupply/__manifest__.py
+++ b/product_route_profile_internal_resupply/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Product Route Profile Internal Resupply",
+    "summary": "SUMMARY",
+    "version": "14.0.1.0.0",
+    "category": "Warehouse",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["Kev-Roche"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "product_route_profile",
+    ],
+    "data": [
+        "views/product_template.xml",
+    ],
+}

--- a/product_route_profile_internal_resupply/i18n/fr.po
+++ b/product_route_profile_internal_resupply/i18n/fr.po
@@ -1,0 +1,78 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* product_route_profile_internal_resupply
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-11-11 13:17+0000\n"
+"PO-Revision-Date: 2022-11-11 14:18+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 3.2.1\n"
+
+#. module: product_route_profile_internal_resupply
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_product_template__display_name
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_route_profile__display_name
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_stock_location_route__display_name
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_stock_warehouse__display_name
+msgid "Display Name"
+msgstr "Nom"
+
+#. module: product_route_profile_internal_resupply
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_product_template__id
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_route_profile__id
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_stock_location_route__id
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_stock_warehouse__id
+msgid "ID"
+msgstr ""
+
+#. module: product_route_profile_internal_resupply
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_stock_location_route__internal_supply
+msgid "Internal Supply"
+msgstr "Réapprovisionnement Interne"
+
+#. module: product_route_profile_internal_resupply
+#: model:ir.model,name:product_route_profile_internal_resupply.model_stock_location_route
+msgid "Inventory Routes"
+msgstr "Routes logistiques"
+
+#. module: product_route_profile_internal_resupply
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_product_template____last_update
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_route_profile____last_update
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_stock_location_route____last_update
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_stock_warehouse____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: product_route_profile_internal_resupply
+#: model:ir.model,name:product_route_profile_internal_resupply.model_product_template
+msgid "Product Template"
+msgstr "Modèle de produit"
+
+#. module: product_route_profile_internal_resupply
+#: model:ir.model,name:product_route_profile_internal_resupply.model_route_profile
+msgid "Route Profile"
+msgstr "Profil de routes"
+
+#. module: product_route_profile_internal_resupply
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_route_profile__route_ids
+msgid "Routes"
+msgstr "Routes"
+
+#. module: product_route_profile_internal_resupply
+#: model:ir.model,name:product_route_profile_internal_resupply.model_stock_warehouse
+msgid "Warehouse"
+msgstr "Entrepôt"
+
+#. module: product_route_profile_internal_resupply
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_product_product__internal_supply_ids
+#: model:ir.model.fields,field_description:product_route_profile_internal_resupply.field_product_template__internal_supply_ids
+msgid "internal Supplies"
+msgstr "Réappro. Internes"

--- a/product_route_profile_internal_resupply/models/__init__.py
+++ b/product_route_profile_internal_resupply/models/__init__.py
@@ -1,0 +1,4 @@
+from . import product_template
+from . import stock_location_route
+from . import stock_warehouse
+from . import route_profile

--- a/product_route_profile_internal_resupply/models/product_template.py
+++ b/product_route_profile_internal_resupply/models/product_template.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2022 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    internal_supply_ids = fields.Many2many(
+        comodel_name="stock.location.route",
+        string="internal Supplies",
+        domain=[
+            ("internal_supply", "=", True),
+        ],
+    )
+
+    @api.depends("internal_supply_ids")
+    def _compute_route_ids(self):
+        super()._compute_route_ids()
+
+    def _get_routes(self):
+        return super()._get_routes() | self.internal_supply_ids
+
+    def _get_or_create_profile(self, profiles, routes):
+        routes -= self.internal_supply_ids
+        return super()._get_or_create_profile(profiles, routes)
+
+    def _search_route_ids(self, operator, value):
+        res = super()._search_route_ids(operator, value)
+        res.insert(1, '"|", ("internal_supply_ids", operator, value),')
+        return res

--- a/product_route_profile_internal_resupply/models/route_profile.py
+++ b/product_route_profile_internal_resupply/models/route_profile.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class RouteProfile(models.Model):
+    _inherit = "route.profile"
+
+    route_ids = fields.Many2many(
+        "stock.location.route",
+        string="Routes",
+        domain=[("product_selectable", "=", True), ("internal_supply", "=", False)],
+    )

--- a/product_route_profile_internal_resupply/models/stock_location_route.py
+++ b/product_route_profile_internal_resupply/models/stock_location_route.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2022 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockLocationRoute(models.Model):
+    _inherit = "stock.location.route"
+
+    internal_supply = fields.Boolean(
+        string="Internal Supply",
+        readonly=True,
+    )

--- a/product_route_profile_internal_resupply/models/stock_warehouse.py
+++ b/product_route_profile_internal_resupply/models/stock_warehouse.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockWarehouse(models.Model):
+    _inherit = "stock.warehouse"
+
+    def _get_inter_warehouse_route_values(self, supplier_warehouse):
+        res = super()._get_inter_warehouse_route_values(supplier_warehouse)
+        res["internal_supply"] = True
+        return res

--- a/product_route_profile_internal_resupply/readme/CONTRIBUTORS.rst
+++ b/product_route_profile_internal_resupply/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Kévin Roche <kevin.roche@akretion.com>

--- a/product_route_profile_internal_resupply/readme/DESCRIPTION.rst
+++ b/product_route_profile_internal_resupply/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module allows to add Internal Supplies Routes separately to other routes in route_profile.

--- a/product_route_profile_internal_resupply/readme/USAGE.rst
+++ b/product_route_profile_internal_resupply/readme/USAGE.rst
@@ -1,0 +1,1 @@
+On a warehouse, set another warehouse in "Ressuply From" and select the relative route in "Internal Supplies" on product template.

--- a/product_route_profile_internal_resupply/tests/__init__.py
+++ b/product_route_profile_internal_resupply/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_route_profile_internal_resupply

--- a/product_route_profile_internal_resupply/tests/test_product_route_profile_internal_resupply.py
+++ b/product_route_profile_internal_resupply/tests/test_product_route_profile_internal_resupply.py
@@ -1,0 +1,40 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestProductRouteProfileInternalResupply(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestProductRouteProfileInternalResupply, cls).setUpClass()
+
+        cls.company = cls.env.ref("base.main_company")
+        cls.env["res.config.settings"].write(
+            {
+                "group_stock_adv_location": True,
+                "group_stock_multi_locations": True,
+            }
+        )
+        cls.wh = cls.env.ref("stock.warehouse0")
+        cls.wh_2 = cls.env["stock.warehouse"].create({"name": "WH2", "code": "WH2"})
+        cls.wh.resupply_wh_ids = cls.wh_2
+
+        cls.product = cls.env["product.template"].create(
+            {
+                "name": "Template 1",
+                "company_id": False,
+            }
+        )
+
+    def test_1_int_supply_route(self):
+        self.wh.resupply_wh_ids = self.wh_2
+        int_supply_route = self.env["stock.location.route"].search(
+            [("internal_supply", "=", True)]
+        )
+        self.assertTrue(int_supply_route)
+        self.product.internal_supply_ids = int_supply_route
+        self.assertIn(int_supply_route, self.product.route_ids)
+        self.product.internal_supply_ids = False
+        self.assertNotIn(int_supply_route, self.product.route_ids)

--- a/product_route_profile_internal_resupply/views/product_template.xml
+++ b/product_route_profile_internal_resupply/views/product_template.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright (C) 2022 Akretion (<http://www.akretion.com>).
+ @author Kévin Roche <kevin.roche@akretion.com>
+ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_template_route_profile_internal_form" model="ir.ui.view">
+        <field name="name">product.template.route.profile.internal.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='route_profile_id']" position="before">
+                <field
+                    name="internal_supply_ids"
+                    widget="many2many_tags"
+                    options="{'no_create': True}"
+                    colspan="4"
+                    attrs="{'invisible': [('type', 'in', ['service', 'digital'])]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/product_route_profile_internal_resupply/odoo/addons/product_route_profile_internal_resupply
+++ b/setup/product_route_profile_internal_resupply/odoo/addons/product_route_profile_internal_resupply
@@ -1,0 +1,1 @@
+../../../../product_route_profile_internal_resupply

--- a/setup/product_route_profile_internal_resupply/setup.py
+++ b/setup/product_route_profile_internal_resupply/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to add Internal Supplies Routes separately to other routes in route_profile.
depends of refactor here : https://github.com/OCA/stock-logistics-warehouse/pull/1547