### PR TITLE
[14.0][IMP] stock_quant_manual_assign: reserved field as readonly

### DIFF
--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -176,7 +176,9 @@ class AssignManualQuantsLines(models.TransientModel):
         string="On Hand",
         digits="Product Unit of Measure",
     )
-    reserved = fields.Float(string="Others Reserved", digits="Product Unit of Measure")
+    reserved = fields.Float(
+        string="Others Reserved", digits="Product Unit of Measure", readonly=True
+    )
     selected = fields.Boolean(string="Select")
     qty = fields.Float(string="QTY", digits="Product Unit of Measure")
 


### PR DESCRIPTION
This field shouldn't be editable since it doesn't change anything when editing it in the wizard and it's confusing 