### PR TITLE
[14.0][FIX]stock_available_mrp don't use correct bom for computing potential qty

### DIFF
--- a/stock_available_mrp/models/product_product.py
+++ b/stock_available_mrp/models/product_product.py
@@ -11,21 +11,22 @@ from odoo.tools import float_round
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
-    def _compute_appropriate_bom_ids(self):
-        for prod in self:
-            variant_bom_ids = prod.variant_bom_ids
-            template_bom_ids = prod.bom_ids.filtered(lambda b: b.product_id is False)
-            appropriate_bom_ids = variant_bom_ids | template_bom_ids
-            prod.appropriate_bom_ids = appropriate_bom_ids
-
     appropriate_bom_ids = fields.One2many(
         comodel_name="mrp.bom", compute="_compute_appropriate_bom_ids"
     )
+
+    def _compute_appropriate_bom_ids(self):
+        for prod in self:
+            variant_bom_ids = prod.variant_bom_ids
+            template_bom_ids = prod.bom_ids.filtered(lambda b: not b.product_id)
+            appropriate_bom_ids = variant_bom_ids | template_bom_ids
+            prod.appropriate_bom_ids = appropriate_bom_ids
 
     @api.depends(
         "virtual_available",
         "bom_ids",
         "bom_ids.product_qty",
+        "appropriate_bom_ids",
     )
     def _compute_available_quantities(self):
         super()._compute_available_quantities()

--- a/stock_available_mrp/models/product_product.py
+++ b/stock_available_mrp/models/product_product.py
@@ -3,27 +3,30 @@
 
 from collections import Counter
 
-from odoo import api, models, fields
+from odoo import api, fields, models
 from odoo.fields import first
 from odoo.tools import float_round
 
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
-    
+
     def _compute_appropriate_bom_ids(self):
         for prod in self:
             variant_bom_ids = prod.variant_bom_ids
-            template_bom_ids = prod.bom_ids.filtered(lambda b: b.product_id == False)
-            appropriate_bom_ids = variant_bom_ids|template_bom_ids
+            template_bom_ids = prod.bom_ids.filtered(lambda b: b.product_id is False)
+            appropriate_bom_ids = variant_bom_ids | template_bom_ids
             prod.appropriate_bom_ids = appropriate_bom_ids
-    
+
     appropriate_bom_ids = fields.One2many(
-        comodel_name="mrp.bom",
-        compute="_compute_appropriate_bom_ids"
+        comodel_name="mrp.bom", compute="_compute_appropriate_bom_ids"
     )
 
-    @api.depends("virtual_available", "bom_ids", "bom_ids.product_qty", )
+    @api.depends(
+        "virtual_available",
+        "bom_ids",
+        "bom_ids.product_qty",
+    )
     def _compute_available_quantities(self):
         super()._compute_available_quantities()
 

--- a/stock_available_mrp/readme/CONTRIBUTORS.rst
+++ b/stock_available_mrp/readme/CONTRIBUTORS.rst
@@ -9,3 +9,5 @@
 
   * Víctor Martínez
   * David Vidal
+
+* Florent THOMAS <florent.thomas@mind-and-go.com>

--- a/stock_available_mrp/readme/DESCRIPTION.rst
+++ b/stock_available_mrp/readme/DESCRIPTION.rst
@@ -4,3 +4,5 @@ quantity that can be manufactured with the components immediately at hand.
 By configuration, the "Potential quantity" can be computed based on other product field.
 For example, "Potential quantity" can be the quantity that can be manufactured
 with the components available to promise.
+The potential is based on bom associated to variant first.
+If no `appropriate_bom_ids` is found, `bom_ids` with no variant is used.  

--- a/stock_available_mrp/readme/DESCRIPTION.rst
+++ b/stock_available_mrp/readme/DESCRIPTION.rst
@@ -5,4 +5,4 @@ By configuration, the "Potential quantity" can be computed based on other produc
 For example, "Potential quantity" can be the quantity that can be manufactured
 with the components available to promise.
 The potential is based on bom associated to variant first.
-If no `appropriate_bom_ids` is found, `bom_ids` with no variant is used.  
+If no `appropriate_bom_ids` is found, `bom_ids` with no variant is used.


### PR DESCRIPTION
When working with different BOMs for multiple variant , the field bom_ids is referencing all the bom associated to the product template. The variant_bom_ids field is no more relevant as it's incomplete. It's not considering that bom without variant could apply on a variant.
So all the references to bom_ids in this mocule could refrence bad Bom depending of the setup.
This PR try to correct this behaviour by introducing a field referencing appropriate boms only regarding the variant and the absence of variant.