### PR TITLE
[12][FIX] stock_quant_manual_assign multi-uom bug

### DIFF
--- a/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
@@ -15,6 +15,7 @@
                         <field name="reserved"/>
                         <field name="selected"/>
                         <field name="qty" attrs="{'readonly':[('selected', '=', False)]}" sum="qty"/>
+                        <field name="uom_id" groups="uom.group_uom"/>
                     </tree>
                 </field>
                 <group col='4' colspan="4">


### PR DESCRIPTION
Fix multi-uom bug : there is a confusion on the fields of stock.move.line between product_uom_qty which is in the uom of the stock.move.line (which may be different from product uom) and product_qty which is in the uom of the product. Fixes bug #1527 

Improve usability by adding an uom_id field in the wizard, to show the uom of the qty fields displayed on the lines of the wizard