### PR TITLE
[14.0][FIX] Stock Move Location: apply putaway rules

### DIFF
--- a/stock_move_location/tests/test_common.py
+++ b/stock_move_location/tests/test_common.py
@@ -120,10 +120,21 @@ class TestsCommon(common.SavepointCase):
     def set_product_amount(
         self, product, location, amount, lot_id=None, package_id=None, owner_id=None
     ):
+        """Set available stock Quantity to 'amount'"""
+        current_qty = self.env["stock.quant"]._get_available_quantity(
+            product,
+            location,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+        )
+        # Since _update_available_quantity decreases or increases,
+        # we need to first get the current amount.
+        change_amount = amount - current_qty
         self.env["stock.quant"]._update_available_quantity(
             product,
             location,
-            amount,
+            change_amount,
             lot_id=lot_id,
             package_id=package_id,
             owner_id=owner_id,

--- a/stock_move_location/tests/test_move_location.py
+++ b/stock_move_location/tests/test_move_location.py
@@ -156,6 +156,14 @@ class TestMoveLocation(TestsCommon):
             putaway_line.destination_location_id, self.internal_loc_2_shelf
         )
 
+        # Actually commit the wizard and check stock.move.line.location_dest_id
+        ret = wizard.action_move_location()
+        picking = self.env["stock.picking"].browse([ret["res_id"]])
+        putaway_move_line = picking.move_line_ids.filtered(
+            lambda l: l.product_id == self.product_no_lots
+        )[0]
+        self.assertEqual(putaway_move_line.location_dest_id, self.internal_loc_2_shelf)
+
     def test_delivery_order_assignation_after_transfer(self):
         """
         Make sure using the wizard doesn't break assignation on delivery orders

--- a/stock_move_location/tests/test_move_location.py
+++ b/stock_move_location/tests/test_move_location.py
@@ -237,3 +237,24 @@ class TestMoveLocation(TestsCommon):
         self.assertEqual(len(delivery_move.move_line_ids), 1)
         self.assertEqual(delivery_move.move_line_ids.product_uom_qty, 20.0)
         self.assertEqual(delivery_move.move_line_ids.location_id, wh_stock_shelf_3)
+
+    def test_wizard_available_quantity_exeptions(self):
+        """
+        Make sure _get_available_quantity returns 0,0 on stock exceptions.
+        """
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        wizard.onchange_origin_location()
+        first_line = wizard.stock_move_location_line_ids[0]
+
+        # Check Product with no stock
+        self.set_product_amount(
+            product=first_line.product_id,
+            location=first_line.origin_location_id,
+            amount=0,
+        )
+        self.assertEqual(first_line._get_available_quantity(), (0, 0))
+
+        # Check Line without product
+        second_line = wizard.stock_move_location_line_ids[1]
+        second_line.product_id = False
+        self.assertEqual(second_line._get_available_quantity(), (0, 0))

--- a/stock_move_location/wizard/stock_move_location_line.py
+++ b/stock_move_location/wizard/stock_move_location_line.py
@@ -129,7 +129,7 @@ class StockMoveLocationWizardLine(models.TransientModel):
         more than exists."""
         self.ensure_one()
         if not self.product_id:
-            return 0
+            return 0, 0
         if self.env.context.get("planned"):
             # for planned transfer we don't care about the amounts at all
             return self.move_quantity, 0
@@ -154,7 +154,7 @@ class StockMoveLocationWizardLine(models.TransientModel):
         if not available_qty:
             # if it is immediate transfer and product doesn't exist in that
             # location -> make the transfer of 0.
-            return 0
+            return 0, 0
         rounding = self.product_uom_id.rounding
         available_qty_lt_move_qty = (
             self._compare(available_qty, self.move_quantity, rounding) == -1

--- a/stock_move_location/wizard/stock_move_location_line.py
+++ b/stock_move_location/wizard/stock_move_location_line.py
@@ -103,7 +103,7 @@ class StockMoveLocationWizardLine(models.TransientModel):
         self.ensure_one()
         location_dest_id = (
             self.move_location_wizard_id.apply_putaway_strategy
-            and self.destination_location_id.get_putaway_strategy(self.product_id).id
+            and self.destination_location_id._get_putaway_strategy(self.product_id).id
             or self.destination_location_id.id
         )
         qty_todo, qty_done = self._get_available_quantity()


### PR DESCRIPTION
The function called to get the putaway rule when creating the stock.move.lines does not exist in odoo 14.0.
https://github.com/OCA/stock-logistics-warehouse/blob/5830833b99df972329e173633dbec27ca002e05f/stock_move_location/wizard/stock_move_location_line.py#L106

- `get_putaway_strategy` should actuall be [_get_putaway_strategy](https://github.com/odoo/odoo//blob/076baeacbbdf92ae1b500e6716fd95d32acc4a53/addons/stock/models/stock_location.py#L135)
- Extend test to actually commit the wizard and check the resulting move.lines

P.s. This is my first PR to the OCA, so please let me know if I missed something. 