### PR TITLE
[14.0][FIX] stock_cycle_count: remove widget

### DIFF
--- a/stock_cycle_count/views/stock_inventory_view.xml
+++ b/stock_cycle_count/views/stock_inventory_view.xml
@@ -9,7 +9,7 @@
         <field name="arch" type="xml">
             <field name="date" position="after">
                 <field name="location_ids" />
-                <field name="responsible_id" widget="many2one_avatar_employee" />
+                <field name="responsible_id" />
                 <field name="cycle_count_id" />
                 <field name="inventory_accuracy" />
             </field>


### PR DESCRIPTION
Otherwise we face a blocking error message when accessing to the inventory adjustments app:

![image](https://user-images.githubusercontent.com/7683926/207117879-567270dd-694c-4730-911e-92bf9a85fd2e.png)
