### PR TITLE
[14.0][FIX] stock_available: dict.record.type is undefined

### DIFF
--- a/stock_available/views/product_template_view.xml
+++ b/stock_available/views/product_template_view.xml
@@ -83,7 +83,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='product_lst_price']" position="after">
                 <div
-                    t-if="record.type.raw_value == 'product'"
+                    t-if="record.show_on_hand_qty_status_button.raw_value"
                 >Available to Promise: <field name="immediately_usable_qty" /> <field
                         name="uom_id"
                     /></div>


### PR DESCRIPTION
Ever since [this](https://github.com/odoo/odoo/commit/322a89e16fe41e64b8d944327b15587105a323f9) was merged on base, the field `type` stopped being available in the view.

~~Here I add it back to avoid getting an error when display kanban view for `product.template`.~~
Here I change it to use the new `show_on_hand_qty_status_button` field.