### PR TITLE
[16.0][FIX] stock_move_location

### DIFF
--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -47,11 +47,10 @@ class StockMoveLocationWizard(models.TransientModel):
         required=True,
         domain=lambda self: self._get_locations_domain(),
     )
-    stock_move_location_line_ids = fields.Many2many(
+    stock_move_location_line_ids = fields.One2many(
+        "wiz.stock.move.location.line",
+        "move_location_wizard_id",
         string="Move Location lines",
-        comodel_name="wiz.stock.move.location.line",
-        column1="move_location_wiz_id",
-        column2="move_location_line_wiz_id",
     )
     picking_type_id = fields.Many2one(
         comodel_name="stock.picking.type", default=_get_default_picking_type_id

--- a/stock_move_location/wizard/stock_move_location.xml
+++ b/stock_move_location/wizard/stock_move_location.xml
@@ -41,7 +41,6 @@
                         <field
                             name="stock_move_location_line_ids"
                             nolabel="1"
-                            widget="one2many_list"
                             mode="tree,kanban"
                             colspan="2"
                         >

--- a/stock_move_location/wizard/stock_move_location_line.py
+++ b/stock_move_location/wizard/stock_move_location_line.py
@@ -11,12 +11,9 @@ class StockMoveLocationWizardLine(models.TransientModel):
     _name = "wiz.stock.move.location.line"
     _description = "Wizard move location line"
 
-    move_location_wizard_id = fields.Many2many(
+    move_location_wizard_id = fields.Many2one(
         string="Move location Wizard",
         comodel_name="wiz.stock.move.location",
-        column1="move_location_line_wiz_id",
-        column2="move_location_wiz_id",
-        readonly=True,
     )
     product_id = fields.Many2one(
         string="Product", comodel_name="product.product", required=True


### PR DESCRIPTION
Use One2many instead of Many2many for popup of move location.

Before this commit, we got issues when we move location from inventory adjust and press enter button. And, even we add create="0" in tree tag of many2many field there is unnecessary popup when we move location from Inventory > Operations > Move from location... and press enter in the last record of many2many tree view.

Using many2many field with one2many_list widget can cause unnecessary things and I think there is no reason we must use many2many field.
Related issues - https://github.com/OCA/stock-logistics-warehouse/issues/1578 