### PR TITLE
[13.0][stock_fifo_update_kit_cost][new]

### DIFF
--- a/setup/stock_fifo_update_kit_cost/odoo/addons/stock_fifo_update_kit_cost
+++ b/setup/stock_fifo_update_kit_cost/odoo/addons/stock_fifo_update_kit_cost
@@ -1,0 +1,1 @@
+../../../../stock_fifo_update_kit_cost

--- a/setup/stock_fifo_update_kit_cost/setup.py
+++ b/setup/stock_fifo_update_kit_cost/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_fifo_update_kit_cost/__init__.py
+++ b/stock_fifo_update_kit_cost/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_fifo_update_kit_cost/__manifest__.py
+++ b/stock_fifo_update_kit_cost/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Camptocamp SA
+# Copyright 2016-19 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Stock Fifo Update Kit Cost",
+    "summary": "Automatically update the cost of a kit when the components "
+    "are shipped",
+    "version": "13.0.1.0.1",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "development_status": "Beta",
+    "maintainers": ["JordiBForgeFlow"],
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "category": "Warehouse Management",
+    "depends": ["stock_account"],
+    "license": "LGPL-3",
+}

--- a/stock_fifo_update_kit_cost/models/__init__.py
+++ b/stock_fifo_update_kit_cost/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product

--- a/stock_fifo_update_kit_cost/models/product.py
+++ b/stock_fifo_update_kit_cost/models/product.py
@@ -1,0 +1,30 @@
+# Copyright 20121 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import models
+
+
+class Product(models.Model):
+    _inherit = "product.product"
+
+    def _run_fifo(self, quantity, company):
+        vals = super(Product, self)._run_fifo(quantity, company)
+        phantom_boms = (
+            self.env["mrp.bom.line"]
+            .search(
+                [
+                    ("product_id", "in", self.ids),
+                    ("bom_id.type", "=", "phantom"),
+                    "|",
+                    ("company_id", "=", company.id),
+                    ("company_id", "=", False),
+                ]
+            )
+            .mapped("bom_id")
+        )
+        products = phantom_boms.mapped("product_id")
+        products |= phantom_boms.mapped("product_tmpl_id.product_variant_ids")
+        for product in products:
+            cost = product._get_price_from_bom(phantom_boms)
+            product.sudo().with_context(force_company=company.id).standard_price = cost
+        return vals

--- a/stock_fifo_update_kit_cost/models/product.py
+++ b/stock_fifo_update_kit_cost/models/product.py
@@ -25,6 +25,10 @@ class Product(models.Model):
         products = phantom_boms.mapped("product_id")
         products |= phantom_boms.mapped("product_tmpl_id.product_variant_ids")
         for product in products:
-            cost = product._get_price_from_bom(phantom_boms)
-            product.sudo().with_context(force_company=company.id).standard_price = cost
+            ph_boms = phantom_boms.filtered(
+                lambda b: b.product_id == product) or phantom_boms.filtered(
+                lambda b: b.product_tmpl_id == product.product_tmpl_id)
+            if ph_boms:
+                cost = product._compute_bom_price(ph_boms[0], boms_to_recompute=[])
+                product.sudo().with_context(force_company=company.id).standard_price = cost
         return vals

--- a/stock_fifo_update_kit_cost/readme/CONTRIBUTORS.rst
+++ b/stock_fifo_update_kit_cost/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Jordi Ballester Alomar <jordi.ballester@forgeflow.com>

--- a/stock_fifo_update_kit_cost/readme/DESCRIPTION.rst
+++ b/stock_fifo_update_kit_cost/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module allows the cost of a product that is sold as a kit to be updated
+automatically when the components are delivered.

--- a/stock_fifo_update_kit_cost/tests/__init__.py
+++ b/stock_fifo_update_kit_cost/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_stock_fifo_update_cost

--- a/stock_fifo_update_kit_cost/tests/test_stock_fifo_update_cost.py
+++ b/stock_fifo_update_kit_cost/tests/test_stock_fifo_update_cost.py
@@ -1,0 +1,206 @@
+# Copyright 2017-2020 ForgeFlow S.L.
+#   (http://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+
+class Test_stock_fifo_update_cost(TransactionCase):
+    def setUp(self, *args, **kwargs):
+        super(Test_stock_fifo_update_cost, self).setUp(*args, **kwargs)
+
+        self.obj_product = self.env["product.product"]
+        self.product_ctg_model = self.env["product.category"]
+        self.bom_model = self.env["mrp.bom"]
+        self.bom_line_model = self.env["mrp.bom.line"]
+        self.pick_order = self.env["stock.picking"]
+        self.company_partner = self.env.ref("base.main_partner")
+        self.customer_location = self.env["ir.model.data"].xmlid_to_object(
+            "stock.stock_location_customers"
+        )
+
+        self.picking_type_out = self.env["ir.model.data"].xmlid_to_object(
+            "stock.picking_type_out"
+        )
+        self.stock_location = self.env["ir.model.data"].xmlid_to_object(
+            "stock.stock_location_stock"
+        )
+
+        product_ctg = self.product_ctg_model.create(
+            {
+                "name": "test_product_ctg",
+                "property_valuation": "manual_periodic",
+                "property_cost_method": "fifo",
+            }
+        )
+
+        self.product1 = self.obj_product.create(
+            {
+                "name": "Test Product 1",
+                "type": "product",
+                "standard_price": 500.0 ,
+                "list_price" : 600.0,
+                "categ_id": product_ctg.id,
+            }
+        )
+        self.product2 = self.obj_product.create(
+            {
+                "name": "Test Product 2",
+                "type": "product",
+                "standard_price": 1000.0,
+                "list_price": 1300.0,
+                "categ_id": product_ctg.id,
+            }
+        )
+
+        self.kitproduct = self.obj_product.create(
+            {
+                "name": "Test kit",
+                "type": "product",
+                "standard_price": 0.0,
+                "list_price": 2000.0,
+                "categ_id": product_ctg.id,
+            }
+        )
+
+        self.manufacturedProduct = self.obj_product.create(
+            {
+                "name": "Test mtp",
+                "type": "product",
+                "standard_price": 0.0,
+                "list_price": 2000.0,
+                "categ_id": product_ctg.id,
+            }
+        )
+        self.bom_manufacturedProduct_1 = self.bom_model.create(
+            {
+                "product_tmpl_id": self.manufacturedProduct.product_tmpl_id.id,
+                "type": "normal",
+                "product_qty": 1,
+            }
+        )
+        self.bom_line_model.create(
+            {
+                "bom_id": self.bom_manufacturedProduct_1.id,
+                "product_id": self.product1.id,
+                "product_qty": 1,
+            }
+        )
+        self.bom_line_model.create(
+            {
+                "bom_id": self.bom_manufacturedProduct_1.id,
+                "product_id": self.product2.id,
+                "product_qty": 1,
+            }
+        )
+
+        self.bom_kitproduct_1 = self.bom_model.create(
+            {
+                "product_tmpl_id": self.kitproduct.product_tmpl_id.id,
+                "type": "phantom",
+                "product_qty": 1,
+            }
+        )
+        self.bom_line_model.create(
+            {
+                "bom_id": self.bom_kitproduct_1.id,
+                "product_id": self.product1.id,
+                "product_qty": 1,
+            }
+        )
+
+        self.bom_line_model.create(
+            {
+                "bom_id": self.bom_kitproduct_1.id,
+                "product_id": self.product2.id,
+                "product_qty": 1,
+            }
+        )
+        self.env["stock.quant"].create(
+            {
+                "product_id": self.product1.id,
+                "location_id": self.env.ref("stock.stock_location_stock").id,
+                "quantity": 6.0,
+            }
+        )
+        self.env["stock.quant"].create(
+            {
+                "product_id": self.product2.id,
+                "location_id": self.env.ref("stock.stock_location_stock").id,
+                "quantity": 6.0,
+            }
+        )
+
+
+    def test_calculate_standard_price_phbom(self):
+
+        self.delivery = self.pick_order.create(
+            {
+                "picking_type_id": self.picking_type_out.id,
+                "partner_id": self.company_partner.id,
+                "location_dest_id": self.customer_location.id,
+                "location_id": self.stock_location.id,
+
+                "move_lines": [
+
+                    (
+                        0,
+                        0,
+                        {
+                            "name": 'move',
+                            "company_id": 1,
+                            "product_uom_qty": 1.0,
+                            "product_uom": self.kitproduct.uom_id.id,
+                            "product_id": self.kitproduct.id,
+                            "location_dest_id": self.customer_location.id,
+                            "location_id": self.stock_location.id,
+                        }
+                    )
+                ],
+            }
+
+        )
+
+        self.delivery.action_confirm()
+        self.delivery.action_assign()
+        self.delivery.move_line_ids.write({'qty_done': 1})
+        self.delivery.button_validate()
+        self.assertEqual(self.delivery.state, "done")
+        self.assertEqual(self.kitproduct.standard_price, self.product1.standard_price +
+                         self.product2.standard_price)
+
+    def test_calculate_standard_price_manufacturedbom(self):
+        self.delivery = self.pick_order.create(
+            {
+                "picking_type_id": self.picking_type_out.id,
+                "partner_id": self.company_partner.id,
+                "location_dest_id": self.customer_location.id,
+                "location_id": self.stock_location.id,
+
+                "move_lines": [
+
+                    (
+                        0,
+                        0,
+                        {
+                            "name": 'move',
+                            "company_id": 1,
+                            "product_uom_qty": 1.0,
+                            "product_uom": self.manufacturedProduct.uom_id.id,
+                            "product_id": self.manufacturedProduct.id,
+                            "location_dest_id": self.customer_location.id,
+                            "location_id": self.stock_location.id,
+                        }
+                    )
+                ],
+            }
+
+        )
+
+        self.delivery.action_confirm()
+        self.delivery.action_assign()
+        self.delivery.move_lines.quantity_done = 1.0
+        self.delivery.button_validate()
+        self.assertEqual(self.delivery.state, "done")
+        self.assertEqual(self.manufacturedProduct.standard_price, 0)


### PR DESCRIPTION
Supersedes https://github.com/OCA/stock-logistics-warehouse/pull/1273
```
This module allows the cost of a product that is sold as a kit to be updated automatically when the components are delivered.

https://github.com/ForgeFlow
```