### PR TITLE
[14.0][FIX] stock_move_location: wrong destination location

### DIFF
--- a/stock_move_location/tests/test_move_location.py
+++ b/stock_move_location/tests/test_move_location.py
@@ -258,3 +258,17 @@ class TestMoveLocation(TestsCommon):
         second_line = wizard.stock_move_location_line_ids[1]
         second_line.product_id = False
         self.assertEqual(second_line._get_available_quantity(), (0, 0))
+
+    def test_wizard_different_destinations(self):
+        """
+        Create a picking whose line destinations are differents. The first line is sent
+        to the origin location.
+        """
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        wizard.onchange_origin_location()
+        wizard.stock_move_location_line_ids[0].write(
+            {"destination_location_id": self.internal_loc_1.id}
+        )
+        wizard.action_move_location()
+        locations = self.internal_loc_1 + self.internal_loc_2
+        self.assertEqual(wizard.picking_id.move_line_ids.location_dest_id, locations)

--- a/stock_move_location/wizard/stock_move_location.xml
+++ b/stock_move_location/wizard/stock_move_location.xml
@@ -64,11 +64,7 @@
                                     readonly="1"
                                     force_save="1"
                                 />
-                                <field
-                                    name="destination_location_id"
-                                    readonly="1"
-                                    force_save="1"
-                                />
+                                <field name="destination_location_id" />
                                 <field
                                     name="lot_id"
                                     domain="[('product_id', '=', product_id)]"


### PR DESCRIPTION
When you change `Destination Location`, lines are visually updated but actually behind the field remains the same, so the stock move lines are wrong created. If we force recreate lines it works

For reproducing it: 

1. Go to Inventory > Operations > Move from location... 
2.  Change the `Destination location` to any other. 
3. Press `Inmediate transfer`.
4.  Check that the stock move lines generated in the picking are wrong because location destination isn't the one we chosed.


Function `get_putaway_strategy` is now called `_get_putaway_strategy`.