### PR TITLE
[14.0][FIX] stock_available: field must be present in view before being able to access raw_value

### DIFF
--- a/stock_available/__manifest__.py
+++ b/stock_available/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Stock available to promise",
-    "version": "14.0.1.1.0",
+    "version": "14.0.1.1.1",
     "author": "Numérigraphe, Sodexis, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "development_status": "Production/Stable",

--- a/stock_available/views/product_template_view.xml
+++ b/stock_available/views/product_template_view.xml
@@ -82,6 +82,7 @@
         <field name="inherit_id" ref="stock.product_template_kanban_stock_view" />
         <field name="arch" type="xml">
             <xpath expr="//div[@name='product_lst_price']" position="after">
+                <field name="show_on_hand_qty_status_button" invisible="1" />
                 <div
                     t-if="record.show_on_hand_qty_status_button.raw_value"
                 >Available to Promise: <field name="immediately_usable_qty" /> <field


### PR DESCRIPTION
Go to Sales > Products kanban view and a hard error shows that raw_value is not available on undefined. This is because the field in question is not in the kanban view. This pull request adds the field and sets it to invisible. 