### PR TITLE
[14.0][FIX] stock_request_mrp: Avoid copying the relationship to mrp.production when duplicating a record

### DIFF
--- a/stock_request_mrp/models/stock_request.py
+++ b/stock_request_mrp/models/stock_request.py
@@ -15,6 +15,7 @@ class StockRequest(models.Model):
         "mrp_production_id",
         string="Manufacturing Orders",
         readonly=True,
+        copy=False,
     )
     production_count = fields.Integer(
         string="Manufacturing Orders count",

--- a/stock_request_mrp/tests/test_stock_request_mrp.py
+++ b/stock_request_mrp/tests/test_stock_request_mrp.py
@@ -86,6 +86,8 @@ class TestStockRequestMrp(TestStockRequest):
         manufacturing_order.button_mark_done()
         self.assertEqual(order.stock_request_ids.qty_in_progress, 0.0)
         self.assertEqual(order.stock_request_ids.qty_done, 5.0)
+        order2 = order.copy()
+        self.assertFalse(order2.production_ids)
 
     def test_stock_request_order_action_cancel(self):
         order = self._create_stock_request(self.stock_request_user, [(self.product, 5)])


### PR DESCRIPTION
Avoid copying the relationship to `mrp.production` when duplicating a record

Please @pedrobaeza can you review it?

@Tecnativa TT41342