### PR TITLE
[15.0][FIX] stock_request_mrp: Avoid copying the relationship to mrp.production when duplicating a record

### DIFF
--- a/stock_request_mrp/models/stock_request.py
+++ b/stock_request_mrp/models/stock_request.py
@@ -15,6 +15,7 @@ class StockRequest(models.Model):
         "mrp_production_id",
         string="Manufacturing Orders",
         readonly=True,
+        copy=False,
     )
     production_count = fields.Integer(
         string="Manufacturing Orders count",

--- a/stock_request_mrp/tests/test_stock_request_mrp.py
+++ b/stock_request_mrp/tests/test_stock_request_mrp.py
@@ -163,6 +163,8 @@ class TestStockRequestMrp(common.TransactionCase):
         manufacturing_order.with_context(skip_immediate=True).button_mark_done()
         self.assertEqual(order.stock_request_ids.qty_in_progress, 0.0)
         self.assertEqual(order.stock_request_ids.qty_done, 5.0)
+        order2 = order.copy()
+        self.assertFalse(order2.production_ids)
 
     def test_view_actions(self):
         expected_date = fields.Datetime.now()


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/1617

Avoid copying the relationship to `mrp.production` when duplicating a record

Please @pedrobaeza can you review it?

@Tecnativa TT41342