### PR TITLE
[FIX] stock_available_base_exclude_location: Fix excluded locations domains

### DIFF
--- a/stock_available_base_exclude_location/models/product_product.py
+++ b/stock_available_base_exclude_location/models/product_product.py
@@ -44,13 +44,13 @@ class ProductProduct(models.Model):
                             excluded_location_ids.ids,
                         )
                     ],
-                    domain_quant_loc,
+                    domain_move_in_loc,
                 ]
             )
             domain_move_out_loc = expression.AND(
                 [
                     [("location_id", "not in", excluded_location_ids.ids)],
-                    domain_quant_loc,
+                    domain_move_out_loc,
                 ]
             )
         return domain_quant_loc, domain_move_in_loc, domain_move_out_loc


### PR DESCRIPTION
I think there is a copy paste error in the `product.product._get_domain_locations_new` domains override

_Courtesy of Olivier Nibart_