### PR TITLE
[14.0][FIX] stock_request: use stock request expected_date as deadline_date

### DIFF
--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -19,8 +19,7 @@ class StockRequest(models.Model):
     def _get_default_requested_by(self):
         return self.env["res.users"].browse(self.env.uid)
 
-    @staticmethod
-    def _get_expected_date():
+    def _get_expected_date(self):
         return fields.Datetime.now()
 
     name = fields.Char(states={"draft": [("readonly", False)]})
@@ -48,6 +47,7 @@ class StockRequest(models.Model):
     expected_date = fields.Datetime(
         "Expected Date",
         index=True,
+        default=_get_expected_date,
         required=True,
         readonly=True,
         states={"draft": [("readonly", False)]},
@@ -406,8 +406,6 @@ class StockRequest(models.Model):
         if "order_id" in upd_vals:
             order_id = self.env["stock.request.order"].browse(upd_vals["order_id"])
             upd_vals["expected_date"] = order_id.expected_date
-        else:
-            upd_vals["expected_date"] = self._get_expected_date()
         return super().create(upd_vals)
 
     def unlink(self):

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -330,6 +330,7 @@ class StockRequest(models.Model):
             "date_planned": max(
                 [self.expected_date, datetime.combine(self.lead_days_date, time.min)]
             ),
+            "date_deadline": self.expected_date,
             "warehouse_id": self.warehouse_id,
             "stock_request_allocation_ids": self.id,
             "group_id": group_id or self.procurement_group_id.id or False,


### PR DESCRIPTION
In this PR I've done 3 things, let me now It you prefer 3 distincts PRs:

* https://github.com/OCA/stock-logistics-warehouse/commit/5f40bc0f997c18b73e81f1049cfb47291a2f1a58: improves unit test to make sure `assetRaises` realy test what it expected to test
* https://github.com/OCA/stock-logistics-warehouse/commit/dddabb3003781f83a80cf45791428df5f45fc3e9: do not force default expected date on stock.request if provide on creation without stock.request.order
* use the expected date as deadline_date on procurement creation to avoid merging `stock.move` from different stock.request with different expected date. I wonder the impact on running prod env and wonder if I should do something less impacting ? 