### PR TITLE
[FW] stock_helper: add location.get_closest_warehouse

### DIFF
--- a/stock_helper/README.rst
+++ b/stock_helper/README.rst
@@ -49,12 +49,14 @@ Authors
 ~~~~~~~
 
 * Camptocamp
+* Michael Tietz (MT Software)
 
 Contributors
 ~~~~~~~~~~~~
 
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Christopher Ormaza <chris.ormaza@forgeflow.com>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_helper/__manifest__.py
+++ b/stock_helper/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Stock Helpers",
     "summary": "Add methods shared between various stock modules",
     "version": "16.0.1.0.1",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Michael Tietz (MT Software), Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "category": "Hidden",
     "depends": ["stock"],

--- a/stock_helper/models/stock_location.py
+++ b/stock_helper/models/stock_location.py
@@ -1,4 +1,5 @@
 # Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2022 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from odoo import models
@@ -18,3 +19,26 @@ class StockLocation(models.Model):
         # Efficient way to verify that the current location is
         # below one of the other location without using SQL.
         return func(self.parent_path.startswith(other.parent_path) for other in others)
+
+    def get_closest_warehouse(self):
+        """Returns closest warehouse for current location.
+
+        By default the get_warehouse (which is located in the odoo core module stock)
+        returns the warehouse via searching the view_location_id with parent_of.
+        If we have multiple warehouses
+        where a view_location_id is a parent of an other view_location_id
+        Then it depends on the sorting of the warehouses which this method returns
+
+        With this methods we will really get the closest warehouse of a location
+        """
+        self.ensure_one()
+        location_ids = [int(x) for x in self.parent_path.split("/") if x]
+        warehouses = (
+            self.env["stock.warehouse"]
+            .search([("view_location_id", "in", location_ids)])
+            .sorted(lambda w: w.view_location_id.parent_path, reverse=True)
+        )
+        for warehouse in warehouses:
+            if self.parent_path.startswith(warehouse.view_location_id.parent_path):
+                return warehouse
+        return warehouses.browse()

--- a/stock_helper/readme/CONTRIBUTORS.rst
+++ b/stock_helper/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Christopher Ormaza <chris.ormaza@forgeflow.com>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>

--- a/stock_helper/tests/__init__.py
+++ b/stock_helper/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_location_is_sublocation_of
+from . import test_location_get_closest_warehouse

--- a/stock_helper/tests/test_location_get_closest_warehouse.py
+++ b/stock_helper/tests/test_location_get_closest_warehouse.py
@@ -1,0 +1,33 @@
+# Copyright 2022 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+
+from .common import StockHelperCommonCase
+
+
+class TestStockLocationGetClosestWarehouse(StockHelperCommonCase):
+    def test_get_closest_warehouse(self):
+        test_warehouse = self.env["stock.warehouse"].create(
+            {"name": "Test Warehouse", "code": "Test WH Code"}
+        )
+        test_warehouse.view_location_id.location_id = self.wh.lot_stock_id.id
+        location = test_warehouse.lot_stock_id
+
+        self.assertEqual(location.get_warehouse(), self.wh)
+        self.assertEqual(location.get_closest_warehouse(), test_warehouse)
+
+        self.wh.sequence = 100
+        test_warehouse.sequence = 1
+        self.assertEqual(location.get_warehouse(), test_warehouse)
+        self.assertEqual(location.get_closest_warehouse(), test_warehouse)
+
+        self.wh.sequence = 1
+        test_warehouse.sequence = 100
+        self.assertEqual(location.get_warehouse(), self.wh)
+        self.assertEqual(location.get_closest_warehouse(), test_warehouse)
+
+    def test_get_closest_warehouse_no_warehouse(self):
+        location = self.wh.lot_stock_id.create(
+            {"name": "Test no warehouse", "barcode": "test_no_warehouse"}
+        )
+        self.assertFalse(location.get_closest_warehouse())


### PR DESCRIPTION
Forwardport of :

- #1466 

On a multi warehouse configuration
where a warehouse view_location is parent of an other warehouse's view_location this will return the closest warehouse of a location

Not like the get_warehouse method (odoo core code) which returns from all parent warehouses found
the first one ordered by the sequence