### PR TITLE
[15.0][FIX] stock_reserve: Avoid creation of pickings when confirming stock reservations

### DIFF
--- a/stock_reserve/model/stock_reserve.py
+++ b/stock_reserve/model/stock_reserve.py
@@ -123,8 +123,9 @@ class StockReservation(models.Model):
         A date until which the product is reserved can be specified.
         """
         self.write({"date": fields.Datetime.now()})
-        self.mapped("move_id")._action_confirm(merge=False)
-        self.mapped("move_id.picking_id").action_assign()
+        # Don't call _action_confirm() method to prevent assign picking
+        self.mapped("move_id").write({"state": "confirmed"})
+        self.mapped("move_id")._action_assign()
         return True
 
     def release_reserve(self):
@@ -133,8 +134,6 @@ class StockReservation(models.Model):
         """
         moves = self.mapped("move_id")
         moves._action_cancel()
-        # HACK: For avoiding to accumulate all reservations in the same picking
-        moves.write({"picking_id": False})
         return True
 
     def _get_state_domain_release_reserve(self, mode):

--- a/stock_reserve/tests/test_stock_reserve.py
+++ b/stock_reserve/tests/test_stock_reserve.py
@@ -34,9 +34,11 @@ class TestStockReserve(common.TransactionCase):
     def test_reservation_and_reservation_release(self):
         reservation_1 = self._create_stock_reservation(6)
         reservation_1.reserve()
+        self.assertFalse(reservation_1.picking_id)
         self.assertEqual(self.product.virtual_available, 4)
         reservation_2 = self._create_stock_reservation(1)
         reservation_2.reserve()
+        self.assertFalse(reservation_2.picking_id)
         self.assertEqual(self.product.virtual_available, 3)
         reservation_1.release_reserve()
         self.assertEqual(self.product.virtual_available, 9)
@@ -45,6 +47,7 @@ class TestStockReserve(common.TransactionCase):
         reservation_1 = self._create_stock_reservation(6)
         reservation_1.date_validity = fields.Date.from_string("2021-01-01")
         reservation_1.reserve()
+        self.assertFalse(reservation_1.picking_id)
         self.assertEqual(self.product.virtual_available, 4)
         cron = self.env.ref("stock_reserve.ir_cron_release_stock_reservation")
         cron.method_direct_trigger()
@@ -53,6 +56,7 @@ class TestStockReserve(common.TransactionCase):
     def test_cron_reserve(self):
         reservation_1 = self._create_stock_reservation(11)
         reservation_1.reserve()
+        self.assertFalse(reservation_1.picking_id)
         self.assertEqual(reservation_1.state, "partially_available")
         self.env["stock.quant"].create(
             {


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/1639

Avoid creation of pickings when confirming stock reservations.

Example use case:
- Create a stock reservation.
- Click on the "Reserve" button

Before this change, a delivery picking was created (unnecessary in my opinion), now, NO picking is created.

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT41080