### PR TITLE
[14.0][FIX] stock_request: Set with cancelled state the stock moves that are cancelled.

### DIFF
--- a/stock_request/models/stock_move.py
+++ b/stock_request/models/stock_move.py
@@ -69,7 +69,7 @@ class StockMove(models.Model):
 
     def _action_cancel(self):
         res = super()._action_cancel()
-        self.mapped("allocation_ids.stock_request_id").check_done()
+        self.mapped("allocation_ids.stock_request_id").check_cancel()
         return res
 
     def _action_done(self, cancel_backorder=False):

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -236,12 +236,19 @@ class StockRequest(models.Model):
     def action_cancel(self):
         self.sudo().mapped("move_ids")._action_cancel()
         self.write({"state": "cancel"})
+        self.mapped("order_id").check_cancel()
         return True
 
     def action_done(self):
         self.write({"state": "done"})
         self.mapped("order_id").check_done()
         return True
+
+    def check_cancel(self):
+        for request in self:
+            if request._check_cancel_allocation():
+                request.write({"state": "cancel"})
+                request.mapped("order_id").check_cancel()
 
     def check_done(self):
         precision = self.env["decimal.precision"].precision_get(
@@ -259,11 +266,13 @@ class StockRequest(models.Model):
                 >= 0
             ):
                 request.action_done()
-            elif request._check_done_allocation():
-                request.action_done()
+            elif request._check_cancel_allocation():
+                # If qty_done=0 and qty_cancelled>0 it's cancelled
+                request.write({"state": "cancel"})
+                request.mapped("order_id").check_cancel()
         return True
 
-    def _check_done_allocation(self):
+    def _check_cancel_allocation(self):
         precision = self.env["decimal.precision"].precision_get(
             "Product Unit of Measure"
         )

--- a/stock_request/models/stock_request_order.py
+++ b/stock_request/models/stock_request_order.py
@@ -249,6 +249,12 @@ class StockRequestOrder(models.Model):
                 rec.action_done()
         return
 
+    def check_cancel(self):
+        for rec in self:
+            if not rec.stock_request_ids.filtered(lambda r: r.state != "cancel"):
+                rec.write({"state": "cancel"})
+        return
+
     def action_view_transfer(self):
         action = self.env["ir.actions.act_window"]._for_xml_id(
             "stock.action_picking_tree_all"

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -680,7 +680,7 @@ class TestStockRequestBase(TestStockRequest):
         self.assertEqual(stock_request_2.qty_in_progress, 0)
         self.assertEqual(stock_request_2.qty_done, 0)
         self.assertEqual(stock_request_2.qty_cancelled, 6)
-        self.assertEqual(stock_request_2.state, "done")
+        self.assertEqual(stock_request_2.state, "cancel")
 
     def test_cancel_request(self):
         expected_date = fields.Datetime.now()
@@ -1064,8 +1064,11 @@ class TestStockRequestBase(TestStockRequest):
         sr2.refresh()
         sr3.refresh()
         self.assertEqual(sr1.state, "done")
+        self.assertEqual(sr1.qty_done, 5)
         self.assertEqual(sr1.qty_cancelled, 0)
-        self.assertEqual(sr2.state, "done")
+        self.assertEqual(sr2.state, "cancel")
+        self.assertEqual(sr2.qty_done, 1)
         self.assertEqual(sr2.qty_cancelled, 4)
-        self.assertEqual(sr3.state, "done")
+        self.assertEqual(sr3.state, "cancel")
+        self.assertEqual(sr3.qty_done, 0)
         self.assertEqual(sr3.qty_cancelled, 5)

--- a/stock_request_mrp/tests/test_stock_request_mrp.py
+++ b/stock_request_mrp/tests/test_stock_request_mrp.py
@@ -97,6 +97,14 @@ class TestStockRequestMrp(TestStockRequest):
         order.with_context(bypass_confirm_wizard=True).action_cancel()
         self.assertEqual(production.state, "cancel")
 
+    def test_stock_request_order_production_action_cancel(self):
+        order = self._create_stock_request(self.stock_request_user, [(self.product, 5)])
+        order.action_confirm()
+        production = fields.first(order.stock_request_ids.production_ids)
+        self.assertEqual(production.state, "confirmed")
+        production.action_cancel()
+        self.assertEqual(order.state, "cancel")
+
     def test_view_actions(self):
         order = self._create_stock_request(self.stock_request_user, [(self.product, 5)])
         order.action_confirm()


### PR DESCRIPTION
Set with cancelled state the stock moves that are cancelled.

Example use case:

- Create a stock.request (or stock.request.order)
- Confirm.
- Cancel the stock move.
- stock.request and stock.request.order must be set with status cancelled.

Please @pedrobaeza can you review it?

@Tecnativa TT41827
