### PR TITLE
[15.0][FIX] stock_request: Set with cancelled state the stock moves that are cancelled.

### DIFF
--- a/stock_request/models/stock_move.py
+++ b/stock_request/models/stock_move.py
@@ -69,7 +69,7 @@ class StockMove(models.Model):
 
     def _action_cancel(self):
         res = super()._action_cancel()
-        self.mapped("allocation_ids.stock_request_id").check_done()
+        self.mapped("allocation_ids.stock_request_id").check_cancel()
         return res
 
     def _action_done(self, cancel_backorder=False):

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -231,12 +231,19 @@ class StockRequest(models.Model):
     def action_cancel(self):
         self.sudo().mapped("move_ids")._action_cancel()
         self.write({"state": "cancel"})
+        self.mapped("order_id").check_cancel()
         return True
 
     def action_done(self):
         self.write({"state": "done"})
         self.mapped("order_id").check_done()
         return True
+
+    def check_cancel(self):
+        for request in self:
+            if request._check_cancel_allocation():
+                request.write({"state": "cancel"})
+                request.mapped("order_id").check_cancel()
 
     def check_done(self):
         precision = self.env["decimal.precision"].precision_get(
@@ -254,11 +261,13 @@ class StockRequest(models.Model):
                 >= 0
             ):
                 request.action_done()
-            elif request._check_done_allocation():
-                request.action_done()
+            elif request._check_cancel_allocation():
+                # If qty_done=0 and qty_cancelled>0 it's cancelled
+                request.write({"state": "cancel"})
+                request.mapped("order_id").check_cancel()
         return True
 
-    def _check_done_allocation(self):
+    def _check_cancel_allocation(self):
         precision = self.env["decimal.precision"].precision_get(
             "Product Unit of Measure"
         )

--- a/stock_request/models/stock_request_order.py
+++ b/stock_request/models/stock_request_order.py
@@ -246,6 +246,12 @@ class StockRequestOrder(models.Model):
                 rec.action_done()
         return
 
+    def check_cancel(self):
+        for rec in self:
+            if not rec.stock_request_ids.filtered(lambda r: r.state != "cancel"):
+                rec.write({"state": "cancel"})
+        return
+
     def action_view_transfer(self):
         action = self.env["ir.actions.act_window"]._for_xml_id(
             "stock.action_picking_tree_all"

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -699,7 +699,7 @@ class TestStockRequestBase(TestStockRequest):
         self.assertEqual(stock_request_2.qty_in_progress, 0)
         self.assertEqual(stock_request_2.qty_done, 0)
         self.assertEqual(stock_request_2.qty_cancelled, 6)
-        self.assertEqual(stock_request_2.state, "done")
+        self.assertEqual(stock_request_2.state, "cancel")
 
     def test_cancel_request(self):
         expected_date = fields.Datetime.now()
@@ -1105,8 +1105,11 @@ class TestStockRequestBase(TestStockRequest):
         sr2.refresh()
         sr3.refresh()
         self.assertEqual(sr1.state, "done")
+        self.assertEqual(sr1.qty_done, 5)
         self.assertEqual(sr1.qty_cancelled, 0)
-        self.assertEqual(sr2.state, "done")
+        self.assertEqual(sr2.state, "cancel")
+        self.assertEqual(sr2.qty_done, 1)
         self.assertEqual(sr2.qty_cancelled, 4)
-        self.assertEqual(sr3.state, "done")
+        self.assertEqual(sr3.state, "cancel")
+        self.assertEqual(sr3.qty_done, 0)
         self.assertEqual(sr3.qty_cancelled, 5)

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -1,4 +1,5 @@
 # Copyright 2017 ForgeFlow S.L.
+# Copyright 2022 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
 from collections import Counter
@@ -11,11 +12,9 @@ from odoo.tests import common, new_test_user
 class TestStockRequest(common.TransactionCase):
     def setUp(self):
         super().setUp()
-
         # common models
         self.stock_request = self.env["stock.request"]
         self.request_order = self.env["stock.request.order"]
-
         # refs
         self.stock_request_user_group = self.env.ref(
             "stock_request.group_stock_request_user"
@@ -24,7 +23,6 @@ class TestStockRequest(common.TransactionCase):
         self.warehouse = self.env.ref("stock.warehouse0")
         self.categ_unit = self.env.ref("uom.product_uom_categ_unit")
         self.virtual_loc = self.env.ref("stock.stock_location_customers")
-
         # common data
         self.company_2 = self.env["res.company"].create(
             {"name": "Comp2", "parent_id": self.main_company.id}
@@ -61,45 +59,22 @@ class TestStockRequest(common.TransactionCase):
         self.product_company_2 = self._create_product(
             "SH_2", "Shoes", self.company_2.id
         )
-
-        self.ressuply_loc = self.env["stock.location"].create(
-            {
-                "name": "Ressuply",
-                "location_id": self.warehouse.view_location_id.id,
-                "usage": "internal",
-                "company_id": self.main_company.id,
-            }
+        self.ressuply_loc = self._create_location(
+            name="Ressuply",
+            location_id=self.warehouse.view_location_id.id,
+            company_id=self.main_company.id,
         )
-
-        self.ressuply_loc_2 = self.env["stock.location"].create(
-            {
-                "name": "Ressuply",
-                "location_id": self.wh2.view_location_id.id,
-                "usage": "internal",
-                "company_id": self.company_2.id,
-            }
+        self.ressuply_loc_2 = self._create_location(
+            name="Ressuply",
+            location_id=self.wh2.view_location_id.id,
+            company_id=self.company_2.id,
         )
-
-        self.route = self.env["stock.location.route"].create(
-            {
-                "name": "Transfer",
-                "product_categ_selectable": False,
-                "product_selectable": True,
-                "company_id": self.main_company.id,
-                "sequence": 10,
-            }
+        self.route = self._create_location_route(
+            name="Transfer", company_id=self.main_company.id
         )
-
-        self.route_2 = self.env["stock.location.route"].create(
-            {
-                "name": "Transfer",
-                "product_categ_selectable": False,
-                "product_selectable": True,
-                "company_id": self.company_2.id,
-                "sequence": 10,
-            }
+        self.route_2 = self._create_location_route(
+            name="Transfer", company_id=self.company_2.id
         )
-
         self.uom_dozen = self.env["uom.uom"].create(
             {
                 "name": "Test-DozenA",
@@ -109,7 +84,6 @@ class TestStockRequest(common.TransactionCase):
                 "rounding": 0.001,
             }
         )
-
         self.env["stock.rule"].create(
             {
                 "name": "Transfer",
@@ -123,7 +97,6 @@ class TestStockRequest(common.TransactionCase):
                 "company_id": self.main_company.id,
             }
         )
-
         self.env["stock.rule"].create(
             {
                 "name": "Transfer",
@@ -137,7 +110,6 @@ class TestStockRequest(common.TransactionCase):
                 "company_id": self.company_2.id,
             }
         )
-
         self.env["ir.config_parameter"].sudo().set_param(
             "stock.no_auto_scheduler", "True"
         )
@@ -172,6 +144,19 @@ class TestStockRequest(common.TransactionCase):
 
     def _create_product_attribute(self, name):
         return self.env["product.attribute"].create({"name": name})
+
+    def _create_location(self, **vals):
+        return self.env["stock.location"].create(dict(usage="internal", **vals))
+
+    def _create_location_route(self, **vals):
+        return self.env["stock.location.route"].create(
+            dict(
+                product_categ_selectable=False,
+                product_selectable=True,
+                sequence=10,
+                **vals
+            )
+        )
 
 
 class TestStockRequestBase(TestStockRequest):

--- a/stock_request_mrp/models/mrp_production.py
+++ b/stock_request_mrp/models/mrp_production.py
@@ -27,7 +27,9 @@ class MrpProduction(models.Model):
         """
         :return dict: dictionary value for created view
         """
-        action = self.env.ref("stock_request.action_stock_request_form").read()[0]
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "stock_request.action_stock_request_form"
+        )
 
         requests = self.mapped("stock_request_ids")
         if len(requests) > 1:

--- a/stock_request_mrp/models/stock_request.py
+++ b/stock_request_mrp/models/stock_request.py
@@ -45,7 +45,9 @@ class StockRequest(models.Model):
             )
 
     def action_view_mrp_production(self):
-        action = self.env.ref("mrp.mrp_production_action").read()[0]
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "mrp.mrp_production_action"
+        )
         productions = self.mapped("production_ids")
         if len(productions) > 1:
             action["domain"] = [("id", "in", productions.ids)]

--- a/stock_request_mrp/models/stock_request_order.py
+++ b/stock_request_mrp/models/stock_request_order.py
@@ -26,7 +26,9 @@ class StockRequestOrder(models.Model):
             req.production_count = len(req.production_ids)
 
     def action_view_mrp_production(self):
-        action = self.env.ref("mrp.mrp_production_action").read()[0]
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "mrp.mrp_production_action"
+        )
         productions = self.mapped("production_ids")
         if len(productions) > 1:
             action["domain"] = [("id", "in", productions.ids)]

--- a/stock_request_mrp/tests/test_stock_request_mrp.py
+++ b/stock_request_mrp/tests/test_stock_request_mrp.py
@@ -104,6 +104,22 @@ class TestStockRequestMrp(TestStockRequest):
         order2 = order.copy()
         self.assertFalse(order2.production_ids)
 
+    def test_stock_request_order_action_cancel(self):
+        order = self._create_stock_request(self.stock_request_user, [(self.product, 5)])
+        order.action_confirm()
+        production = fields.first(order.stock_request_ids.production_ids)
+        self.assertEqual(production.state, "confirmed")
+        order.with_context(bypass_confirm_wizard=True).action_cancel()
+        self.assertEqual(production.state, "cancel")
+
+    def test_stock_request_order_production_action_cancel(self):
+        order = self._create_stock_request(self.stock_request_user, [(self.product, 5)])
+        order.action_confirm()
+        production = fields.first(order.stock_request_ids.production_ids)
+        self.assertEqual(production.state, "confirmed")
+        production.action_cancel()
+        self.assertEqual(order.state, "cancel")
+
     def test_view_actions(self):
         order = self._create_stock_request(self.stock_request_user, [(self.product, 5)])
         order.action_confirm()


### PR DESCRIPTION
FWP 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/1647

Set with cancelled state the stock moves that are cancelled.

Example use case:

- Create a stock.request (or stock.request.order)
- Confirm.
- Cancel the stock move.
- stock.request and stock.request.order must be set with status cancelled.

Extra changes:
- [x] Refactor tests (from 14.0: https://github.com/OCA/stock-logistics-warehouse/commit/c76e95757b6e21ee50332bbf817cf39e8db79c1a)
- [x] Change actions from `.read()` to `_for_xml_id()`

Please @pedrobaeza can you review it?

@Tecnativa TT41827
