### PR TITLE
[14.0][FW-PORT] stock_demand_estimate_matrix: remove action extension

### DIFF
--- a/stock_demand_estimate_matrix/views/stock_demand_estimate_view.xml
+++ b/stock_demand_estimate_matrix/views/stock_demand_estimate_view.xml
@@ -43,10 +43,5 @@
             </field>
         </field>
     </record>
-    <record
-        id="stock_demand_estimate.stock_demand_estimate_action"
-        model="ir.actions.act_window"
-    >
-        <field name="view_mode">tree,pivot</field>
-    </record>
+
 </odoo>


### PR DESCRIPTION
no need to modify action, once the tree view is set as editable it will work as itended, no need to remove form from the view modes.

Origin: https://github.com/OCA/stock-logistics-warehouse/pull/1656