### PR TITLE
[16.0][IMP] stock_demand_estimate: enhance views

### DIFF
--- a/stock_demand_estimate/models/stock_demand_estimate.py
+++ b/stock_demand_estimate/models/stock_demand_estimate.py
@@ -33,7 +33,7 @@ class StockDemandEstimate(models.Model):
     )
     product_uom_qty = fields.Float(string="Quantity", digits="Product Unit of Measure")
     product_qty = fields.Float(
-        "Real Quantity",
+        string="Quantity (Product UoM)",
         compute="_compute_product_quantity",
         inverse="_inverse_product_quantity",
         digits=0,

--- a/stock_demand_estimate/views/stock_demand_estimate_view.xml
+++ b/stock_demand_estimate/views/stock_demand_estimate_view.xml
@@ -56,6 +56,19 @@
             </pivot>
         </field>
     </record>
+
+    <record id="stock_demand_estimate_view_graph" model="ir.ui.view">
+        <field name="name">stock.demand.estimate.graph</field>
+        <field name="model">stock.demand.estimate</field>
+        <field name="arch" type="xml">
+            <graph type="bar" stacked="True">
+                <field name="product_qty" type="measure" />
+                <field name="date_from" />
+                <field name="product_id" />
+            </graph>
+        </field>
+    </record>
+
     <record id="stock_demand_estimate_view_search" model="ir.ui.view">
         <field name="name">stock.demand.estimate.search</field>
         <field name="model">stock.demand.estimate</field>
@@ -63,6 +76,38 @@
             <search string="Search Stock Demand Estimates">
                 <field name="product_id" />
                 <field name="location_id" />
+                <separator />
+                <filter
+                    name="expired"
+                    string="Expired"
+                    domain="[('date_to', '&lt;', context_today().strftime('%Y-%m-%d'))]"
+                />
+                <filter
+                    name="not_expired"
+                    string="Not Expired"
+                    domain="['|', ('date_to', '=', False), ('date_to', '&gt;', context_today().strftime('%Y-%m-%d'))]"
+                />
+                <separator />
+                <group expand="0" string="Group By">
+                    <filter
+                        string="Product"
+                        name="groupby_product"
+                        domain="[]"
+                        context="{'group_by':'product_id'}"
+                    />
+                    <filter
+                        string="Location"
+                        name="groupby_location"
+                        domain="[]"
+                        context="{'group_by':'location_id'}"
+                    />
+                    <filter
+                        string="Date (From)"
+                        name="groupby_date_from"
+                        domain="[]"
+                        context="{'group_by':'date_from'}"
+                    />
+                </group>
             </search>
         </field>
     </record>
@@ -70,8 +115,9 @@
         <field name="name">Stock Demand Estimates</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">stock.demand.estimate</field>
-        <field name="view_mode">tree,form,pivot</field>
+        <field name="view_mode">tree,form,pivot,graph</field>
         <field name="search_view_id" ref="stock_demand_estimate_view_search" />
+        <field name="context">{"search_default_not_expired": 1}</field>
     </record>
     <menuitem
         id="stock_demand_planning_menu"


### PR DESCRIPTION
* Add a graph view.
* Add handy filters: (not) expired; group by date, location and/or product.
* Relabel `product_qty` as "Real Quantity" was really confusing.

Forward port of #1656 

@ForgeFlow