### PR TITLE
[15.0][FIX] stock_move_location: No read on actions

### DIFF
--- a/stock_move_location/models/stock_picking_type.py
+++ b/stock_move_location/models/stock_picking_type.py
@@ -1,4 +1,5 @@
-# Copyright 2019 Sergio Teruel <sergio.teruel@tecnativa.com>
+# Copyright 2019 Tecnativa - Sergio Teruel
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import fields, models
 
@@ -14,9 +15,9 @@ class StockPickingType(models.Model):
     )
 
     def action_move_location(self):
-        action = self.env.ref(
+        action = self.env["ir.actions.act_window"]._for_xml_id(
             "stock_move_location.wiz_stock_move_location_action"
-        ).read()[0]
+        )
         action["context"] = {
             "default_origin_location_id": self.default_location_src_id.id,
             "default_destination_location_id": self.default_location_dest_id.id,

--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
 # Copyright 2018 Camptocamp SA
-# Copyright 2019 Sergio Teruel - Tecnativa <sergio.teruel@tecnativa.com>
+# Copyright 2019 Tecnativa - Sergio Teruel
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from itertools import groupby
@@ -255,11 +256,13 @@ class StockMoveLocationWizard(models.TransientModel):
         self.picking_id = picking
         return self._get_picking_action(picking.id)
 
-    def _get_picking_action(self, pickinig_id):
-        action = self.env.ref("stock.action_picking_tree_all").read()[0]
-        form_view = self.env.ref("stock.view_picking_form").id
+    def _get_picking_action(self, picking_id):
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "stock.action_picking_tree_all"
+        )
+        view_id = self.env.ref("stock.view_picking_form").id
         action.update(
-            {"view_mode": "form", "views": [(form_view, "form")], "res_id": pickinig_id}
+            {"view_mode": "form", "views": [(view_id, "form")], "res_id": picking_id}
         )
         return action
 


### PR DESCRIPTION
The permissions on actions has been restricted on this version. Use _for_xml_id helper that was built for not requiring such permissions.

@Tecnativa TT42955