### PR TITLE
[15.0][FIX] stock_request: Do not change stock.group_stock_user to avoid in consistency

### DIFF
--- a/stock_request/security/stock_request_security.xml
+++ b/stock_request/security/stock_request_security.xml
@@ -26,9 +26,6 @@
         <field name="name">Stock Request Order</field>
         <field name="category_id" ref="base.module_category_hidden" />
     </record>
-    <record id="stock.group_stock_user" model="res.groups">
-        <field name="implied_ids" eval="[(4, ref('group_stock_request_user'))]" />
-    </record>
     <data noupdate="1">
         <record model="ir.rule" id="stock_picking_rule">
             <field name="name">stock_request multi-company</field>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/1712

Do not change `stock.group_stock_user` to avoid in consistency

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT43317