### PR TITLE
[14.0][FIX] stock_quant_reservation_info_mrp: incorrect key in manifest

### DIFF
--- a/stock_quant_reservation_info_mrp/__manifest__.py
+++ b/stock_quant_reservation_info_mrp/__manifest__.py
@@ -13,5 +13,5 @@
     "license": "AGPL-3",
     "data": ["views/stock_move_line.xml"],
     "installable": True,
-    "auto-install": True,
+    "auto_install": True,
 }


### PR DESCRIPTION
Module was not being autoinstalled.

cc @DavidJForgeFlow 