### PR TITLE
[FIX] stock_location_orderpoint/source_relocate: Use recordset for trap_jobs evaluation

### DIFF
--- a/stock_location_orderpoint/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint.py
@@ -108,7 +108,7 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
             move = self._create_outgoing_move(move_qty)
             trap.assert_jobs_count(1, only=job_func)
             trap.assert_enqueued_job(
-                orderpoint.run_auto_replenishment,
+                orderpoint.browse().run_auto_replenishment,
                 args=(move.product_id, move.location_id, "location_id"),
                 kwargs={},
                 properties=dict(
@@ -124,7 +124,7 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
             move = self._create_incoming_move(move_qty, location_src)
             trap.assert_jobs_count(1, only=job_func)
             trap.assert_enqueued_job(
-                orderpoint.run_auto_replenishment,
+                orderpoint.browse().run_auto_replenishment,
                 args=(move.product_id, move.location_dest_id, "location_src_id"),
                 kwargs={},
                 properties=dict(
@@ -142,7 +142,7 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
             move = self._create_outgoing_move(move_qty)
             trap.assert_jobs_count(1, only=job_func)
             trap.assert_enqueued_job(
-                orderpoint.run_auto_replenishment,
+                orderpoint.browse().run_auto_replenishment,
                 args=(move.product_id, move.location_id, "location_id"),
                 kwargs={},
                 properties=dict(

--- a/stock_location_orderpoint_source_relocate/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint_source_relocate/tests/test_location_orderpoint.py
@@ -51,7 +51,7 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon, SourceRelocateCommon)
             self.assertEqual(move.location_id, internal_location)
             trap.assert_jobs_count(1, only=job_func)
             trap.assert_enqueued_job(
-                orderpoint.run_auto_replenishment,
+                job_func,
                 args=(move.product_id, internal_location, "location_id"),
                 kwargs={},
                 properties=dict(


### PR DESCRIPTION
…ap_jobs evaluation

Due to https://github.com/OCA/queue/pull/537/commits/299cf4d82a68614fb6cf376601ed5bbdee680753