### PR TITLE
[15.0][FIX] stock_inventory_discrepancy: Ensure active_ids value

### DIFF
--- a/stock_inventory_discrepancy/models/stock_quant.py
+++ b/stock_inventory_discrepancy/models/stock_quant.py
@@ -63,6 +63,7 @@ class StockQuant(models.Model):
             action["context"] = dict(
                 self._context.copy(),
                 discrepancy_quant_ids=over_discrepancy.ids,
+                active_ids=self.ids,
             )
             return action
         return super().action_apply_inventory()


### PR DESCRIPTION
Steps to reproduce:

- Enter a product.
- Navigate to stock on hand.
- Adjust quantity and rebase discrepancy limit.
- Accept the discrepancy popup.

You get an error as the ID to be tried to adjust is the product one, not the quant one.

We need to overwrite active_ids context with the quant IDs to be handled on the wizard popup.

@Tecnativa TT43947