### PR TITLE
[12.0][IMP] stock_request: add route helper field to the stock request order

### DIFF
--- a/stock_request/views/stock_request_order_views.xml
+++ b/stock_request/views/stock_request_order_views.xml
@@ -11,6 +11,7 @@
                        groups="stock.group_stock_multi_locations"/>
                 <field name="location_id"
                        groups="stock.group_stock_multi_locations"/>
+                <field name="route_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                 <field name="state"/>
             </tree>
         </field>
@@ -71,6 +72,9 @@
                             <field name="location_id"
                                    groups="stock.group_stock_multi_locations"/>
                             <field name="allow_virtual_location" invisible="1"/>
+                            <field name="route_id"
+                                   options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
+                            <field name="route_ids" invisible="1"/>
                             <field name="procurement_group_id"
                                    groups="stock.group_adv_location"/>
                             <field name="company_id"
@@ -88,6 +92,7 @@
                             'default_procurement_group_id': procurement_group_id,
                             'default_company_id': company_id,
                             'default_state': state,
+                            'default_route_id': route_id,
                             }" attrs="{'readonly': [('state', '!=', 'draft')]}">
                                 <tree editable="bottom">
                                     <field name="name" readonly="1"/>
@@ -135,6 +140,7 @@
                 <field name="state"/>
                 <field name="warehouse_id"/>
                 <field name="location_id" groups="stock.group_stock_multi_locations"/>
+                <field name="route_id" groups="stock.group_stock_multi_locations"/>
                 <field name="company_id" groups="base.group_multi_company"/>
                 <separator/>
                 <filter string="Draft" name="draft" domain="[('state','=','draft')]"/>


### PR DESCRIPTION
- adds a route_id field to the stock request orders, serving as a helper field to set a default value when entering the stock requests

![image](https://github.com/OCA/stock-logistics-warehouse/assets/3459102/f0de7f9f-36e3-431c-87db-dc821f38e340)
