### PR TITLE
[14.0][FIX] stock_exception: delete overwrite order by module

### DIFF
--- a/stock_exception/models/stock.py
+++ b/stock_exception/models/stock.py
@@ -7,7 +7,6 @@ from odoo import api, models
 class StockPicking(models.Model):
     _inherit = ["stock.picking", "base.exception"]
     _name = "stock.picking"
-    _order = "main_exception_id asc, priority desc, scheduled_date asc, id desc"
 
     @api.model
     def test_all_draft_pickings(self):


### PR DESCRIPTION
From issue: https://github.com/OCA/stock-logistics-warehouse/issues/1721

It can't add new view for sort because base exception need name module that we config.
So, I delete `_order` in stock_exception

@jerzyk