### PR TITLE
[15.0][ENH] stock_location_lockdown: add wizard view to select location to lock

### DIFF
--- a/stock_location_lockdown/README.rst
+++ b/stock_location_lockdown/README.rst
@@ -38,7 +38,10 @@ Theses locations must have *Location Type* set to *Internal Location* because th
 Usage
 =====
 
-* Once the module is installed, select any internal location for which you want to prevent stock entrance and check the box *Block Stock Entrance*. Then, you won't be allow to add stock on these locations.
+* Once the module is installed, You have to config user's access right as Inventory Administrator, then go to menu Inventory -> Operations -> Update Stock Location Block.
+* Select any internal location for which you want to prevent stock entrance and click update button. Then, you won't be allow to add stock on these locations.
+* At any internal location if it lock you will see *Block Stock Entrance* is checked.
+* You can unlock by click at menu *Update Stock Location Block* and remove location and click update.
 
 Bug Tracker
 ===========
@@ -63,6 +66,7 @@ Contributors
 
 * Florian da Costa <florian.dacosta@akretion.com>
 * David Montull Guasch <david.montull@bt-group.com>
+* Theerayut Attajak <theerayuta@ecosoft.co.th>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_location_lockdown/__init__.py
+++ b/stock_location_lockdown/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizards

--- a/stock_location_lockdown/__manifest__.py
+++ b/stock_location_lockdown/__manifest__.py
@@ -12,5 +12,9 @@
     "application": False,
     "installable": True,
     "depends": ["stock"],
-    "data": ["views/stock_location.xml"],
+    "data": [
+        "views/stock_location.xml",
+        "security/ir.model.access.csv",
+        "wizards/stock_location_lock_view.xml",
+    ],
 }

--- a/stock_location_lockdown/models/stock_location.py
+++ b/stock_location_lockdown/models/stock_location.py
@@ -1,33 +1,17 @@
 # Copyright 2019 Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, fields, models
-from odoo.exceptions import UserError
+from odoo import fields, models
 
 
 class StockLocation(models.Model):
     _inherit = "stock.location"
 
+    start_lock_date = fields.Date()
+    end_lock_date = fields.Date()
     block_stock_entrance = fields.Boolean(
+        readonly=True,
         help="if this box is checked, putting stock on this location won't be "
         "allowed. Usually used for a virtual location that has "
-        "childrens."
+        "childrens.",
     )
-
-    # Raise error if the location that you're trying to block
-    # has already got quants
-    def write(self, values):
-        res = super().write(values)
-
-        if "block_stock_entrance" in values and values["block_stock_entrance"]:
-            # Unlink zero quants before checking
-            # if there are quants on the location
-            self.env["stock.quant"]._unlink_zero_quants()
-            if self.mapped("quant_ids"):
-                raise UserError(
-                    _(
-                        "It is impossible to prohibit this location from\
-                    receiving products as it already contains some."
-                    )
-                )
-        return res

--- a/stock_location_lockdown/models/stock_quant.py
+++ b/stock_location_lockdown/models/stock_quant.py
@@ -10,7 +10,7 @@ class StockQuant(models.Model):
 
     # Raise an error when trying to change a quant
     # which corresponding stock location is blocked
-    @api.constrains("location_id")
+    @api.constrains("location_id", "quantity")
     def check_location_blocked(self):
         for record in self:
             if record.location_id.block_stock_entrance:

--- a/stock_location_lockdown/readme/CONTRIBUTORS.rst
+++ b/stock_location_lockdown/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Florian da Costa <florian.dacosta@akretion.com>
 * David Montull Guasch <david.montull@bt-group.com>
+* Theerayut Attajak <theerayuta@ecosoft.co.th>

--- a/stock_location_lockdown/readme/USAGE.rst
+++ b/stock_location_lockdown/readme/USAGE.rst
@@ -1,1 +1,4 @@
-* Once the module is installed, select any internal location for which you want to prevent stock entrance and check the box *Block Stock Entrance*. Then, you won't be allow to add stock on these locations.
+* Once the module is installed, You have to config user's access right as Inventory Administrator, then go to menu Inventory -> Operations -> Update Stock Location Block
+* Select any internal location for which you want to prevent stock entrance and click update button. Then, you won't be allow to add stock on these locations.
+* At any internal location if it was locked you will see *Block Stock Entrance* is checked.
+* You can unlock by click at menu *Update Stock Location Block* and remove location and click update.

--- a/stock_location_lockdown/security/ir.model.access.csv
+++ b/stock_location_lockdown/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_location_lock,Full access on stock.locaiton.lock,model_stock_location_lock,stock.group_stock_manager,1,1,1,1

--- a/stock_location_lockdown/wizards/__init__.py
+++ b/stock_location_lockdown/wizards/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2023 Ecosoft Co., Ltd (https://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from . import stock_location_lock

--- a/stock_location_lockdown/wizards/stock_location_lock.py
+++ b/stock_location_lockdown/wizards/stock_location_lock.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Ecosoft Co., Ltd (https://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, fields, models
+
+
+class StockLocationLock(models.TransientModel):
+    _name = "stock.location.lock"
+    _description = "Stock Transfer Lock Date"
+
+    location_ids = fields.Many2many(
+        comodel_name="stock.location",
+        string="Locations",
+        domain=[("usage", "=", "internal")],
+    )
+
+    @api.model
+    def default_get(self, field_list):
+        res = super(StockLocationLock, self).default_get(field_list)
+        locations = self.location_ids.search([("block_stock_entrance", "=", True)])
+        if locations:
+            res.update({"location_ids": [(6, 0, [x.id for x in locations])]})
+        return res
+
+    def _reset_block_stock_entrance(self):
+        """
+        This function will set block stock entrance in all location to False
+        """
+        locations = self.location_ids.search([("usage", "=", "internal")])
+        for rec in locations:
+            rec.sudo().write(
+                {
+                    "block_stock_entrance": False,
+                }
+            )
+
+    def execute(self):
+        self.ensure_one()
+        # raise UserError(self.location_ids)
+        self._reset_block_stock_entrance()
+        for rec in self.location_ids:
+            rec.sudo().write({"block_stock_entrance": True})

--- a/stock_location_lockdown/wizards/stock_location_lock_view.xml
+++ b/stock_location_lockdown/wizards/stock_location_lock_view.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="stock_location_lock_form_view" model="ir.ui.view">
+        <field name="name">stock.location.lock.form</field>
+        <field name="model">stock.location.lock</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group id="main">
+                        <field
+                            name="location_ids"
+                            widget="many2many_tags"
+                            options="{'no_create': True}"
+                        />
+                    </group>
+                </sheet>
+                <footer>
+                    <button
+                        string="Update"
+                        name="execute"
+                        type="object"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record id="stock_location_lock_act_window" model="ir.actions.act_window">
+        <field name="name">Update Stock Location Lock</field>
+        <field name="res_model">stock.location.lock</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+    <record id="stock_location_lock_menu" model="ir.ui.menu">
+        <field name="name">Update Stock Location Lock</field>
+        <field name="parent_id" ref="stock.menu_stock_warehouse_mgmt" />
+        <field name="action" ref="stock_location_lock_act_window" />
+        <field name="sequence" eval="70" />
+    </record>
+</odoo>


### PR DESCRIPTION
**TODO**:
- [ ] Test Script

After installed this module, Inventory Administrator can select location to lock easily by go
menu **Inventory** -> **Operations** -> **Update Stock Location Lock**
![Screenshot from 2023-06-23 14-37-43](https://github.com/OCA/stock-logistics-warehouse/assets/96042966/994fd80e-ed6d-4327-83ea-896f29de1f2f)

Then select any location and click **Update**
![Screenshot from 2023-06-23 08-58-57](https://github.com/OCA/stock-logistics-warehouse/assets/96042966/0b8689cf-0e72-4325-bda2-3b604e39c916)

If you go for check at Location you will notice **Block Stock Entrance** is checked, the product can not move in or out through this location.
![Screenshot from 2023-06-23 14-41-10](https://github.com/OCA/stock-logistics-warehouse/assets/96042966/c6d608a1-4624-4566-af96-db73939f7393)

To unlock location just go to menu **Update Stock Location Lock** again and remove location and click **Update**

Note: You can lock only Internal Location according to this module.

Best Regards
