### PR TITLE
[15.0][FIX] stock_reserve: Set company_id empty from stock_location_reservation to avoid multi-company incompatibilities

### DIFF
--- a/stock_reserve/data/stock_data.xml
+++ b/stock_reserve/data/stock_data.xml
@@ -3,5 +3,6 @@
     <record id="stock_location_reservation" model="stock.location">
         <field name="name">Reservation Stock</field>
         <field name="location_id" ref="stock.stock_location_locations" />
+        <field name="company_id" />
     </record>
 </odoo>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/1777

Set `company_id` empty from stock_location_reservation to avoid multi-company incompatibilities.

Please @pedrobaeza can you review it?

@Tecnativa TT44108