### PR TITLE
[15.0][IMP] stock_inventory: do not delete inv adjustment groups if in process or done

### DIFF
--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -1,5 +1,5 @@
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 
 
@@ -214,3 +214,14 @@ class InventoryAdjustmentsGroup(models.Model):
                             " you are only able to add one product."
                         )
                     )
+
+    def unlink(self):
+        for adjustment in self:
+            if adjustment.state != "draft":
+                raise UserError(
+                    _(
+                        "You can only delete inventory adjustments groups in"
+                        " draft state."
+                    )
+                )
+        return super().unlink()

--- a/stock_inventory/models/stock_move_line.py
+++ b/stock_inventory/models/stock_move_line.py
@@ -4,4 +4,4 @@ from odoo import fields, models
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    inventory_adjustment_id = fields.Many2one("stock.inventory")
+    inventory_adjustment_id = fields.Many2one("stock.inventory", ondelete="restrict")


### PR DESCRIPTION
I think it is weird you can delete inventory adjustments groups that are in progress or completed, I think they should be kept for traceability to what was done.
@ForgeFlow 
@DavidJForgeFlow 