### PR TITLE
[15.0][IMP] stock_inventory: allow to enter directly quantity for products without quants

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockQuant(models.Model):
@@ -34,3 +34,14 @@ class StockQuant(models.Model):
             move.inventory_adjustment_id = adjustment
             rec.to_do = False
         return res
+
+    @api.model
+    def _unlink_zero_quants(self):
+        # Prevents unlinking of the quants until the inventory adjustments are completed
+        # inherit the method _unlink_zero_quants without totally overwrite is not
+        # possible witohut a hook.
+        to_do_quants = self.env["stock.quant"].search([("to_do", "=", True)])
+        if to_do_quants:
+            return True
+        else:
+            return super()._unlink_zero_quants()

--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+
 from odoo import api, fields, models
 
 
@@ -18,20 +22,28 @@ class StockQuant(models.Model):
                     or rec.location_id in x.location_ids.child_ids
                 )
             )
+            # For zero quants that are actually zero quantity this will return the
+            # last stock move line, because no one was created, that is the reason
+            # for the create_date filter, it is not accurate but better than link
+            # old stock moves
+            date_today = datetime.now()
+            date_to_create = date_today - relativedelta(minutes=10)
             moves = record_moves.search(
                 [
                     ("product_id", "=", rec.product_id.id),
                     ("lot_id", "=", rec.lot_id.id),
                     ("company_id", "=", rec.company_id.id),
+                    ("create_date", ">", date_to_create),
                     "|",
                     ("location_id", "=", rec.location_id.id),
                     ("location_dest_id", "=", rec.location_id.id),
                 ],
                 order="create_date asc",
             )
-            move = moves[len(moves) - 1]
-            adjustment.stock_move_ids |= move
-            move.inventory_adjustment_id = adjustment
+            if len(moves):
+                move = moves[len(moves) - 1]
+                adjustment.stock_move_ids |= move
+                move.inventory_adjustment_id = adjustment
             rec.to_do = False
         return res
 

--- a/stock_inventory/readme/DESCRIPTION.rst
+++ b/stock_inventory/readme/DESCRIPTION.rst
@@ -1,1 +1,3 @@
 This module allows to group Inventory Adjustments and have a group traceability (like before Odoo 15.0).
+Products without stock added so easy up the quant creation of those, if they counted
+quantity is zero for those products the quants created will be deleted by Odoo anyway.


### PR DESCRIPTION
For cycle counts or big counts it is common to count products that are not in stock because:

- Some units of products that were supposed not be qty remaining are counted
- It is useful to have the full list of products for verification purposes, verify that there are not actual any quantity for that product.

Because of that, we are precreating the quants for those products. When the inventory adjustment finishes then the automated process in Odoo will delete the created zero quants so there is no issue at this respect.

Known issues:
- For products that are tracked by lots, the combinations for products and lots can be huge, specially for serial number. For those kind of adjustments (based on lot) this feature is not available
- For letting the user to decide if including products with zero stock I am thinking on putting some checkbox somewhere, I am thinking on a boolean at company level, but I am not sure. For now, that is not implemented
- The link of stock move lines to quants is not consistent, it assumes a stock move line was created, but it some cases it won't happen. I added an extra domain based on create_date but that is not consistent too.

cc @ForgeFlow

