### PR TITLE
[15.0][FIX] stock_orderpoint_generator: fix test test_errors

### DIFF
--- a/stock_orderpoint_generator/tests/test_orderpoint_generator.py
+++ b/stock_orderpoint_generator/tests/test_orderpoint_generator.py
@@ -15,7 +15,9 @@ class TestOrderpointGenerator(TransactionCase):
         cls.orderpoint_model = cls.env["stock.warehouse.orderpoint"]
         cls.orderpoint_template_model = cls.env["stock.warehouse.orderpoint.template"]
         cls.product_model = cls.env["product.product"]
-        cls.attr = cls.env["product.attribute"].create({"name": "Size"})
+        cls.attr = cls.env["product.attribute"].create(
+            {"name": "stock_orderpoint_generator attribute"}
+        )
         cls.attr_value_a = cls.env["product.attribute.value"].create(
             {"name": "A", "attribute_id": cls.attr.id}
         )


### PR DESCRIPTION
The Size attribute is already defined in the point_of_sale module so when both modules are installed an error occurs in the tests. This is solved by changing the name of the attribute in the tests of the stock_orderpoint_generator module.

![image](https://github.com/OCA/stock-logistics-warehouse/assets/118818446/c973e798-b062-46de-8606-77b225e54c41)

cc @Tecnativa TT41548

@pedrobaeza @victoralmau please review