### PR TITLE
[14.0][FIX] stock_available_mrp: bom component uom

### DIFF
--- a/stock_available_mrp/models/product_product.py
+++ b/stock_available_mrp/models/product_product.py
@@ -149,7 +149,14 @@ class ProductProduct(models.Model):
                 if current_line._skip_bom_line(current_product):
                     continue
 
-                line_quantity = current_qty * current_line.product_qty
+                line_quantity = (
+                    current_qty
+                    * current_line.product_uom_id._compute_quantity(
+                        current_line.product_qty,
+                        current_line.product_id.uom_id,
+                        rounding_method="DOWN",
+                    )
+                )
 
                 sub_bom = first(current_line.product_id.bom_ids)
                 if sub_bom.type == "phantom":


### PR DESCRIPTION
This commit fix the issue on potential qty compute when any component has a different uom than the form one.
Right now is using the qtys like if the component qty and the product available qty were using the same uom even when this is not the case.