### PR TITLE
[FIX] stock_reserve - Notes field gets squashed into unreadable width due to v16 quirk

### DIFF
--- a/stock_reserve/view/stock_reserve.xml
+++ b/stock_reserve/view/stock_reserve.xml
@@ -69,8 +69,8 @@
                             <field name="location_id" />
                             <field name="location_dest_id" />
                         </group>
-                        <group name="note" string="Notes">
-                            <field name="note" nolabel="1" />
+                        <group name="note" colspan="2">
+                            <field name="note" />
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
Notes field is not properly readable due to squashed width.

![image](https://github.com/OCA/stock-logistics-warehouse/assets/53917021/d11452c0-09c7-4af8-9d02-dc2a20f41897)
