### PR TITLE
[15.0][IMP] stock_request_mrp: Change invisible attr of the action_view_stock_request action of mrp.production

### DIFF
--- a/stock_request_mrp/models/mrp_production.py
+++ b/stock_request_mrp/models/mrp_production.py
@@ -23,6 +23,10 @@ class MrpProduction(models.Model):
         for rec in self:
             rec.stock_request_count = len(rec.stock_request_ids)
 
+    def _get_stock_requests(self):
+        """Get all stock requests from action (allows inheritance by other modules)."""
+        return self.mapped("stock_request_ids")
+
     def action_view_stock_request(self):
         """
         :return dict: dictionary value for created view
@@ -30,8 +34,8 @@ class MrpProduction(models.Model):
         action = self.env["ir.actions.act_window"]._for_xml_id(
             "stock_request.action_stock_request_form"
         )
-
         requests = self.mapped("stock_request_ids")
+        requests = self._get_stock_requests()
         if len(requests) > 1:
             action["domain"] = [("id", "in", requests.ids)]
         elif requests:

--- a/stock_request_mrp/views/mrp_production_views.xml
+++ b/stock_request_mrp/views/mrp_production_views.xml
@@ -17,7 +17,7 @@
                     name="action_view_stock_request"
                     class="oe_stat_button"
                     icon="fa-chain"
-                    attrs="{'invisible':[('stock_request_ids', '=', [])]}"
+                    attrs="{'invisible':[('stock_request_count', '=', 0)]}"
                 >
                     <field
                         name="stock_request_count"


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/1824

Changes done:
- [x] Change invisible attr of the `action_view_stock_request` action of `mrp.production`
- [x] Add `_get_stock_requests()` method to get all stock requests from action (allows inheritance by other modules)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT43297