### PR TITLE
[15.0][IMP] stock_request_purchase: Change invisible attr of the action_view_stock_request action of purchase.order

### DIFF
--- a/stock_request_purchase/models/purchase_order.py
+++ b/stock_request_purchase/models/purchase_order.py
@@ -22,6 +22,10 @@ class PurchaseOrder(models.Model):
             rec.stock_request_ids = rec.order_line.mapped("stock_request_ids")
             rec.stock_request_count = len(rec.stock_request_ids)
 
+    def _get_stock_requests(self):
+        """Get all stock requests from action (allows inheritance by other modules)."""
+        return self.mapped("stock_request_ids")
+
     def action_view_stock_request(self):
         """
         :return dict: dictionary value for created view
@@ -30,7 +34,7 @@ class PurchaseOrder(models.Model):
             "stock_request.action_stock_request_form"
         )
 
-        requests = self.mapped("stock_request_ids")
+        requests = self._get_stock_requests()
         if len(requests) > 1:
             action["domain"] = [("id", "in", requests.ids)]
         elif requests:

--- a/stock_request_purchase/views/purchase_order_views.xml
+++ b/stock_request_purchase/views/purchase_order_views.xml
@@ -17,7 +17,7 @@
                     name="action_view_stock_request"
                     class="oe_stat_button"
                     icon="fa-chain"
-                    attrs="{'invisible':[('stock_request_ids', '=', [])]}"
+                    attrs="{'invisible':[('stock_request_count', '=', 0)]}"
                 >
                     <field
                         name="stock_request_count"


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/1825

Changes done:
- [x] Change invisible attr of the `action_view_stock_request` action of `purchase.order`
- [x] Add `_get_stock_requests()` method to get all stock requests from action (allows inheritance by other modules)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT43297