### PR TITLE
[14.0][IMP] stock_reserve_rule: add full bin strategy

### DIFF
--- a/stock_reserve_rule/models/stock_reserve_rule.py
+++ b/stock_reserve_rule/models/stock_reserve_rule.py
@@ -133,6 +133,7 @@ class StockReserveRuleRemoval(models.Model):
             ("default", "Default Removal Strategy"),
             ("empty_bin", "Empty Bins"),
             ("packaging", "Full Packaging"),
+            ("full_bin", "Full Bin"),
         ],
         required=True,
         default="default",
@@ -142,7 +143,8 @@ class StockReserveRuleRemoval(models.Model):
         "Empty Bins: take goods from a location only if the bin is"
         " empty afterwards.\n"
         "Full Packaging: take goods from a location only if the location "
-        "quantity matches a packaging quantity (do not open boxes).",
+        "quantity matches a packaging quantity (do not open boxes).\n"
+        "Full Bin: take goods from a location if it reserves all its content",
     )
 
     packaging_type_ids = fields.Many2many(
@@ -296,3 +298,38 @@ class StockReserveRuleRemoval(models.Model):
                     # compute how much packaging we can get
                     take = (need // pack_quantity) * pack_quantity
                     need = yield location, location_quantity, take, None, None
+
+    def _apply_strategy_full_bin(self, quants):
+        need = yield
+        # Only location with nothing reserved can be fully emptied
+        quants = quants.filtered(lambda q: q.reserved_quantity == 0)
+        # Group by location (in this removal strategies, we want to consider
+        # the total quantity held in a location).
+        quants_per_bin = quants._group_by_location()
+        # We take goods only if we empty the bin.
+        # The original ordering (fefo, fifo, ...) must be kept.
+        product = fields.first(quants).product_id
+        rounding = product.uom_id.rounding
+        locations_with_other_quants = [
+            group["location_id"][0]
+            for group in quants.read_group(
+                [
+                    ("location_id", "in", quants.location_id.ids),
+                    ("product_id", "not in", quants.product_id.ids),
+                    ("quantity", ">", 0),
+                ],
+                ["location_id"],
+                "location_id",
+            )
+        ]
+        for location, location_quants in quants_per_bin:
+            if location.id in locations_with_other_quants:
+                continue
+
+            location_quantity = sum(location_quants.mapped("quantity"))
+
+            if location_quantity <= 0:
+                continue
+
+            if float_compare(need, location_quantity, rounding) != -1:
+                need = yield location, location_quantity, need, None, None


### PR DESCRIPTION
The full empty bin rule is like the empty bin rule, but it should take everything. That means there can not be any pre existing reservations.

ref.: rau-206