### PR TITLE
[14.0][FIX] stock_request: Change to free_qty field to use stock

### DIFF
--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -404,7 +404,7 @@ class StockRequest(models.Model):
                     float_compare(
                         request.product_id.sudo()
                         .with_context(location=request.location_id.id)
-                        .qty_available,
+                        .free_qty,
                         request.product_uom_qty,
                         precision_digits=precision,
                     )


### PR DESCRIPTION
We need to use the `free_qty` field because it is the one that has the correct value if for example we have stock reservations.

@Tecnativa TT43413