### PR TITLE
[IMP] stock_move_packaging_qty: display in PDF reports

### DIFF
--- a/stock_move_packaging_qty/__manifest__.py
+++ b/stock_move_packaging_qty/__manifest__.py
@@ -8,7 +8,11 @@
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "category": "Warehouse",
     "depends": ["stock"],
-    "data": ["views/stock_picking_form_view.xml", "views/stock_move_tree_view.xml"],
+    "data": [
+        "views/report_stock_picking.xml",
+        "views/stock_move_tree_view.xml",
+        "views/stock_picking_form_view.xml",
+    ],
     "license": "LGPL-3",
     "installable": True,
     "maintainers": ["yajo"],

--- a/stock_move_packaging_qty/readme/DESCRIPTION.rst
+++ b/stock_move_packaging_qty/readme/DESCRIPTION.rst
@@ -1,1 +1,1 @@
-Add packaging fields in the stock moves
+Add packaging fields in the stock moves and their reports.

--- a/stock_move_packaging_qty/views/report_stock_picking.xml
+++ b/stock_move_packaging_qty/views/report_stock_picking.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Moduon Team S.L.
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0) -->
+<data>
+    <template id="report_picking" inherit_id="stock.report_picking">
+        <xpath expr="//span[@t-field='ml.product_uom_id']" position="after">
+            <div
+                t-if="ml.move_id.product_packaging_id"
+                class="text-secondary"
+                groups="product.group_stock_packaging"
+            >
+                <t
+                    t-set="ml_packaging_qty"
+                    t-value="(ml.qty_done if o.state == 'done' else ml.reserved_uom_qty) / ml.move_id.product_packaging_id.qty"
+                />
+                <span t-field="ml.move_id.product_packaging_id" />:
+                <span t-out="ml_packaging_qty" />
+            </div>
+        </xpath>
+    </template>
+
+    <template id="report_delivery_document" inherit_id="stock.report_delivery_document">
+        <!-- DOCS https://github.com/orgs/OCA/discussions/111 -->
+        <xpath
+            expr="//table[@name='stock_move_table']/tbody//td[
+                1 + count(
+                    //table[@name='stock_move_table']
+                    //th[@name='th_sm_ordered']
+                    /preceding-sibling::*
+                )
+            ]"
+            position="inside"
+        >
+            <div
+                t-if="move.product_packaging_id"
+                class="text-secondary"
+                groups="product.group_stock_packaging"
+            >
+                <span t-field="move.product_packaging_id" />:
+                <span t-field="move.product_packaging_qty" />
+            </div>
+        </xpath>
+    </template>
+</data>


### PR DESCRIPTION
Directly display qty on delivery slip.

![flameshot_2023-09-08_11-06_1](https://github.com/OCA/stock-logistics-warehouse/assets/973709/1daa52d8-8d92-4b65-9ffe-2ce27d134626)


In the case of picking operations report, compute the qty based on the one found in the `stock.move.line` and the `product.packaging` ratio.

![flameshot_2023-09-08_11-05](https://github.com/OCA/stock-logistics-warehouse/assets/973709/7498d494-42a7-4fea-845b-18532178e852)



@moduon MT-3774