### PR TITLE
[14.0][IMP] stock_request_mrp: Add exceptions from production cancel to stock.request or stock.request.order

### DIFF
--- a/stock_request_mrp/__manifest__.py
+++ b/stock_request_mrp/__manifest__.py
@@ -1,5 +1,6 @@
 # Copyright 2017-20 ForgeFlow S.L. (https://www.forgeflow.com)
 # Copyright 2022 Tecnativa - Pedro M. Baeza
+# Copyright 2023 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 {
@@ -16,6 +17,7 @@
         "views/stock_request_views.xml",
         "views/stock_request_order_views.xml",
         "views/mrp_production_views.xml",
+        "views/stock_request_templates.xml",
     ],
     "installable": True,
     "auto_install": True,

--- a/stock_request_mrp/i18n/es.po
+++ b/stock_request_mrp/i18n/es.po
@@ -6,15 +6,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2023-01-24 12:44+0000\n"
+"POT-Creation-Date: 2023-09-11 07:12+0000\n"
+"PO-Revision-Date: 2023-09-11 09:13+0200\n"
 "Last-Translator: Víctor Martínez <victor.martinez@tecnativa.com>\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#. module: stock_request_mrp
+#: model_terms:ir.ui.view,arch_db:stock_request_mrp.exception_mrp_cancel
+msgid ": cancelled"
+msgstr ": cancelado"
 
 #. module: stock_request_mrp
 #: model:ir.model.fields,field_description:stock_request_mrp.field_mrp_production__display_name
@@ -23,6 +29,21 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_request_mrp.field_stock_rule__display_name
 msgid "Display Name"
 msgstr "Nombre mostrado"
+
+#. module: stock_request_mrp
+#: model_terms:ir.ui.view,arch_db:stock_request_mrp.exception_mrp_cancel
+msgid "Exception(s) occurred on the stock request order(s):"
+msgstr "Excepción(es) ocurridas en lo(s) pedido(s) de existencia(s):"
+
+#. module: stock_request_mrp
+#: model_terms:ir.ui.view,arch_db:stock_request_mrp.exception_mrp_cancel
+msgid "Exception(s) occurred on the stock request(s):"
+msgstr "Excepción(es) ocurridas en la(s) solicitud(es) de existencia(s):"
+
+#. module: stock_request_mrp
+#: model_terms:ir.ui.view,arch_db:stock_request_mrp.exception_mrp_cancel
+msgid "Exception(s):"
+msgstr "Excepción(es):"
 
 #. module: stock_request_mrp
 #: model:ir.model.fields,field_description:stock_request_mrp.field_mrp_production__id
@@ -44,7 +65,12 @@ msgstr "Última modificación el"
 #: model_terms:ir.ui.view,arch_db:stock_request_mrp.stock_request_order_form
 #: model_terms:ir.ui.view,arch_db:stock_request_mrp.view_stock_request_form
 msgid "MOs"
-msgstr ""
+msgstr "OPs"
+
+#. module: stock_request_mrp
+#: model_terms:ir.ui.view,arch_db:stock_request_mrp.exception_mrp_cancel
+msgid "Manual actions may be needed."
+msgstr "Acciones manuales podrían ser necesitadas."
 
 #. module: stock_request_mrp
 #: model:ir.model.fields,field_description:stock_request_mrp.field_stock_request__production_ids
@@ -92,6 +118,5 @@ msgstr "Regla de Inventario"
 #. module: stock_request_mrp
 #: code:addons/stock_request_mrp/models/stock_request.py:0
 #, python-format
-msgid ""
-"You have linked to a Manufacture Order that belongs to another company."
+msgid "You have linked to a Manufacture Order that belongs to another company."
 msgstr ""

--- a/stock_request_mrp/i18n/stock_request_mrp.pot
+++ b/stock_request_mrp/i18n/stock_request_mrp.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-09-11 07:12+0000\n"
+"PO-Revision-Date: 2023-09-11 07:12+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,11 +16,31 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_request_mrp
+#: model_terms:ir.ui.view,arch_db:stock_request_mrp.exception_mrp_cancel
+msgid ": cancelled"
+msgstr ""
+
+#. module: stock_request_mrp
 #: model:ir.model.fields,field_description:stock_request_mrp.field_mrp_production__display_name
 #: model:ir.model.fields,field_description:stock_request_mrp.field_stock_request__display_name
 #: model:ir.model.fields,field_description:stock_request_mrp.field_stock_request_order__display_name
 #: model:ir.model.fields,field_description:stock_request_mrp.field_stock_rule__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: stock_request_mrp
+#: model_terms:ir.ui.view,arch_db:stock_request_mrp.exception_mrp_cancel
+msgid "Exception(s) occurred on the stock request order(s):"
+msgstr ""
+
+#. module: stock_request_mrp
+#: model_terms:ir.ui.view,arch_db:stock_request_mrp.exception_mrp_cancel
+msgid "Exception(s) occurred on the stock request(s):"
+msgstr ""
+
+#. module: stock_request_mrp
+#: model_terms:ir.ui.view,arch_db:stock_request_mrp.exception_mrp_cancel
+msgid "Exception(s):"
 msgstr ""
 
 #. module: stock_request_mrp
@@ -41,6 +63,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock_request_mrp.stock_request_order_form
 #: model_terms:ir.ui.view,arch_db:stock_request_mrp.view_stock_request_form
 msgid "MOs"
+msgstr ""
+
+#. module: stock_request_mrp
+#: model_terms:ir.ui.view,arch_db:stock_request_mrp.exception_mrp_cancel
+msgid "Manual actions may be needed."
 msgstr ""
 
 #. module: stock_request_mrp

--- a/stock_request_mrp/models/mrp_production.py
+++ b/stock_request_mrp/models/mrp_production.py
@@ -1,5 +1,6 @@
 # Copyright 2020 ForgeFlow S.L. (https://www.forgeflow.com)
 # Copyright 2022 Tecnativa - Pedro M. Baeza
+# Copyright 2023 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
@@ -74,3 +75,66 @@ class MrpProduction(models.Model):
                 for request in self.stock_request_ids
             ]
         return res
+
+    def _action_cancel(self):
+        """Add exception to stock.request or stock.request.order."""
+        res = super()._action_cancel()
+        self._exception_on_stock_request()
+        return res
+
+    def _get_all_sources(self):
+        """Method to obtain first parent."""
+        res = self.env["mrp.production"]
+        for item in self:
+            for source in item._get_sources():
+                res += source
+                res += source._get_all_sources()
+        return res
+
+    def _exception_on_stock_request(self):
+        """Group by stock.request or stock.request.order with all productions.
+        We need to get the parent production so that it applies if a level 3
+        production is cancelled for example.
+        We check that an exception does not already exist because it is passed
+        through the cancel method several times."""
+
+        def _render_note_exception_request(rendering_context):
+            item = rendering_context[0]
+            key = item._name.replace(".", "_")
+            values = {
+                "productions": rendering_context[1],
+                key: item,
+            }
+            template = self.env.ref("stock_request_mrp.exception_mrp_cancel")
+            return template._render(values=values)
+
+        requests_info = {}
+        request_orders_info = {}
+        production_model = self.env["mrp.production"]
+        for item in self:
+            sources = item._get_all_sources() or item
+            for request in sources.stock_request_ids:
+                if request.order_id:
+                    if request.order_id not in request_orders_info:
+                        request_orders_info[request.order_id] = production_model
+                    request_orders_info[request.order_id] += item
+                else:
+                    if request not in requests_info:
+                        requests_info[request] = production_model
+                    requests_info[request] += item
+        picking_model = self.env["stock.picking"]
+        exception = self.env.ref("mail.mail_activity_data_warning")
+        # stock.request
+        for request, productions in requests_info.items():
+            if not any(
+                request.activity_ids.filtered(lambda x: x.activity_type_id == exception)
+            ):
+                documents = {(request, self.env.user): (request, productions)}
+                picking_model._log_activity(_render_note_exception_request, documents)
+        # stock.request.order
+        for order, productions in request_orders_info.items():
+            if not any(
+                order.activity_ids.filtered(lambda x: x.activity_type_id == exception)
+            ):
+                documents = {(order, self.env.user): (order, productions)}
+                picking_model._log_activity(_render_note_exception_request, documents)

--- a/stock_request_mrp/tests/test_stock_request_mrp.py
+++ b/stock_request_mrp/tests/test_stock_request_mrp.py
@@ -1,6 +1,6 @@
 # Copyright 2016-20 ForgeFlow S.L. (https://www.forgeflow.com)
 # Copyright 2022 Tecnativa - Pedro M. Baeza
-# Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2022-2023 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
 from odoo import fields
@@ -23,6 +23,8 @@ class TestStockRequestMrp(TestStockRequest):
         self.raw_2 = self._create_product("LC", "Lace", False)
         self._update_qty_in_location(self.warehouse.lot_stock_id, self.raw_2, 10)
         self.bom = self._create_mrp_bom(self.product, [self.raw_1, self.raw_2])
+        self.mto_route = self.env.ref("stock.route_warehouse0_mto")
+        self.mto_route.active = True
 
     def _update_qty_in_location(self, location, product, quantity):
         self.env["stock.quant"]._update_available_quantity(product, location, quantity)
@@ -64,6 +66,19 @@ class TestStockRequestMrp(TestStockRequest):
                 item_form.product_uom_qty = product_data[1]
         return order_form.save()
 
+    def _create_stock_request_only(self, user, product_data):
+        request_form = Form(
+            self.stock_request.with_user(user).with_context(
+                default_company_id=self.main_company.id,
+                default_warehouse_id=self.warehouse.id,
+                default_location_id=self.warehouse.lot_stock_id,
+            )
+        )
+        request_form.expected_date = fields.Date.today()
+        request_form.product_id = product_data[0]
+        request_form.product_uom_qty = product_data[1]
+        return request_form.save()
+
     def test_create_request_01(self):
         """Single Stock request with buy rule"""
         order = self._create_stock_request(self.stock_request_user, [(self.product, 5)])
@@ -104,6 +119,74 @@ class TestStockRequestMrp(TestStockRequest):
         self.assertEqual(production.state, "confirmed")
         production.action_cancel()
         self.assertEqual(order.state, "cancel")
+
+    def test_stock_request_order_activity_exception_01(self):
+        order = self._create_stock_request(self.stock_request_user, [(self.product, 5)])
+        order.action_confirm()
+        production = fields.first(order.stock_request_ids.production_ids)
+        production.action_cancel()
+        self.assertIn(
+            self.env.ref("mail.mail_activity_data_warning"),
+            order.activity_ids.mapped("activity_type_id"),
+        )
+
+    def test_stock_request_order_activity_exception_02(self):
+        self.product.write(
+            {"route_ids": [(6, 0, [self.route_manufacture.id, self.mto_route.id])]}
+        )
+        self.raw_2.write(
+            {"route_ids": [(6, 0, [self.route_manufacture.id, self.mto_route.id])]}
+        )
+        self.bom.bom_line_ids.filtered(
+            lambda x: x.product_id == self.raw_2
+        ).product_qty = 2
+        raw_2_component = self._create_product("SL", "Sole component", False)
+        self._create_mrp_bom(self.raw_2, [raw_2_component])
+        order = self._create_stock_request(self.stock_request_user, [(self.product, 6)])
+        order.action_confirm()
+        production = fields.first(order.stock_request_ids.production_ids)
+        production_child = production._get_children()
+        production_child.action_cancel()
+        self.assertIn(
+            self.env.ref("mail.mail_activity_data_warning"),
+            order.activity_ids.mapped("activity_type_id"),
+        )
+
+    def test_stock_request_activity_exception_01(self):
+        request = self._create_stock_request_only(
+            self.stock_request_user, (self.product, 5)
+        )
+        request.action_confirm()
+        production = fields.first(request.production_ids)
+        production.action_cancel()
+        self.assertIn(
+            self.env.ref("mail.mail_activity_data_warning"),
+            request.activity_ids.mapped("activity_type_id"),
+        )
+
+    def test_stock_request_activity_exception_02(self):
+        self.product.write(
+            {"route_ids": [(6, 0, [self.route_manufacture.id, self.mto_route.id])]}
+        )
+        self.raw_2.write(
+            {"route_ids": [(6, 0, [self.route_manufacture.id, self.mto_route.id])]}
+        )
+        self.bom.bom_line_ids.filtered(
+            lambda x: x.product_id == self.raw_2
+        ).product_qty = 2
+        raw_2_component = self._create_product("SL", "Sole component", False)
+        self._create_mrp_bom(self.raw_2, [raw_2_component])
+        request = self._create_stock_request_only(
+            self.stock_request_user, (self.product, 6)
+        )
+        request.action_confirm()
+        production = fields.first(request.production_ids)
+        production_child = production._get_children()
+        production_child.action_cancel()
+        self.assertIn(
+            self.env.ref("mail.mail_activity_data_warning"),
+            request.activity_ids.mapped("activity_type_id"),
+        )
 
     def test_view_actions(self):
         order = self._create_stock_request(self.stock_request_user, [(self.product, 5)])

--- a/stock_request_mrp/views/stock_request_templates.xml
+++ b/stock_request_mrp/views/stock_request_templates.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="exception_mrp_cancel">
+        <div class="alert alert-warning" role="alert">
+            <t t-if="stock_request_order">
+                Exception(s) occurred on the stock request order(s):
+                <a
+                    href="#"
+                    data-oe-model="stock.request.order"
+                    t-att-data-oe-id="stock_request_order.id"
+                ><t t-esc="stock_request_order.name" /></a>.
+            </t>
+            <t t-if="stock_request">
+                Exception(s) occurred on the stock request(s):
+                <a
+                    href="#"
+                    data-oe-model="stock.request"
+                    t-att-data-oe-id="stock_request.id"
+                ><t t-esc="stock_request.name" /></a>.
+            </t>
+            Manual actions may be needed.
+            <div class="mt16">
+                <p>Exception(s):</p>
+                <ul t-foreach="productions" t-as="production">
+                    <li>
+                        <a
+                            href="#"
+                            data-oe-model="mrp.production"
+                            t-att-data-oe-id="production.id"
+                        ><t t-esc="production.name" /></a>: cancelled
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </template>
+</odoo>


### PR DESCRIPTION
Add exceptions from production cancel to `stock.request` or `stock.request.order`

Steps to reproduce it:

**A1: Only with `stock.request` and simple manufacture**
- Create a stock request of a product to be manufactured.
- Confirm the stock request
- Go to the production and cancel it
- An exception will have been added to the stock.request indicating that the production has been cancelled.

**A2: Only with `stock.request` and submanufacturing**
- Create a stock request of a by-product to be manufactured.
- Confirm the stock request
- Go to the production and click on the smart-button child MOs.
- Cancel the manufacture of the by-product.
- An exception will have been added to the stock.request indicating that the child production has been cancelled.

**B1: Only with **stock.request.order** and simple production**
- Do the same steps as in A1 but with request order

**B2: Only with **stock.request.order** and submanufacturing**
- Doe the same steps as in A2 but with request order.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT44811