### PR TITLE
[14.0][IMP] stock_request_purchase: Add exceptions from purchase order cancel to stock.request or stock.request.order

### DIFF
--- a/stock_request_purchase/__manifest__.py
+++ b/stock_request_purchase/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2017-20 ForgeFlow S.L. (https://www.forgeflow.com)
+# Copyright 2023 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 {
@@ -14,6 +15,7 @@
         "security/ir.model.access.csv",
         "views/stock_request_views.xml",
         "views/stock_request_order_views.xml",
+        "views/stock_request_templates.xml",
         "views/purchase_order_views.xml",
     ],
     "installable": True,

--- a/stock_request_purchase/i18n/es.po
+++ b/stock_request_purchase/i18n/es.po
@@ -8,22 +8,80 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-02 03:44+0000\n"
-"PO-Revision-Date: 2020-01-17 05:13+0000\n"
+"POT-Creation-Date: 2023-09-11 09:27+0000\n"
+"PO-Revision-Date: 2023-09-11 11:28+0200\n"
 "Last-Translator: Nelson Ramírez Sánchez <info@konos.cl>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.10\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#. module: stock_request_purchase
+#: model_terms:ir.ui.view,arch_db:stock_request_purchase.exception_po_cancel
+msgid ": cancelled"
+msgstr ": cancelado"
+
+#. module: stock_request_purchase
+#: model:ir.model.fields,field_description:stock_request_purchase.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:stock_request_purchase.field_purchase_order_line__display_name
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request__display_name
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request_order__display_name
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_rule__display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: stock_request_purchase
+#: model_terms:ir.ui.view,arch_db:stock_request_purchase.exception_po_cancel
+msgid "Exception(s) occurred on the stock request order(s):"
+msgstr "Excepción(es) ocurridas en lo(s) pedido(s) de existencia(s):"
+
+#. module: stock_request_purchase
+#: model_terms:ir.ui.view,arch_db:stock_request_purchase.exception_po_cancel
+msgid "Exception(s) occurred on the stock request(s):"
+msgstr "Excepción(es) ocurridas en la(s) solicitud(es) de existencia(s):"
+
+#. module: stock_request_purchase
+#: model_terms:ir.ui.view,arch_db:stock_request_purchase.exception_po_cancel
+msgid "Exception(s):"
+msgstr "Excepción(es):"
+
+#. module: stock_request_purchase
+#: model:ir.model.fields,field_description:stock_request_purchase.field_purchase_order__id
+#: model:ir.model.fields,field_description:stock_request_purchase.field_purchase_order_line__id
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request__id
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request_order__id
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_rule__id
+msgid "ID"
+msgstr "ID"
+
+#. module: stock_request_purchase
+#: model:ir.model.fields,field_description:stock_request_purchase.field_purchase_order____last_update
+#: model:ir.model.fields,field_description:stock_request_purchase.field_purchase_order_line____last_update
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request____last_update
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request_order____last_update
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_rule____last_update
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: stock_request_purchase
+#: model_terms:ir.ui.view,arch_db:stock_request_purchase.exception_po_cancel
+msgid "Manual actions may be needed."
+msgstr "Acciones manuales podrían ser necesitadas."
 
 #. module: stock_request_purchase
 #: model_terms:ir.ui.view,arch_db:stock_request_purchase.stock_request_order_form
 #: model_terms:ir.ui.view,arch_db:stock_request_purchase.view_stock_request_form
 msgid "Purchase"
 msgstr "Compra"
+
+#. module: stock_request_purchase
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request__purchase_count
+#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request_order__purchase_count
+msgid "Purchase Count"
+msgstr "Número de todas las compras"
 
 #. module: stock_request_purchase
 #: model:ir.model,name:stock_request_purchase.model_purchase_order
@@ -46,12 +104,6 @@ msgstr "Líneas de pedido de compra"
 #: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request_order__purchase_ids
 msgid "Purchase Orders"
 msgstr "Pedidos de compras"
-
-#. module: stock_request_purchase
-#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request__purchase_count
-#: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request_order__purchase_count
-msgid "Purchase count"
-msgstr "# de Compras"
 
 #. module: stock_request_purchase
 #: model:ir.model,name:stock_request_purchase.model_stock_request
@@ -98,6 +150,3 @@ msgid ""
 "You have linked to a purchase order line that belongs to another company."
 msgstr ""
 "Ha seleccionada una línea de pedido de compras que pertenece a otra compañía."
-
-#~ msgid "Procurement Rule"
-#~ msgstr "Regla de abastecimiento"

--- a/stock_request_purchase/i18n/stock_request_purchase.pot
+++ b/stock_request_purchase/i18n/stock_request_purchase.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-09-11 09:27+0000\n"
+"PO-Revision-Date: 2023-09-11 09:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,12 +16,32 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_request_purchase
+#: model_terms:ir.ui.view,arch_db:stock_request_purchase.exception_po_cancel
+msgid ": cancelled"
+msgstr ""
+
+#. module: stock_request_purchase
 #: model:ir.model.fields,field_description:stock_request_purchase.field_purchase_order__display_name
 #: model:ir.model.fields,field_description:stock_request_purchase.field_purchase_order_line__display_name
 #: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request__display_name
 #: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request_order__display_name
 #: model:ir.model.fields,field_description:stock_request_purchase.field_stock_rule__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: stock_request_purchase
+#: model_terms:ir.ui.view,arch_db:stock_request_purchase.exception_po_cancel
+msgid "Exception(s) occurred on the stock request order(s):"
+msgstr ""
+
+#. module: stock_request_purchase
+#: model_terms:ir.ui.view,arch_db:stock_request_purchase.exception_po_cancel
+msgid "Exception(s) occurred on the stock request(s):"
+msgstr ""
+
+#. module: stock_request_purchase
+#: model_terms:ir.ui.view,arch_db:stock_request_purchase.exception_po_cancel
+msgid "Exception(s):"
 msgstr ""
 
 #. module: stock_request_purchase
@@ -38,6 +60,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_request_purchase.field_stock_request_order____last_update
 #: model:ir.model.fields,field_description:stock_request_purchase.field_stock_rule____last_update
 msgid "Last Modified on"
+msgstr ""
+
+#. module: stock_request_purchase
+#: model_terms:ir.ui.view,arch_db:stock_request_purchase.exception_po_cancel
+msgid "Manual actions may be needed."
 msgstr ""
 
 #. module: stock_request_purchase

--- a/stock_request_purchase/models/purchase_order.py
+++ b/stock_request_purchase/models/purchase_order.py
@@ -1,4 +1,5 @@
 # Copyright 2017-20 ForgeFlow S.L. (https://www.forgeflow.com)
+# Copyright 2023 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
@@ -21,6 +22,52 @@ class PurchaseOrder(models.Model):
         for rec in self:
             rec.stock_request_ids = rec.order_line.mapped("stock_request_ids")
             rec.stock_request_count = len(rec.stock_request_ids)
+
+    def button_cancel(self):
+        super().button_cancel()
+        self._exception_on_stock_request()
+
+    def _get_exception_on_stock_request_info(self):
+        requests_info = {}
+        request_orders_info = {}
+        purchase_model = self.env["purchase.order"]
+        for item in self.filtered(
+            lambda x: x.state == "cancel" and x.stock_request_ids
+        ):
+            for request in item.stock_request_ids:
+                if request.order_id:
+                    if request.order_id not in request_orders_info:
+                        request_orders_info[request.order_id] = purchase_model
+                    request_orders_info[request.order_id] += item
+                else:
+                    if request not in requests_info:
+                        requests_info[request] = purchase_model
+                    requests_info[request] += item
+        return requests_info, request_orders_info
+
+    def _exception_on_stock_request(self):
+        """Group by stock.request or stock.request.order with all orders."""
+
+        def _render_note_exception_request(rendering_context):
+            item = rendering_context[0]
+            key = item._name.replace(".", "_")
+            values = {
+                "orders": rendering_context[1],
+                key: item,
+            }
+            template = self.env.ref("stock_request_purchase.exception_po_cancel")
+            return template._render(values=values)
+
+        requests_info, request_orders_info = self._get_exception_on_stock_request_info()
+        picking_model = self.env["stock.picking"]
+        # stock.request
+        for request, purchase_orders in requests_info.items():
+            documents = {(request, self.env.user): (request, purchase_orders)}
+            picking_model._log_activity(_render_note_exception_request, documents)
+        # stock.request.order
+        for order, purchase_orders in request_orders_info.items():
+            documents = {(order, self.env.user): (order, purchase_orders)}
+            picking_model._log_activity(_render_note_exception_request, documents)
 
     def _get_stock_requests(self):
         """Get all stock requests from action (allows inheritance by other modules)."""

--- a/stock_request_purchase/tests/test_stock_request_purchase.py
+++ b/stock_request_purchase/tests/test_stock_request_purchase.py
@@ -217,6 +217,10 @@ class TestStockRequestPurchase(common.TransactionCase):
         self.assertEqual(stock_request.purchase_ids.state, "draft")
         stock_request.action_cancel()
         self.assertEqual(stock_request.purchase_ids.state, "cancel")
+        self.assertIn(
+            self.env.ref("mail.mail_activity_data_warning"),
+            stock_request.activity_ids.mapped("activity_type_id"),
+        )
 
     def test_view_actions(self):
         expected_date = fields.Datetime.now()
@@ -263,3 +267,8 @@ class TestStockRequestPurchase(common.TransactionCase):
         self.assertEqual(action["domain"], "[]")
         self.assertEqual("views" in action.keys(), True)
         self.assertEqual(action["res_id"], order.purchase_ids[0].id)
+        order.action_cancel()
+        self.assertIn(
+            self.env.ref("mail.mail_activity_data_warning"),
+            order.activity_ids.mapped("activity_type_id"),
+        )

--- a/stock_request_purchase/views/stock_request_templates.xml
+++ b/stock_request_purchase/views/stock_request_templates.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="exception_po_cancel">
+        <div class="alert alert-warning" role="alert">
+            <t t-if="stock_request_order">
+                Exception(s) occurred on the stock request order(s):
+                <a
+                    href="#"
+                    data-oe-model="stock.request.order"
+                    t-att-data-oe-id="stock_request_order.id"
+                ><t t-esc="stock_request_order.name" /></a>.
+            </t>
+            <t t-if="stock_request">
+                Exception(s) occurred on the stock request(s):
+                <a
+                    href="#"
+                    data-oe-model="stock.request"
+                    t-att-data-oe-id="stock_request.id"
+                ><t t-esc="stock_request.name" /></a>.
+            </t>
+            Manual actions may be needed.
+            <div class="mt16">
+                <p>Exception(s):</p>
+                <ul t-foreach="orders" t-as="order">
+                    <li>
+                        <a
+                            href="#"
+                            data-oe-model="purchase.order"
+                            t-att-data-oe-id="order.id"
+                        ><t t-esc="order.name" /></a>: cancelled
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </template>
+</odoo>


### PR DESCRIPTION
Add exceptions from purchase order cancel to `stock.request` or `stock.request.order`

Steps to reproduce it:

**A: Only with `stock.request`**
- Create a stock request of a product to be purchased.
- Confirm the stock request
- Go to the purchase order and cancel it
- An exception will have been added to the stock.request indicating that the purchase order has been cancelled.

**B: Only with `stock.request.order`**
- Do the same steps as in A but with request order

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT44811