### PR TITLE
[14.0][FIX] stock_request_*: Change to the correct icon

### DIFF
--- a/stock_request_mrp/views/stock_request_order_views.xml
+++ b/stock_request_mrp/views/stock_request_order_views.xml
@@ -14,7 +14,7 @@
                     type="object"
                     name="action_view_mrp_production"
                     class="oe_stat_button"
-                    icon="fa-truck"
+                    icon="fa-wrench"
                     attrs="{'invisible': [('production_count', '=', 0)]}"
                 >
                     <field name="production_count" widget="statinfo" string="MOs" />

--- a/stock_request_mrp/views/stock_request_views.xml
+++ b/stock_request_mrp/views/stock_request_views.xml
@@ -14,7 +14,7 @@
                     type="object"
                     name="action_view_mrp_production"
                     class="oe_stat_button"
-                    icon="fa-truck"
+                    icon="fa-wrench"
                     attrs="{'invisible': [('production_count', '=', 0)]}"
                 >
                     <field name="production_count" widget="statinfo" string="MOs" />

--- a/stock_request_purchase/views/stock_request_order_views.xml
+++ b/stock_request_purchase/views/stock_request_order_views.xml
@@ -14,7 +14,7 @@
                     type="object"
                     name="action_view_purchase"
                     class="oe_stat_button"
-                    icon="fa-truck"
+                    icon="fa-credit-card"
                     attrs="{'invisible': [('purchase_count', '=', 0)]}"
                 >
                     <field name="purchase_count" widget="statinfo" string="Purchase" />

--- a/stock_request_purchase/views/stock_request_views.xml
+++ b/stock_request_purchase/views/stock_request_views.xml
@@ -14,7 +14,7 @@
                     type="object"
                     name="action_view_purchase"
                     class="oe_stat_button"
-                    icon="fa-truck"
+                    icon="fa-credit-card"
                     attrs="{'invisible': [('purchase_count', '=', 0)]}"
                 >
                     <field name="purchase_count" widget="statinfo" string="Purchase" />


### PR DESCRIPTION
Change to the correct icon from purchase and mrp.

**Before**
![antes](https://github.com/OCA/stock-logistics-warehouse/assets/4117568/d3b82e8f-5a3f-47aa-9341-03f5040f2c6e)

**After**
![despues](https://github.com/OCA/stock-logistics-warehouse/assets/4117568/3435bd10-7b44-4b55-98e7-f6f92554a054)


@Tecnativa