### PR TITLE
[14.0][FIX] stock_move_location: Fix onchange and make editable

### DIFF
--- a/stock_move_location/tests/test_move_location.py
+++ b/stock_move_location/tests/test_move_location.py
@@ -251,3 +251,17 @@ class TestMoveLocation(TestsCommon):
         self.assertEqual(len(delivery_move.move_line_ids), 1)
         self.assertEqual(delivery_move.move_line_ids.product_uom_qty, 20.0)
         self.assertEqual(delivery_move.move_line_ids.location_id, wh_stock_shelf_3)
+
+    def test_wizard_different_destinations(self):
+        """
+        Create a picking whose line destinations are differents. The first line is sent
+        to the origin location.
+        """
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        wizard.onchange_origin_location()
+        wizard.stock_move_location_line_ids[0].write(
+            {"destination_location_id": self.internal_loc_1.id}
+        )
+        wizard.action_move_location()
+        locations = self.internal_loc_1 + self.internal_loc_2
+        self.assertEqual(wizard.picking_id.move_line_ids.location_dest_id, locations)

--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -147,8 +147,11 @@ class StockMoveLocationWizard(models.TransientModel):
 
     @api.onchange("destination_location_id")
     def _onchange_destination_location_id(self):
-        for line in self.stock_move_location_line_ids:
-            line.destination_location_id = self.destination_location_id
+        if self.env.context.get("active_model", False) == "stock.quant":
+            for line in self.stock_move_location_line_ids:
+                line.destination_location_id = self.destination_location_id
+        else:
+            self.create_lines()
 
     def _clear_lines(self):
         self.stock_move_location_line_ids = False
@@ -287,6 +290,8 @@ class StockMoveLocationWizard(models.TransientModel):
         return self.env.cr.dictfetchall()
 
     def _get_stock_move_location_lines_values(self):
+        if not (self.destination_location_id or self.origin_location_id):
+            return []
         product_obj = self.env["product.product"]
         product_data = []
         for group in self._get_group_quants():
@@ -324,18 +329,22 @@ class StockMoveLocationWizard(models.TransientModel):
             not self.env.context.get("origin_location_disable")
             and self.origin_location_id
         ):
-            lines = []
-            line_model = self.env["wiz.stock.move.location.line"]
-            for line_val in self._get_stock_move_location_lines_values():
-                if line_val.get("max_quantity") <= 0:
-                    continue
-                line = line_model.create(line_val)
-                line.max_quantity = line.get_max_quantity()
-                line.reserved_quantity = line.reserved_quantity
-                lines.append(line)
-            self.update(
-                {"stock_move_location_line_ids": [(6, 0, [line.id for line in lines])]}
-            )
+            self.create_lines()
+
+    def create_lines(self):
+        self._clear_lines()
+        lines = []
+        line_model = self.env["wiz.stock.move.location.line"]
+        for line_val in self._get_stock_move_location_lines_values():
+            if line_val.get("max_quantity") <= 0:
+                continue
+            line = line_model.create(line_val)
+            line.max_quantity = line.get_max_quantity()
+            line.reserved_quantity = line.reserved_quantity
+            lines.append(line)
+        self.update(
+            {"stock_move_location_line_ids": [(6, 0, [line.id for line in lines])]}
+        )
 
     def clear_lines(self):
         self._clear_lines()

--- a/stock_move_location/wizard/stock_move_location.xml
+++ b/stock_move_location/wizard/stock_move_location.xml
@@ -63,11 +63,7 @@
                                     readonly="1"
                                     force_save="1"
                                 />
-                                <field
-                                    name="destination_location_id"
-                                    readonly="1"
-                                    force_save="1"
-                                />
+                                <field name="destination_location_id" />
                                 <field
                                     name="lot_id"
                                     domain="[('product_id', '=', product_id)]"


### PR DESCRIPTION
This bug https://github.com/OCA/stock-logistics-warehouse/pull/1607 also happens in v15. I also took the functionality to edit each line destination location.

In this case, since the onchange on `Operation type` doesn't exists an error happens because there is no `Destination location` on the picking moves. 

![Captura desde 2023-09-12 11-39-19](https://github.com/OCA/stock-logistics-warehouse/assets/100672471/f8e0d612-faf8-4975-b55d-a53ee41301c6)
