### PR TITLE
FIX stock_move_common_dest: calling _compute_common_dest_move_ids on …

### DIFF
--- a/stock_move_common_dest/models/stock_move.py
+++ b/stock_move_common_dest/models/stock_move.py
@@ -5,7 +5,6 @@ from odoo.osv.expression import FALSE_DOMAIN
 
 
 class StockMove(models.Model):
-
     _inherit = "stock.move"
 
     common_dest_move_ids = fields.Many2many(
@@ -45,6 +44,10 @@ class StockMove(models.Model):
         "move_dest_ids.picking_id.move_lines.move_orig_ids",
     )
     def _compute_common_dest_move_ids(self):
+        if not self.ids:
+            for move in self:
+                move.common_dest_move_ids = [(5, 0, 0)]
+            return
         self._flush_common_dest_move_query()
         sql = self._common_dest_move_query()
         self.env.cr.execute(sql, (tuple(self.ids),))

--- a/stock_move_common_dest/tests/test_move_common_dest.py
+++ b/stock_move_common_dest/tests/test_move_common_dest.py
@@ -172,3 +172,15 @@ class TestCommonMoveDest(SavepointCase):
             ),
             pick_move_1a | pick_move_1b,
         )
+
+    def test_compute_common_dest_move_ids_on_new_record(self):
+        """Discovered while testing MRP with code such as::
+
+            with Form(cls.env["mrp.production"]) as mo_form:
+                mo_form.product_id = cls.product
+
+        This call _compute_common_dest_move_ids on a new instance
+        (without stock_move db record)
+        """
+        move = self.env["stock.move"].new({})
+        self.assertFalse(move.common_dest_move_ids)


### PR DESCRIPTION
…new record


This is mainly to fix some test in MRP where this module is installed.

To reproduce add a test like this:


```python
            with Form(cls.env["mrp.production"]) as mo_form:
                mo_form.product_id = cls.product
```

This will call _compute_common_dest_move_ids on a new instance which give the following trace-back:

```
[...]/lib/python3.8/site-packages/odoo/fields.py:2495: in __get__
    return super().__get__(records, owner)
[...]/lib/python3.8/site-packages/odoo/fields.py:1042: in __get__
    self.compute_value(recs)
[...]/lib/python3.8/site-packages/odoo/fields.py:1198: in compute_value
    records._compute_field_value(self)
[...]/lib/python3.8/site-packages/odoo/models.py:4079: in _compute_field_value
    odoo.fields.determine(field.compute, self)
[...]/lib/python3.8/site-packages/odoo/fields.py:82: in determine
    return needle(*args)
.gitaggregate/stock-logistics-warehouse-stock-move-common-dest/setup/stock_move_common_dest/odoo/addons/stock_move_common_dest/models/stock_move.py:50: in _compute_common_dest_move_ids
    self.env.cr.execute(sql, (tuple(self.ids),))
<decorator-gen-3>:2: in execute
    ???
[...]/lib/python3.8/site-packages/odoo/sql_db.py:101: in check
    return f(self, *args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <odoo.sql_db.Cursor object at 0x7f3367eaff10>
query = 'SELECT smmr.move_orig_id move_id\n            , array_agg(smmr2.move_orig_id) common_move_dest_ids\n            FROM ...g_id != smmr2.move_orig_id\n            AND smmr.move_orig_id IN %s\n            GROUP BY smmr.move_orig_id;\n        '
params = ((),), log_exceptions = None

    @check
    def execute(self, query, params=None, log_exceptions=None):
        if params and not isinstance(params, (tuple, list, dict)):
            # psycopg2's TypeError is not clear if you mess up the params
            raise ValueError("SQL query parameters should be a tuple, list or dict; got %r" % (params,))
    
        now = time.time()
        try:
            params = params or None
>           res = self._obj.execute(query, params)
E           psycopg2.errors.SyntaxError: ERREUR:  erreur de syntaxe sur ou près de « ) »
E           LIGNE 13 :             AND smmr.move_orig_id IN ()

```
