### PR TITLE
[14.0][FIX] stock_orderpoint_origin: correct procurement_group field for pickings

### DIFF
--- a/stock_orderpoint_origin/models/procurement_group.py
+++ b/stock_orderpoint_origin/models/procurement_group.py
@@ -26,7 +26,13 @@ class ProcurementGroup(models.Model):
                 if not line["document_in"] and line["document_out"]:
                     source_docs.add(line["document_out"])
             if source_docs:
-                source_groups = [x.procurement_group_id for x in source_docs]
+                # stock.picking object doesn't have field procurement_group_id,
+                # so we check if the source document is a picking to use the
+                # correct field (group_id)
+                source_groups = [
+                    x.procurement_group_id if x._name != "stock.picking" else x.group_id
+                    for x in source_docs
+                ]
                 source_names = ", ".join([x.name for x in source_docs])
                 new_origin = "%s (from %s)" % (source_names, procurement.origin)
                 new_procurement = procurement._replace(origin=new_origin)
@@ -34,4 +40,4 @@ class ProcurementGroup(models.Model):
                 new_procurements.append(new_procurement)
             else:
                 new_procurements.append(procurement)
-        return super().run(new_procurements, raise_user_error=True)
+        return super().run(new_procurements, raise_user_error)


### PR DESCRIPTION
Fine repush (squashed) of https://github.com/OCA/stock-logistics-warehouse/pull/1433.