### PR TITLE
[14.0][IMP] stock_location_package_restriction: Change no restriction value

### DIFF
--- a/stock_location_package_restriction/__manifest__.py
+++ b/stock_location_package_restriction/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Stock Location Package Restriction",
     "summary": """
         Control if the location can contain products not in a package""",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "category": "Warehouse Management",
     "author": "Raumschmiede.de, BCIM, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",

--- a/stock_location_package_restriction/migrations/14.0.1.1.0/pre-migrate.py
+++ b/stock_location_package_restriction/migrations/14.0.1.1.0/pre-migrate.py
@@ -1,0 +1,22 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+
+def migrate(cr, installed_version):
+    if not installed_version:
+        return
+    # Replace the norestriction value to null for the package_restriction field
+    queries = [
+        """
+            ALTER TABLE stock_location
+            ALTER COLUMN package_restriction
+            drop not null;
+        """,
+        """
+            UPDATE stock_location
+            SET package_restriction = null
+            WHERE package_restriction = 'norestriction'
+        """,
+    ]
+    for query in queries:
+        cr.execute(query)

--- a/stock_location_package_restriction/models/stock_location.py
+++ b/stock_location_package_restriction/models/stock_location.py
@@ -5,7 +5,6 @@ from odoo import api, fields, models
 
 SINGLEPACKAGE = "singlepackage"
 MULTIPACKAGE = "multiplepackage"
-NORESTRICTION = "norestriction"
 
 
 class StockLocation(models.Model):
@@ -17,18 +16,16 @@ class StockLocation(models.Model):
             Control if the location can contain products not in a package.
 
             Options:
+              * False (not set): Not mandatory, the location can contain products
+                not part of a package
               * Mandatory and unique: The location cannot have products not
                 part of a package and you cannot have more than 1 package on
                 the location
               * Mandatory and not unique:  The location cannot have products
                 not part of a package and you may have store multiple packages
                 on the location
-              * Not mandatory: The location can contain products not part of a
-                package
         """,
-        required=True,
         store=True,
-        default="norestriction",
     )
 
     @api.model
@@ -36,5 +33,4 @@ class StockLocation(models.Model):
         return [
             (MULTIPACKAGE, "Mandatory"),
             (SINGLEPACKAGE, "Mandatory and unique"),
-            (NORESTRICTION, "Not mandatory"),
         ]

--- a/stock_location_package_restriction/models/stock_move.py
+++ b/stock_location_package_restriction/models/stock_move.py
@@ -6,7 +6,7 @@ from odoo import _, models
 from odoo.exceptions import ValidationError
 from odoo.tools import groupby
 
-from .stock_location import NORESTRICTION, SINGLEPACKAGE
+from .stock_location import SINGLEPACKAGE
 
 
 class StockMove(models.Model):
@@ -22,7 +22,7 @@ class StockMove(models.Model):
         quants_grouped = self.env["stock.quant"].read_group(
             [
                 ("location_id", "in", self.move_line_ids.location_dest_id.ids),
-                ("location_id.package_restriction", "!=", NORESTRICTION),
+                ("location_id.package_restriction", "!=", False),
                 ("quantity", ">", 0),
             ],
             ["location_id", "package_id:array_agg"],
@@ -34,7 +34,7 @@ class StockMove(models.Model):
         for location, move_lines in groupby(
             self.move_line_ids, lambda m: m.location_dest_id
         ):
-            if location.package_restriction == NORESTRICTION:
+            if not location.package_restriction:
                 continue
 
             existing_package_ids = location_packages.get(location.id, set())

--- a/stock_location_package_restriction/tests/test_stock_move.py
+++ b/stock_location_package_restriction/tests/test_stock_move.py
@@ -9,7 +9,6 @@ from odoo.tests.common import SavepointCase
 
 from odoo.addons.stock_location_package_restriction.models.stock_location import (
     MULTIPACKAGE,
-    NORESTRICTION,
     SINGLEPACKAGE,
 )
 
@@ -265,7 +264,7 @@ class TestStockMove(SavepointCase):
             self.pack_1,
             self._get_package_in_location(self.location_1),
         )
-        self.location_1.package_restriction = NORESTRICTION
+        self.location_1.package_restriction = False
         picking = self._create_and_assign_picking(
             [
                 ShortMoveInfo(


### PR DESCRIPTION
The required constraint on the field was causing conflict with other module when running the tests.

So instead of having a specific value the default no restriction behaviour, a falsy value is used.