### PR TITLE
[16.0][IMP]stock_reserve: change parent from menu_action_stock_reservation

### DIFF
--- a/stock_reserve/README.rst
+++ b/stock_reserve/README.rst
@@ -52,7 +52,7 @@ Usage
 
 To make a stock reservation:
 
-#. Go to *Inventory > Products*.
+#. Go to *Inventory > Operations*.
 #. Select or create one product with stock.
 #. Click on *Stock Reservations* smart button.
 #. Create one reservation.

--- a/stock_reserve/view/stock_reserve.xml
+++ b/stock_reserve/view/stock_reserve.xml
@@ -199,7 +199,7 @@
     <menuitem
         action="action_stock_reservation_tree"
         id="menu_action_stock_reservation"
-        parent="stock.menu_stock_inventory_control"
-        sequence="30"
+        parent="stock.menu_stock_warehouse_mgmt"
+        sequence="110"
     />
 </odoo>


### PR DESCRIPTION
Hello!

I have created this pull request, to propose to move the stock reservation menu, from Products to Operations.

![image](https://github.com/OCA/stock-logistics-warehouse/assets/110393853/672598c2-5f8d-4be0-bac4-2d96c85ee81c)

Thanks, I look forward to your feedback.

Best regards