### PR TITLE
[14.0][IMP] stock_quant_manual_assign: add assign_manual_quants_action button on stock move form view

### DIFF
--- a/stock_quant_manual_assign/views/stock_move_view.xml
+++ b/stock_quant_manual_assign/views/stock_move_view.xml
@@ -17,4 +17,24 @@
             </button>
         </field>
     </record>
+    <record model="ir.ui.view" id="stock_move_manual_quants_form_view">
+        <field name="name">stock.move.form</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_move_form" />
+        <field name="arch" type="xml">
+            <field name="location_dest_id" position="after">
+                <field name="picking_code" invisible="1" />
+            </field>
+            <field name="product_uom_qty" position="after">
+                <button
+                    name="%(assign_manual_quants_action)d"
+                    type="action"
+                    icon="fa-tags"
+                    title="Manual Quants"
+                    options='{"warn": true}'
+                    attrs="{'invisible':['|',('picking_code','=','incoming'),('state','not in',('confirmed','assigned','partially_available'))]}"
+                />
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/stock_quant_manual_assign/views/stock_move_view.xml
+++ b/stock_quant_manual_assign/views/stock_move_view.xml
@@ -22,10 +22,8 @@
         <field name="model">stock.move</field>
         <field name="inherit_id" ref="stock.view_move_form" />
         <field name="arch" type="xml">
-            <field name="location_dest_id" position="after">
-                <field name="picking_code" invisible="1" />
-            </field>
             <field name="product_uom_qty" position="after">
+                <field name="picking_code" invisible="1" />
                 <button
                     name="%(assign_manual_quants_action)d"
                     type="action"


### PR DESCRIPTION
This improvement adds the Tags icon button after the 'product_uom_qty' field. This can be helpful for users who use the 'stock_reserve' module in their database because when a user reserves stock managed by lots, the lot number is automatically assigned and cannot be changed to any other lot.

@qrtl 