### PR TITLE
[FIX] fix compute method failed to assign

### DIFF
--- a/stock_available_unreserved/models/product_template.py
+++ b/stock_available_unreserved/models/product_template.py
@@ -21,10 +21,11 @@ class ProductTemplate(models.Model):
     def _compute_product_available_not_res(self):
         for tmpl in self:
             if isinstance(tmpl.id, models.NewId):
-                continue
-            tmpl.qty_available_not_res = sum(
-                tmpl.mapped("product_variant_ids.qty_available_not_res")
-            )
+                tmpl.qty_available_not_res = 0
+            else:
+                tmpl.qty_available_not_res = sum(
+                    tmpl.mapped("product_variant_ids.qty_available_not_res")
+                )
 
     def action_open_quants_unreserved(self):
         products_ids = self.mapped("product_variant_ids").ids


### PR DESCRIPTION
Latest Odoo 15 throws a value error with the current compute method

Error:
ValueError: Compute method failed to assign product.template(<NewId 0x7fb38d3512b0>,).qty_available_not_res

Fix:
Assign qty_available_not_res as 0 for the new product