### PR TITLE
[14.0][FIX] stock_available_mrp: Use correct bom for computation

### DIFF
--- a/stock_available_mrp/readme/CONTRIBUTORS.rst
+++ b/stock_available_mrp/readme/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@
 
   * Víctor Martínez
   * David Vidal
+* Michael Tietz (MT Software) <mtietz@mt-software.de>


### PR DESCRIPTION
If a product has siblings and more then one has a bom first(product.bom_ids) could return a bom
for a diferent product, because bom_ids is a one2many field of product.template and this contains all boms of variants Therefor switch to the default methods of odoo
_bom_find and _get_product2bom