### PR TITLE
[FIX] stock_available_unreserved: qty_available_not_res not computed in all cases.

### DIFF
--- a/stock_available_unreserved/models/product_template.py
+++ b/stock_available_unreserved/models/product_template.py
@@ -21,6 +21,7 @@ class ProductTemplate(models.Model):
     def _compute_product_available_not_res(self):
         for tmpl in self:
             if isinstance(tmpl.id, models.NewId):
+                tmpl.qty_available_not_res = False
                 continue
             tmpl.qty_available_not_res = sum(
                 tmpl.mapped("product_variant_ids.qty_available_not_res")


### PR DESCRIPTION
The `qty_available_not_res` field is not computed when creating a new product.template.

To reproduce the error:
Go to Inventory module -> Products -> Products -> Create

The following error pops up:
`ValueError: Compute method failed to assign product.template(<NewId 0x7fd28cf332e0>,).qty_available_not_res`