### PR TITLE
[16.0][FIX] account_move_line_stock_info: use full form width

### DIFF
--- a/account_move_line_stock_info/views/stock_move_view.xml
+++ b/account_move_line_stock_info/views/stock_move_view.xml
@@ -21,8 +21,13 @@
                 expr="//notebook//form//field[@name='description_picking']/.."
                 position="after"
             >
-                <group name="account_move_lines_grp" string="Journal Items" colspan="4">
-                    <field name="account_move_line_ids" readonly="1" nolabel="1" />
+                <group name="account_move_lines_grp" string="Journal Items">
+                    <field
+                        name="account_move_line_ids"
+                        readonly="1"
+                        nolabel="1"
+                        colspan="2"
+                    />
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
Before:
![2023-11-23_13-44](https://github.com/OCA/stock-logistics-warehouse/assets/23449160/5c402fbb-e4d5-4684-8559-d12abfd16ec5)

After:
![image](https://github.com/OCA/stock-logistics-warehouse/assets/23449160/966d1372-51c4-43d8-9452-aba18554f932)
