### PR TITLE
[15.0][FIX] stock_request_analytic: Adding the correct groups to the views to avoid permissions errors

### DIFF
--- a/stock_request_analytic/tests/test_stock_request_analytic.py
+++ b/stock_request_analytic/tests/test_stock_request_analytic.py
@@ -3,11 +3,11 @@
 
 from odoo import fields
 from odoo.exceptions import UserError
-from odoo.tests import Form
-from odoo.tests.common import TransactionCase
+from odoo.tests import Form, common, new_test_user
+from odoo.tests.common import users
 
 
-class TestStockRequestAnalytic(TransactionCase):
+class TestStockRequestAnalytic(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -74,6 +74,17 @@ class TestStockRequestAnalytic(TransactionCase):
                 "type": "product",
                 "route_ids": [(6, 0, cls.demand_route.ids)],
             }
+        )
+        new_test_user(
+            cls.env,
+            login="stock_request_user",
+            groups="%s,%s,%s"
+            % (
+                "stock_request.group_stock_request_user",
+                "analytic.group_analytic_accounting",
+                "stock.group_stock_user",
+            ),
+            company_ids=[(6, 0, [cls.main_company.id, cls.company_2.id])],
         )
 
     def prepare_order_request_analytic(self, analytic, company, analytic_tags=None):
@@ -175,6 +186,7 @@ class TestStockRequestAnalytic(TransactionCase):
             )
             self.StockRequestOrder.create(vals)
 
+    @users("stock_request_user")
     def test_default_analytic(self):
         """
         Create request order with a default analytic

--- a/stock_request_analytic/views/analytic_views.xml
+++ b/stock_request_analytic/views/analytic_views.xml
@@ -6,6 +6,10 @@
         <field name="name">analytic.order.form</field>
         <field name="model">account.analytic.account</field>
         <field name="inherit_id" ref="analytic.view_account_analytic_account_form" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('stock_request.group_stock_request_user'))]"
+        />
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="stock_request_ids" invisible="1" />

--- a/stock_request_analytic/views/stock_request_order_views.xml
+++ b/stock_request_analytic/views/stock_request_order_views.xml
@@ -6,6 +6,10 @@
         <field name="name">stock.request.order.form - stock_request_analytic</field>
         <field name="model">stock.request.order</field>
         <field name="inherit_id" ref="stock_request.stock_request_order_form" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('analytic.group_analytic_accounting')),(4, ref('analytic.group_analytic_tags'))]"
+        />
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <field name="analytic_account_ids" invisible="1" />
@@ -23,6 +27,7 @@
                         name="analytic_count"
                         widget="statinfo"
                         string="Analytic Accounts"
+                        groups="analytic.group_analytic_accounting"
                     />
                 </button>
                 <button
@@ -38,6 +43,7 @@
                         name="analytic_tag_count"
                         widget="statinfo"
                         string="Analytic Tags"
+                        groups="analytic.group_analytic_tags"
                     />
                 </button>
             </div>

--- a/stock_request_analytic/views/stock_request_views.xml
+++ b/stock_request_analytic/views/stock_request_views.xml
@@ -6,6 +6,10 @@
         <field name="name">stock.request.form</field>
         <field name="model">stock.request</field>
         <field name="inherit_id" ref="stock_request.view_stock_request_form" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('analytic.group_analytic_accounting')),(4, ref('analytic.group_analytic_tags'))]"
+        />
         <field name="arch" type="xml">
             <field name="procurement_group_id" position="after">
                 <field


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/1896

Adding the correct groups to the views to avoid permissions errors

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa