### PR TITLE
[16.0][FIX] stock_inventory_discrepancy: fix conflicts and discrepancy lines

### DIFF
--- a/stock_inventory_discrepancy/wizards/__init__.py
+++ b/stock_inventory_discrepancy/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import confirm_discrepancy_wiz
+from . import stock_track_confirmation

--- a/stock_inventory_discrepancy/wizards/stock_track_confirmation.py
+++ b/stock_inventory_discrepancy/wizards/stock_track_confirmation.py
@@ -1,0 +1,9 @@
+from odoo import models
+
+
+class StockTrackConfirmation(models.TransientModel):
+    _inherit = "stock.track.confirmation"
+
+    def action_confirm(self):
+        self = self.with_context(skip_apply_inventory=False)
+        return super().action_confirm()


### PR DESCRIPTION
if you have one line with conflics and another line with discrepancies, the discrepancy wiz is executed first, which is incorrect, as we will have to correct the conflicts first.

Without Changes:

https://github.com/OCA/stock-logistics-warehouse/assets/6359121/22aa0cb3-cea6-4666-a2fa-4f1ed57ee16b

With Changes:

https://github.com/OCA/stock-logistics-warehouse/assets/6359121/d662c3fd-a317-48f3-b97f-ca3cdb3f109e
