### PR TITLE
[16.0][FIX] stock_quant_manual_assign: fixing issue on immediate transfer. 

### DIFF
--- a/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
@@ -12,9 +12,9 @@
                         <field name="package_id" groups="stock.group_tracking_lot" />
                         <field name="owner_id" groups="stock.group_tracking_owner" />
                         <field name="location_id" />
-                        <field name="on_hand" force_save="1" />
-                        <field name="reserved" force_save="1" />
-                        <field name="selected" widget="boolean_toggle" />
+                        <field name="on_hand" />
+                        <field name="reserved" />
+                        <field name="selected" />
                         <field
                             name="qty"
                             attrs="{'readonly':[('selected', '=', False)]}"


### PR DESCRIPTION
When we create immediate transfer, and click on  fill with stock button, odoo will propose the available stock and fill the quantity done. But when you select the other lot, the lot you selected properly added, but the proposed line with done qty will remains. This fix is to address this issue, and also the fix for auto_fill_qty_done error when you change the lot in immediate transfer scenario. last but not least, i add aalso the logic to assign quantity done for immediate transfer when auto_fill_qty_done is activated.