### PR TITLE
[16.0][FIX] stock_reserve: Change web_ribbon text to title to make it translatable

### DIFF
--- a/stock_reserve/view/stock_reserve.xml
+++ b/stock_reserve/view/stock_reserve.xml
@@ -34,7 +34,7 @@
                 <sheet>
                     <widget
                         name="web_ribbon"
-                        text="Released"
+                        title="Released"
                         bg_color="bg-danger"
                         attrs="{'invisible': [('state', '!=', 'cancel')]}"
                     />


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/stock-logistics-warehouse/pull/1922

Change web_ribbon text to title to make it translatable

@Tecnativa