### PR TITLE
[16.0] stock_inventory: various fixes and improvements

### DIFF
--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -7,6 +7,9 @@ class InventoryAdjustmentsGroup(models.Model):
     _name = "stock.inventory"
     _description = "Inventory Adjustment Group"
     _order = "date desc, id desc"
+    _inherit = [
+        "mail.thread",
+    ]
 
     name = fields.Char(required=True, default="Inventory", string="Inventory Reference")
 
@@ -15,6 +18,7 @@ class InventoryAdjustmentsGroup(models.Model):
     state = fields.Selection(
         [("draft", "Draft"), ("in_progress", "In Progress"), ("done", "Done")],
         default="draft",
+        tracking=True,
     )
 
     owner_id = fields.Many2one(

--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -293,6 +293,8 @@ class InventoryAdjustmentsGroup(models.Model):
             {
                 "search_default_to_do": 1,
                 "inventory_id": self.id,
+                "default_stock_inventory_ids": [(4, self.id)],
+                "default_to_do": True,
             }
         )
         result.update(
@@ -342,7 +344,7 @@ class InventoryAdjustmentsGroup(models.Model):
         """
         self.ensure_one()
         Quant = self.env["stock.quant"]
-        if self.product_selection != "manual":
+        if self.product_selection not in ("manual", "one"):
             return Quant.browse()
         quants_values = []
         for product in self._get_product_without_quants(quants):

--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -8,6 +8,11 @@ class StockQuant(models.Model):
         comodel_name="stock.inventory",
         compute="_compute_virtual_in_progress_inventory_id",
     )
+    stock_inventory_ids = fields.Many2many(
+        comodel_name="stock.inventory",
+        string="Inventory Adjustment",
+        readonly=True,
+    )
     to_do = fields.Boolean(default=True)
 
     def _compute_virtual_in_progress_inventory_id(self):

--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -1,44 +1,45 @@
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class StockQuant(models.Model):
     _inherit = "stock.quant"
 
+    virtual_in_progress_inventory_id = fields.Many2one(
+        comodel_name="stock.inventory",
+        compute="_compute_virtual_in_progress_inventory_id",
+    )
     to_do = fields.Boolean(default=True)
+
+    def _compute_virtual_in_progress_inventory_id(self):
+        Inventory = self.env["stock.inventory"]
+        for rec in self:
+            rec.virtual_in_progress_inventory_id = Inventory.search(
+                [
+                    ("state", "=", "in_progress"),
+                    ("location_ids", "parent_of", rec.location_id.ids),
+                ],
+                limit=1,
+            )
 
     def _apply_inventory(self):
         res = super()._apply_inventory()
-        record_moves = self.env["stock.move.line"]
-        for rec in self:
-            adjustment = (
-                self.env["stock.inventory"]
-                .search([("state", "=", "in_progress")])
-                .filtered(
-                    lambda x: rec.location_id in x.location_ids
-                    or rec.location_id in x.location_ids.child_ids
-                )
-            )
-            moves = record_moves.search(
-                [
-                    ("product_id", "=", rec.product_id.id),
-                    ("lot_id", "=", rec.lot_id.id),
-                    "|",
-                    ("location_id", "=", rec.location_id.id),
-                    ("location_dest_id", "=", rec.location_id.id),
-                ],
-                order="create_date asc",
-            ).filtered(
-                lambda x: not x.company_id.id
-                or not rec.company_id.id
-                or rec.company_id.id == x.company_id.id
-            )
-            if len(moves) == 0:
-                raise ValueError(_("No move lines have been created"))
-            move = moves[len(moves) - 1]
-            adjustment.stock_move_ids |= move
-            move.inventory_adjustment_id = adjustment
-            rec.to_do = False
+        self.write(
+            {
+                "to_do": False,
+            }
+        )
         return res
 
     def _get_inventory_fields_write(self):
         return super()._get_inventory_fields_write() + ["to_do"]
+
+    def _get_inventory_move_values(self, qty, location_id, location_dest_id, out=False):
+        res = super()._get_inventory_move_values(
+            qty, location_id, location_dest_id, out=out
+        )
+        inventory = self.virtual_in_progress_inventory_id
+        if self.virtual_in_progress_inventory_id:
+            for move_line_item in res.get("move_line_ids", []):
+                move_line_values = move_line_item[-1]
+                move_line_values["inventory_adjustment_id"] = inventory.id
+        return res

--- a/stock_inventory/tests/test_stock_inventory.py
+++ b/stock_inventory/tests/test_stock_inventory.py
@@ -1,7 +1,7 @@
 # Copyright 2022 ForgeFlow S.L
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
@@ -120,7 +120,7 @@ class TestStockInventory(TransactionCase):
                 "location_ids": [self.location1.id],
             }
         )
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.cr.savepoint():
             inventory2.action_state_to_in_progress()
         self.assertEqual(inventory1.state, "in_progress")
         self.assertEqual(
@@ -136,7 +136,7 @@ class TestStockInventory(TransactionCase):
         inventory1.action_view_inventory_adjustment()
         self.quant1.inventory_quantity = 92
         self.quant1.action_apply_inventory()
-        inventory1._compute_count_stock_quants()
+        inventory1.invalidate_recordset()
         inventory1.action_view_stock_moves()
         self.assertEqual(inventory1.count_stock_moves, 1)
         self.assertEqual(inventory1.count_stock_quants, 3)
@@ -171,8 +171,7 @@ class TestStockInventory(TransactionCase):
         inventory1.action_view_inventory_adjustment()
         self.quant3.inventory_quantity = 74
         self.quant3.action_apply_inventory()
-        inventory1._compute_count_stock_quants()
-        inventory1.action_view_stock_moves()
+        inventory1.invalidate_recordset()
         self.assertEqual(inventory1.count_stock_moves, 1)
         self.assertEqual(inventory1.count_stock_quants, 2)
         self.assertEqual(inventory1.count_stock_quants_string, "1 / 2")
@@ -182,15 +181,15 @@ class TestStockInventory(TransactionCase):
         self.assertEqual(inventory1.stock_move_ids.location_id.id, self.location3.id)
         self.quant1.inventory_quantity = 65
         self.quant1.action_apply_inventory()
-        inventory1._compute_count_stock_quants()
+        inventory1.invalidate_recordset()
         self.assertEqual(inventory1.count_stock_moves, 2)
         self.assertEqual(inventory1.count_stock_quants, 2)
         self.assertEqual(inventory1.count_stock_quants_string, "0 / 2")
         inventory1.action_state_to_done()
 
     def test_03_one_selection(self):
-        with self.assertRaises(ValidationError), self.cr.savepoint():
-            inventory1 = self.inventory_model.create(
+        with self.assertRaises(UserError), self.cr.savepoint():
+            self.inventory_model.create(
                 {
                     "name": "Inventory_Test_5",
                     "product_selection": "one",
@@ -221,7 +220,7 @@ class TestStockInventory(TransactionCase):
         inventory1.action_view_inventory_adjustment()
         self.quant3.inventory_quantity = 74
         self.quant3.action_apply_inventory()
-        inventory1._compute_count_stock_quants()
+        inventory1.invalidate_recordset()
         inventory1.action_view_stock_moves()
         self.assertEqual(inventory1.count_stock_moves, 1)
         self.assertEqual(inventory1.count_stock_quants, 2)
@@ -232,15 +231,15 @@ class TestStockInventory(TransactionCase):
         self.assertEqual(inventory1.stock_move_ids.location_id.id, self.location3.id)
         self.quant1.inventory_quantity = 65
         self.quant1.action_apply_inventory()
-        inventory1._compute_count_stock_quants()
+        inventory1.invalidate_recordset()
         self.assertEqual(inventory1.count_stock_moves, 2)
         self.assertEqual(inventory1.count_stock_quants, 2)
         self.assertEqual(inventory1.count_stock_quants_string, "0 / 2")
         inventory1.action_state_to_done()
 
     def test_04_lot_selection(self):
-        with self.assertRaises(ValidationError), self.cr.savepoint():
-            inventory1 = self.inventory_model.create(
+        with self.assertRaises(UserError), self.cr.savepoint():
+            self.inventory_model.create(
                 {
                     "name": "Inventory_Test_6",
                     "product_selection": "lot",
@@ -271,7 +270,7 @@ class TestStockInventory(TransactionCase):
         inventory1.action_view_inventory_adjustment()
         self.quant3.inventory_quantity = 74
         self.quant3.action_apply_inventory()
-        inventory1._compute_count_stock_quants()
+        inventory1.invalidate_recordset()
         inventory1.action_view_stock_moves()
         self.assertEqual(inventory1.count_stock_moves, 1)
         self.assertEqual(inventory1.count_stock_quants, 1)
@@ -305,7 +304,7 @@ class TestStockInventory(TransactionCase):
         inventory1.action_view_inventory_adjustment()
         self.quant4.inventory_quantity = 74
         self.quant4.action_apply_inventory()
-        inventory1._compute_count_stock_quants()
+        inventory1.invalidate_recordset()
         inventory1.action_view_stock_moves()
         self.assertEqual(inventory1.count_stock_moves, 1)
         self.assertEqual(inventory1.count_stock_quants, 1)

--- a/stock_inventory/views/stock_inventory.xml
+++ b/stock_inventory/views/stock_inventory.xml
@@ -48,7 +48,7 @@
                             name="action_view_inventory_adjustment"
                             class="oe_stat_button"
                             icon="fa-pencil-square-o"
-                            attrs="{'invisible':['|', ('state', 'in', ['draft', 'done']), ('count_stock_quants', '=', 0)]}"
+                            attrs="{'invisible':[('state', 'in', ['draft', 'done'])]}"
                         >
                             <field
                                 name="count_stock_quants_string"

--- a/stock_inventory/views/stock_inventory.xml
+++ b/stock_inventory/views/stock_inventory.xml
@@ -113,6 +113,10 @@
                         </group>
                     </group>
                 </sheet>
+                <div class="oe_chatter">
+                  <field name="message_follower_ids" widget="mail_followers" />
+                  <field name="message_ids" widget="mail_thread" />
+                </div>
             </form>
         </field>
     </record>

--- a/stock_inventory/views/stock_inventory.xml
+++ b/stock_inventory/views/stock_inventory.xml
@@ -20,6 +20,13 @@
                         attrs="{'invisible':['|',('state', 'in', ['draft', 'done']), ('count_stock_moves', '!=', 0)]}"
                         string="Back to Draft"
                     />
+                    <field name="action_state_to_cancel_allowed" invisible="1" />
+                    <button
+                        type="object"
+                        name="action_state_to_cancel"
+                        attrs="{'invisible':[('action_state_to_cancel_allowed', '=', False),]}"
+                        string="Cancel"
+                    />
                     <button
                         type="object"
                         name="action_state_to_done"
@@ -70,16 +77,11 @@
                 </div>
                     <group>
                         <group>
-                            <field
-                                name="product_selection"
-                                widget="radio"
-                                attrs="{'readonly':[('state', 'in', ['in_progress', 'done'])]}"
-                            />
+                            <field name="product_selection" widget="radio" />
                             <field
                                 name="location_ids"
                                 string="Locations"
                                 widget="many2many_tags"
-                                attrs="{'readonly':[('state', 'in', ['in_progress', 'done'])]}"
                                 required="1"
                             />
                         </group>
@@ -92,23 +94,23 @@
                             <field
                                 name="product_ids"
                                 widget="many2many_tags"
-                                attrs="{'readonly':[('state', 'in', ['in_progress', 'done'])], 'required': [('product_selection', 'in', ['manual', 'lot'])],'invisible': [('product_selection', 'in', ['all', 'category', 'one'])]}"
+                                attrs="{'required': [('product_selection', 'in', ['manual', 'lot'])],'invisible': [('product_selection', 'in', ['all', 'category', 'one'])]}"
                             />
                             <field
                                 name="product_ids"
                                 widget="many2many_tags"
                                 options="{'limit': 10}"
-                                attrs="{'readonly':[('state', 'in', ['in_progress', 'done'])], 'required': [('product_selection', '=', 'one')],'invisible': [('product_selection', '!=', 'one')]}"
+                                attrs="{'required': [('product_selection', '=', 'one')],'invisible': [('product_selection', '!=', 'one')]}"
                             />
                             <field
                                 name="category_id"
-                                attrs="{'readonly':[('state', 'in', ['in_progress', 'done'])], 'required': [('product_selection', '=', 'category')],'invisible': [('product_selection', '!=', 'category')]}"
+                                attrs="{'required': [('product_selection', '=', 'category')],'invisible': [('product_selection', '!=', 'category')]}"
                             />
                             <field
                                 name="lot_ids"
                                 widget="many2many_tags"
                                 domain="[('product_id', 'in', product_ids)]"
-                                attrs="{'readonly':[('state', 'in', ['in_progress', 'done'])], 'required': [('product_selection', '=', 'lot')],'invisible': [('product_selection', '!=', 'lot')]}"
+                                attrs="{'required': [('product_selection', '=', 'lot')],'invisible': [('product_selection', '!=', 'lot')]}"
                             />
                         </group>
                     </group>
@@ -128,6 +130,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
+                <field name="location_ids" widget="many2many_tags" />
                 <field
                     name="state"
                     widget="badge"
@@ -137,6 +140,18 @@
                 />
                 <field name="date" />
             </tree>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="stock_inventory_search_view">
+        <field name="model">stock.inventory</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" />
+                <field name="location_ids" widget="many2many_tags" />
+                <field name="date" />
+                <field name="state" />
+            </search>
         </field>
     </record>
 
@@ -154,5 +169,7 @@
         sequence="30"
         action="action_view_inventory_group_form"
     />
-    <delete model="ir.ui.menu" id="stock.menu_action_inventory_tree" />
+    <record model="ir.ui.menu" id="stock.menu_action_inventory_tree">
+        <field name="active" eval="0" />
+    </record>
 </odoo>

--- a/stock_inventory/views/stock_quant.xml
+++ b/stock_inventory/views/stock_quant.xml
@@ -1,4 +1,15 @@
 <odoo>
+    <record model="ir.ui.view" id="view_stock_quant_tree_inventory_editable">
+        <field name="name">stock.quant.tree stock inventory</field>
+        <field name="model">stock.quant</field>
+        <field name="inherit_id" ref="stock.view_stock_quant_tree_inventory_editable" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field name="to_do" invisible="1" />
+                <field name="stock_inventory_ids" invisible="1" />
+            </xpath>
+        </field>
+    </record>
     <record id="view_stock_quant_search_not_done" model="ir.ui.view">
             <field name="name">stock.quant.search.not.done</field>
             <field name="model">stock.quant</field>


### PR DESCRIPTION
- fixed the way to link the move to the inventory, loading all move lines linked to a product or a lot for a given location was not right
- fixed computed methods
- do not use ValidationError if not inside a python constrains
- use states field attribute to avoid duplicating visibility condition
- missing ensure_one
- added cancel state to match with old odoo inventory
- do not delete odoo menu but deactivate it instead!
- create empty quants when confirming a manual inventory for products which have no quants
- show quants button even if there was 0 to allow creating new ones