### PR TITLE
[14.0][IMP] stock_orderpoint_generator auto product addition

### DIFF
--- a/stock_orderpoint_generator/models/__init__.py
+++ b/stock_orderpoint_generator/models/__init__.py
@@ -1,2 +1,4 @@
+from . import orderpoint
 from . import orderpoint_template
 from . import product
+from . import stock_move

--- a/stock_orderpoint_generator/models/orderpoint.py
+++ b/stock_orderpoint_generator/models/orderpoint.py
@@ -1,0 +1,11 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class StockWarehouseOrderpoint(models.Model):
+    _inherit = "stock.warehouse.orderpoint"
+
+    orderpoint_template_id = fields.Many2one(
+        comodel_name="stock.warehouse.orderpoint.template"
+    )

--- a/stock_orderpoint_generator/models/stock_move.py
+++ b/stock_orderpoint_generator/models/stock_move.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Akretion (http://www.akretion.com).
+# @author Florian Mounier <florian.mounier@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _trigger_scheduler(self):
+        if not self or self.env["ir.config_parameter"].sudo().get_param(
+            "stock.no_auto_scheduler"
+        ):
+            return
+
+        for move in self:
+            orderpoint = self.env["stock.warehouse.orderpoint"].search(
+                [
+                    ("product_id", "=", move.product_id.id),
+                    ("trigger", "=", "auto"),
+                    ("location_id", "parent_of", move.location_id.id),
+                    ("company_id", "=", move.company_id.id),
+                ],
+                limit=1,
+            )
+            if not orderpoint:
+                template = self.env["stock.warehouse.orderpoint.template"].search(
+                    [
+                        ("location_id", "parent_of", move.location_id.id),
+                        ("company_id", "=", move.company_id.id),
+                        ("auto_add_product", "=", True),
+                    ],
+                    limit=1,
+                )
+                if template:
+                    template.auto_product_ids = [(4, move.product_id.id)]
+                    template.create_orderpoints(move.product_id)
+        return super()._trigger_scheduler()

--- a/stock_orderpoint_generator/models/stock_move.py
+++ b/stock_orderpoint_generator/models/stock_move.py
@@ -25,7 +25,7 @@ class StockMove(models.Model):
                 limit=1,
             )
             if not orderpoint:
-                template = self.env["stock.warehouse.orderpoint.template"].search(
+                template = self.env["stock.warehouse.orderpoint.template"].sudo().search(
                     [
                         ("location_id", "parent_of", move.location_id.id),
                         ("company_id", "=", move.company_id.id),

--- a/stock_orderpoint_generator/views/orderpoint_template_views.xml
+++ b/stock_orderpoint_generator/views/orderpoint_template_views.xml
@@ -20,6 +20,7 @@
                 <field name="auto_min_qty" />
                 <field name="auto_max_qty" />
                 <field name="auto_generate" />
+                <field name="auto_add_product" />
             </tree>
         </field>
     </record>
@@ -104,6 +105,7 @@
                         <group string="Misc">
                             <field name="active" />
                             <field name="auto_generate" />
+                            <field name="auto_add_product" />
                         </group>
                         <group
                             name="auto_minimum"


### PR DESCRIPTION
Hello, 

This PR adds a field Add product automatically.
When checked, when a picking is validated, the system will look for templates that match
the product and location of the picking. If there is no orderpoint but a 
template is found, it will add the product to the template and create the orderpoint, to trigger automatically the reordering.

It also adds a link between orderpoints and orderpoints templates to recompute orderpoint only linked to the changed template.