### PR TITLE
[14.0][FIX] product_route_profile fix view

### DIFF
--- a/product_route_profile/tests/test_product_route_profile.py
+++ b/product_route_profile/tests/test_product_route_profile.py
@@ -55,6 +55,7 @@ class TestProductRouteProfile(SavepointCase):
         self.product.with_company(
             self.env.company
         ).force_route_profile_id = self.route_profile_2.id
+        self.assertEqual(self.product.route_profile_id, self.route_profile_1)
         self.assertEqual(
             self.product.with_company(self.env.company).route_ids,
             self.route_profile_2.route_ids,

--- a/product_route_profile/views/product_template.xml
+++ b/product_route_profile/views/product_template.xml
@@ -11,6 +11,12 @@
             <xpath expr="//field[@name='route_ids']/parent::div" position="attributes">
                 <attribute name="attrs">{'invisible': True}</attribute>
             </xpath>
+            <xpath expr="//field[@name='route_ids']" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </xpath>
+            <xpath expr="//label[@for='route_ids']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
             <xpath expr="//group[@name='operations']" position="inside">
                 <field
                     name="route_profile_id"


### PR DESCRIPTION
Hello , 

the route_ids field must be read-only in the view to avoid triggering the inverse method, which recalculates the route_profile_id field when the force_route_profile_id field is filled in.