### PR TITLE
[FIX] stock_mts_mto_rule: Don't use current company to create route

### DIFF
--- a/stock_mts_mto_rule/data/stock_data.xml
+++ b/stock_mts_mto_rule/data/stock_data.xml
@@ -7,5 +7,6 @@
         <field name="name">Make To Order + Make To Stock</field>
         <field name="sequence">5</field>
         <field name="product_selectable" eval="True" />
+        <field name="company_id" eval="False" />
     </record>
 </odoo>


### PR DESCRIPTION
As the current company will be used to create route demo data, this will prevent creating new companies in tests.

Set the route as shared between companies.