### PR TITLE
[FIX] stock_pikcing_volume: ambiguous column

### DIFF
--- a/stock_picking_volume/hooks.py
+++ b/stock_picking_volume/hooks.py
@@ -38,7 +38,7 @@ def pre_init_hook(cr):
                             product_uom_qty * pp.volume
                     END
             from reserved_qty_by_move
-            join product_product pp on pp.id = product_id
+            join product_product pp on pp.id = reserved_qty_by_move.product_id
             where
                 stock_move.id = reserved_qty_by_move.move_id
                 and state not in ('done', 'cancel')


### PR DESCRIPTION
When installing this module an ambiguous column error is thrown if you have installed the product_variant_configurator_module

This is due to this module [adding a product_id field in product.configurator model](https://github.com/OCA/product-variant/blob/faddfac83f33d4604333152f10a4156a8b4ea49c/product_variant_configurator/models/product_configurator.py#L34C5-L34C15).
And since [product.product inherits product.configurator](https://github.com/OCA/product-variant/blob/faddfac83f33d4604333152f10a4156a8b4ea49c/product_variant_configurator/models/product_product.py#L11) product_id is ambiguous in this query.