### PR TITLE
[15.0][FIX] stock_request: Avoid set stock request orders empty

### DIFF
--- a/stock_request/i18n/es.po
+++ b/stock_request/i18n/es.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-26 16:12+0000\n"
-"PO-Revision-Date: 2023-03-03 09:06+0000\n"
-"Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
+"POT-Creation-Date: 2024-02-23 08:52+0000\n"
+"PO-Revision-Date: 2024-02-23 09:53+0100\n"
+"Last-Translator: Víctor Martínez <victor.martinez@tecnativa.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -404,6 +404,19 @@ msgid "Is Follower"
 msgstr "Es Seguidor"
 
 #. module: stock_request
+#: code:addons/stock_request/models/stock_request_order.py:0
+#, fuzzy, python-format
+#| msgid ""
+#| "It is not possible to set empty stock request orders (maybe\n"
+#| "                    you should cancel it)."
+msgid ""
+"It is not possible to set empty stock request orders (maybe you should "
+"cancel it)."
+msgstr ""
+"No es posible dejar vacío un pedido de existencias (quizás deberías "
+"cancelarlo)."
+
+#. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_order_form
 msgid "Items"
 msgstr "Elementos"
@@ -509,7 +522,6 @@ msgstr "Nombre"
 
 #. module: stock_request
 #: model:ir.model.constraint,message:stock_request.constraint_stock_request_abstract_name_uniq
-#: model:ir.model.constraint,message:stock_request.constraint_stock_request_kanban_name_uniq
 msgid "Name must be unique"
 msgstr "El nombre debe ser único"
 
@@ -1176,6 +1188,3 @@ msgid ""
 msgstr ""
 "Debe seleccionada una unidad de medida de producto de la misma categoría que "
 "la unidad de medida por defecto del producto"
-
-#~ msgid "SMS Delivery error"
-#~ msgstr "Error de entrega de SMS"

--- a/stock_request/i18n/stock_request.pot
+++ b/stock_request/i18n/stock_request.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-02-23 08:52+0000\n"
+"PO-Revision-Date: 2024-02-23 08:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -388,6 +390,14 @@ msgid "Is Follower"
 msgstr ""
 
 #. module: stock_request
+#: code:addons/stock_request/models/stock_request_order.py:0
+#, python-format
+msgid ""
+"It is not possible to set empty stock request orders (maybe you should "
+"cancel it)."
+msgstr ""
+
+#. module: stock_request
 #: model_terms:ir.ui.view,arch_db:stock_request.stock_request_order_form
 msgid "Items"
 msgstr ""
@@ -490,7 +500,6 @@ msgstr ""
 
 #. module: stock_request
 #: model:ir.model.constraint,message:stock_request.constraint_stock_request_abstract_name_uniq
-#: model:ir.model.constraint,message:stock_request.constraint_stock_request_kanban_name_uniq
 msgid "Name must be unique"
 msgstr ""
 

--- a/stock_request/models/stock_request_order.py
+++ b/stock_request/models/stock_request_order.py
@@ -317,6 +317,16 @@ class StockRequestOrder(models.Model):
                 )
             )
 
+    @api.constrains("stock_request_ids")
+    def _check_location_empty_stock_request_ids(self):
+        if any(not request.stock_request_ids for request in self):
+            raise ValidationError(
+                _(
+                    "It is not possible to set empty stock request orders (maybe "
+                    "you should cancel it)."
+                )
+            )
+
     @api.model
     def _create_from_product_multiselect(self, products):
         if not products:

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -6,7 +6,7 @@ from collections import Counter
 from datetime import datetime
 
 from odoo import exceptions, fields
-from odoo.tests import common, new_test_user
+from odoo.tests import Form, common, new_test_user
 
 
 class TestStockRequest(common.TransactionCase):
@@ -324,6 +324,11 @@ class TestStockRequestBase(TestStockRequest):
 
         self.assertEqual(stock_request.company_id, self.main_company)
         self.assertEqual(stock_request.location_id, self.warehouse.lot_stock_id)
+
+    def test_stock_request_order_empty(self):
+        request_order = Form(self.request_order)
+        with self.assertRaises(exceptions.ValidationError):
+            request_order.save()
 
     def test_stock_request_order_validations_01(self):
         """Testing the discrepancy in warehouse_id between


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/1949

Avoid set stock request orders empty.

Please @pedrobaeza can you review it?

@Tecnativa TT47959