### PR TITLE
[16.0][FIX] stock_putaway_rule_views: Remove required property from fields in putaway rules.

### DIFF
--- a/stock_putaway_product_template/views/stock_putaway_rule_views.xml
+++ b/stock_putaway_product_template/views/stock_putaway_rule_views.xml
@@ -7,21 +7,19 @@
         <field name="inherit_id" ref="stock.stock_putaway_list" />
         <field name="arch" type="xml">
             <field name="product_id" position="attributes">
-                <attribute name="readonly">False</attribute>
                 <attribute
                     name="attrs"
-                >{'readonly': [('category_id', '!=', False)], 'required': [('category_id', '=', False),('product_tmpl_id', '=', False)]}</attribute>
+                >{'readonly': ['|',('category_id', '!=', False), ('product_tmpl_id', '!=', False)]}</attribute>
             </field>
             <field name="category_id" position="attributes">
-                <attribute name="readonly">False</attribute>
                 <attribute
                     name="attrs"
-                >{'readonly': ['|', ('product_id', '!=', False), ('product_tmpl_id', '!=', False)], 'required': [('product_id', '=', False),('product_tmpl_id', '=', False)]}</attribute>
+                >{'readonly': ['|', ('product_id', '!=', False), ('product_tmpl_id', '!=', False)]}</attribute>
             </field>
             <field name="product_id" position="before">
                 <field
                     name="product_tmpl_id"
-                    attrs="{'readonly': [('category_id', '!=', False)], 'required': [('category_id', '=', False), ('product_id', '=', False)]}"
+                    attrs="{'readonly': [('category_id', '!=', False)]}"
                     options="{'no_create': True, 'no_open': True}"
                     force_save="1"
                 />


### PR DESCRIPTION
fw-port https://github.com/OCA/stock-logistics-warehouse/pull/1970

In this module, the product template, variant and category fields were made mandatory. Actually in relocation strategies it is not mandatory to set up a product, so the above mentioned fields should not be mandatory either.

cc @tecnativa TT48457

@victoralmau @sergio-teruel please review