### PR TITLE
[16.0][FIX] stock_move_location: fix planned transfer incorrect reserved_uom_qty

### DIFF
--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -218,7 +218,7 @@ class StockMoveLocationWizard(models.TransientModel):
                     lot_id=line.lot_id,
                     package_id=line.package_id,
                     owner_id=line.owner_id,
-                    strict=False,
+                    strict=True,
                 )
                 move._update_reserved_quantity(
                     line.move_quantity,
@@ -227,7 +227,7 @@ class StockMoveLocationWizard(models.TransientModel):
                     lot_id=line.lot_id,
                     package_id=line.package_id,
                     owner_id=line.owner_id,
-                    strict=False,
+                    strict=True,
                 )
             # Force the state to be assigned, instead of _action_assign,
             # to avoid discarding the selected move_location_line.


### PR DESCRIPTION
This PR fixes stock quant matching in _get_gather_domain by setting strict=True, ensuring precise matching based on lot, package, and location. This change addresses issues arising from the previous approach, which could lead to the inclusion of unnecessary quants, such as those without an owner or lot.

Before this fix, available_quantity was not correctly identifying the quantity for a specific location, lot, and owner.


@qrtl QT4414