### PR TITLE
[16.0][FIX] stock_move_packaging_qty: Replace ml with move_line

### DIFF
--- a/stock_move_packaging_qty/views/report_stock_picking.xml
+++ b/stock_move_packaging_qty/views/report_stock_picking.xml
@@ -99,12 +99,13 @@
     >
         <xpath expr="//td[@name='move_line_lot_qty_done']">
             <div
-                t-if="ml.product_packaging_id"
+                t-if="move_line.product_packaging_id"
                 class="text-secondary"
                 groups="product.group_stock_packaging"
             >
-                <span t-field="ml.product_packaging_id" />:
-                <span t-field="ml.product_packaging_qty_done" />
+                <span t-field="move_line.product_packaging_id" />: <span
+                    t-field="move_line.product_packaging_qty_done"
+                />
             </div>
         </xpath>
     </template>


### PR DESCRIPTION
Fix: Replace ml with move_line. In original report odoo use move_line.

@Shide @yajo please review.

@moduon MT-5825