### PR TITLE
[15.0][FIX] stock_inventory: only set to done adjustment if there is an adjustment

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -51,8 +51,8 @@ class StockQuant(models.Model):
                 }
             )
             rec.to_do = False
-            if self.env.company.stock_inventory_auto_complete:
-                adjustment.action_auto_state_to_done()
+        if adjustment and self.env.company.stock_inventory_auto_complete:
+            adjustment.action_auto_state_to_done()
         return res
 
     def _get_inventory_fields_write(self):


### PR DESCRIPTION
[FIX] stock_inventory: only set to done adjustment if there is an adjustment

to avoid this error

```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5238, in ensure_one
    _id, = self._ids
ValueError: not enough values to unpack (expected 1, got 0)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 368, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 357, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 921, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 546, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1324, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1316, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 471, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 456, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/stock_barcode/models/stock_quant.py", line 89, in action_validate
    res = quants.action_apply_inventory()
  File "/opt/odoo/auto/addons/stock/models/stock_quant.py", line 366, in action_apply_inventory
    self._apply_inventory()
  File "/opt/odoo/auto/addons/stock_inventory/models/stock_quant.py", line 55, in _apply_inventory
    adjustment.action_auto_state_to_done()
  File "/opt/odoo/auto/addons/stock_inventory/models/stock_inventory.py", line 236, in action_auto_state_to_done
    self.ensure_one()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5241, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 654, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: Expected singleton: stock.inventory()
```