### PR TITLE
[15.0][FIX] stock_inventory: check exclude sublocation before change state to in progress

### DIFF
--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -203,7 +203,7 @@ class InventoryAdjustmentsGroup(models.Model):
             ],
             limit=1,
         )
-        if active_rec:
+        if active_rec and not self.exclude_sublocation:
             raise ValidationError(
                 _(
                     "There's already an Adjustment in Process using one requested Location: %s"


### PR DESCRIPTION
It was not possible to move an inventory adjustment to 'in progress' state when it had a sublocation in progress, even if this inventory adjustment had the 'exclude_sublocation' attribute activated.