### PR TITLE
[14.0][FIX]stock_orderpoint_generator: update views to modern format

### DIFF
--- a/stock_orderpoint_generator/wizard/orderpoint_generator_view.xml
+++ b/stock_orderpoint_generator/wizard/orderpoint_generator_view.xml
@@ -24,20 +24,18 @@
             </form>
         </field>
     </record>
-    <act_window
-        name="Reordering Rules Generator"
-        res_model="stock.warehouse.orderpoint.generator"
-        binding_model="product.product"
-        view_mode="form"
-        target="new"
-        id="act_create_product_conf"
-    />
-    <act_window
-        name="Reordering Rules Generator"
-        res_model="stock.warehouse.orderpoint.generator"
-        binding_model="product.template"
-        view_mode="form"
-        target="new"
-        id="act_create_product_template_conf"
-    />
+    <record id="act_create_product_conf" model="ir.actions.act_window">
+        <field name="name">Reordering Rules Generator</field>
+        <field name="res_model">stock.warehouse.orderpoint.generator</field>
+        <field name="binding_model_id" ref="product.model_product_product" />
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+    <record id="act_create_product_template_conf" model="ir.actions.act_window">
+        <field name="name">Reordering Rules Generator</field>
+        <field name="res_model">stock.warehouse.orderpoint.generator</field>
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
 </odoo>


### PR DESCRIPTION
Fixes the following warnings during project build
- `DeprecationWarning: The <act_window> tag is deprecated, use a <record> for 'act_create_product_conf'. warnings.warn(f"The <act_window> tag is deprecated, use a <record> for {xml_id!r}.", DeprecationWarning)`
- `DeprecationWarning: The <act_window> tag is deprecated, use a <record> for 'act_create_product_template_conf'. warnings.warn(f"The <act_window> tag is deprecated, use a <record> for {xml_id!r}.", DeprecationWarning)`