### PR TITLE
[14.0][FIX] stock_orderpoint_origin: fix access error

### DIFF
--- a/stock_orderpoint_origin/models/procurement_group.py
+++ b/stock_orderpoint_origin/models/procurement_group.py
@@ -12,7 +12,7 @@ class ProcurementGroup(models.Model):
         # Store the reorder source Procurement Groups
         # To be used for reference and link navigation
         # Also updates the Origin field of the PO
-        Forecast = self.env["report.stock.report_product_product_replenishment"]
+        Forecast = self.env["report.stock.report_product_product_replenishment"].sudo()
         new_procurements = []
         for procurement in procurements:
             ForecastWH = Forecast


### PR DESCRIPTION
This commit fixes an AccessError that would happen because the report stock.report_product_product_replenishment references several objects (SOs, Pickings, etc) that the user may not have access to.

For example, the user may only have access to SOs that are assigned to them.