### PR TITLE
[15.0][IMP] stock_inventory: be able to do adjustments in same location but for different products

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -4,7 +4,7 @@ from odoo import _, api, fields, models
 class StockQuant(models.Model):
     _inherit = "stock.quant"
 
-    to_do = fields.Boolean(default=True)
+    to_do = fields.Boolean(default=False)
 
     def _apply_inventory(self):
         res = super()._apply_inventory()


### PR DESCRIPTION
Current Restriction is too much restrictive

The main idea is to be able to do adjustments in same location but for different products, also be able to do an inventory adjustment in a sublocation if there is an adjustment on the parent location but doing it "excluding sublocations"