### PR TITLE
[16.0][FIX] stock_quant_manual_assign

### DIFF
--- a/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
@@ -14,7 +14,11 @@
                         <field name="location_id" />
                         <field name="on_hand" force_save="1" />
                         <field name="reserved" force_save="1" />
-                        <field name="selected" widget="boolean_toggle" />
+                        <field
+                            name="selected"
+                            widget="boolean_toggle"
+                            options="{'autosave': False}"
+                        />
                         <field
                             name="qty"
                             attrs="{'readonly':[('selected', '=', False)]}"


### PR DESCRIPTION
Supersede of https://github.com/OCA/stock-logistics-warehouse/pull/1792
This PR is to address the issue that is raised when users toggle the boolean widget in wizard.

@qrtl 