### PR TITLE
[16.0][FIX] stock_quant_manual_assign: Correct handling of immediate transfers

### DIFF
--- a/stock_quant_manual_assign/README.rst
+++ b/stock_quant_manual_assign/README.rst
@@ -160,6 +160,10 @@ Contributors
 
    -  Tony Gu tony@openerp.cn
 
+* `Quartile <https://www.quartile.co>`_:
+
+  * Yoshi Tashiro
+
 Maintainers
 -----------
 

--- a/stock_quant_manual_assign/readme/CONTRIBUTORS.md
+++ b/stock_quant_manual_assign/readme/CONTRIBUTORS.md
@@ -15,3 +15,7 @@
 * `Shine IT <https://www.openerp.cn>`_:
 
   * Tony Gu <tony@openerp.cn>
+
+* `Quartile <https://www.quartile.co>`_:
+
+  * Yoshi Tashiro

--- a/stock_quant_manual_assign/static/description/index.html
+++ b/stock_quant_manual_assign/static/description/index.html
@@ -493,6 +493,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Tony Gu <a class="reference external" href="mailto:tony&#64;openerp.cn">tony&#64;openerp.cn</a></li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Yoshi Tashiro</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -60,13 +60,16 @@ class AssignManualQuants(models.TransientModel):
 
     def assign_quants(self):
         move = self.move_id
-        move._do_unreserve()
+        self.move_id.move_line_ids.unlink()
         for line in self.quants_lines:
             line._assign_quant_line()
         if move.picking_type_id.auto_fill_qty_done:
-            # Auto-fill all lines as done
-            for ml in move.move_line_ids:
-                ml.qty_done = ml.reserved_uom_qty
+            if move.from_immediate_transfer:
+                move.quantity_done = self.lines_qty
+            else:
+                # Auto-fill all lines as done
+                for ml in move.move_line_ids:
+                    ml.qty_done = ml.reserved_uom_qty
         move._recompute_state()
         move.mapped("picking_id")._compute_state()
         return {}


### PR DESCRIPTION
This commit fixes the following issues:

- The previous code does not handle the immediate transfer scenario when `auto_fill_qty_done` is selected in the operation type. This raises a missing-record error, trying to update `qty_done` on non-existing move line records.
- `move._do_unreserve()` keeps existing stock.move.line records if there is some `qty_done` set, which is not a desirable outcome. All the linked move line records should be unlinked before selected quants are assigned.

I also took the liberty of refactoring the test code a bit.

@qrtl QT4574
