### PR TITLE
[16.0][FIX] stock_reserve: Set the correct _default_picking_type_id value

### DIFF
--- a/stock_reserve/model/stock_reserve.py
+++ b/stock_reserve/model/stock_reserve.py
@@ -78,7 +78,17 @@ class StockReservation(models.Model):
         # If picking_type_id is present and location_id is not, try to find
         # default value for location_id
         if not res.get("picking_type_id", None):
-            res["picking_type_id"] = self._default_picking_type_id()
+            res["picking_type_id"] = (
+                self.env["stock.picking.type"]
+                .search(
+                    [
+                        ("code", "=", "outgoing"),
+                        ("company_id", "=", res.get("company_id")),
+                    ],
+                    limit=1,
+                )
+                .id
+            )
 
         picking_type_id = res.get("picking_type_id")
         if picking_type_id and not res.get("location_id", False):
@@ -105,11 +115,6 @@ class StockReservation(models.Model):
         except (except_orm, ValueError):
             location_id = False
         return location_id
-
-    @api.model
-    def _default_picking_type_id(self):
-        ref = "stock.picking_type_out"
-        return self.env.ref(ref, raise_if_not_found=False).id
 
     @api.model
     def _default_location_dest_id(self):


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/stock-logistics-warehouse/pull/2043

Set the correct `_default_picking_type_id` value

Do not use a fixed value because it will not be compatible with multi-company.

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT49168