### PR TITLE
[ADD] stock_exception: when to run the exception (confirm/validate)

### DIFF
--- a/stock_exception/__manifest__.py
+++ b/stock_exception/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Exception",
     "summary": "Custom exceptions on stock picking",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "category": "Generic Modules/Warehouse Management",
     "author": "Ecosoft, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
@@ -15,6 +15,7 @@
         "data/stock_exception_data.xml",
         "wizard/stock_exception_confirm_view.xml",
         "views/stock_view.xml",
+        "views/exception_rule_views.xml",
     ],
     "installable": True,
 }

--- a/stock_exception/data/stock_exception_data.xml
+++ b/stock_exception/data/stock_exception_data.xml
@@ -1,6 +1,6 @@
 <odoo noupdate="1">
     <!-- Test Stock Exceptions Scheduler-->
-    <record model="ir.cron" forcecreate="True" id="ir_cron_test_stock_picking_except">
+    <!-- <record model="ir.cron" forcecreate="True" id="ir_cron_test_stock_picking_except">
         <field name="name">Stock: Test Draft Pickings Exception</field>
         <field name="model_id" ref="stock.model_stock_picking" />
         <field name="state">code</field>
@@ -11,7 +11,7 @@
         <field name="numbercall">-1</field>
         <field name="doall" eval="False" />
         <field name="active" eval="False" />
-    </record>
+    </record> -->
     <record id="sp_excep_no_partner" model="exception.rule">
         <field name="name">No Partner</field>
         <field name="description">No Partner</field>

--- a/stock_exception/models/exception_rule.py
+++ b/stock_exception/models/exception_rule.py
@@ -15,3 +15,5 @@ class ExceptionRule(models.Model):
         ],
         ondelete={"stock.picking": "cascade", "stock.move": "cascade"},
     )
+    check_on_validate = fields.Boolean(default=False)
+    check_on_confirm = fields.Boolean(default=False)

--- a/stock_exception/models/stock.py
+++ b/stock_exception/models/stock.py
@@ -1,18 +1,22 @@
 # Copyright 2021 Ecosoft Co., Ltd (https://ecosoft.co.th)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
-from odoo import api, models
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class StockPicking(models.Model):
     _inherit = ["stock.picking", "base.exception"]
     _name = "stock.picking"
 
-    @api.model
-    def test_all_draft_pickings(self):
-        picking_set = self.search([("state", "=", "draft")])
-        picking_set.detect_exceptions()
-        return True
+    check_on_validate = fields.Boolean(compute="_compute_check_on_validate")
+    check_on_confirm = fields.Boolean(compute="_compute_check_on_confirm")
+
+    # @api.model
+    # def test_all_draft_pickings(self):
+    #     picking_set = self.search([("state", "=", "draft")])
+    #     picking_set.detect_exceptions()
+    #     return True
 
     @api.model
     def _reverse_field(self):
@@ -39,11 +43,50 @@ class StockPicking(models.Model):
 
     def action_confirm(self):
         for rec in self:
-            if rec.detect_exceptions() and not rec.ignore_exception:
+            if (
+                rec.detect_exceptions()
+                and not rec.ignore_exception
+                and rec.exception_ids.check_on_confirm
+            ):
                 return rec._popup_exceptions()
         return super().action_confirm()
+
+    def button_validate(self):
+        for rec in self:
+            if rec.detect_exceptions() and not rec.ignore_exception:
+                if rec.exception_ids.check_on_validate:
+                    raise ValidationError(
+                        "\n".join(rec.exception_ids.mapped("description"))
+                    )
+        return super().button_validate()
 
     @api.model
     def _get_popup_action(self):
         action = self.env.ref("stock_exception.action_stock_exception_confirm")
         return action
+
+    def _check_exception(self):
+        if not self.env.context.get("check_exception", True):
+            return True
+        exception_ids = self.detect_exceptions()
+        if exception_ids and self.env.context.get("raise_exception", True):
+            exceptions = self.env["exception.rule"].browse(exception_ids)
+            for rec in exceptions:
+                if rec.check_on_confirm and self.state == "assigned":
+                    raise ValidationError("\n".join(rec.mapped("description")))
+                if rec.check_on_validate and self.state == "done":
+                    raise ValidationError("\n".join(rec.mapped("description")))
+
+    def _compute_check_on_validate(self):
+        for rec in self:
+            if rec.exception_ids.check_on_validate:
+                rec.check_on_validate = True
+            else:
+                rec.check_on_validate = False
+
+    def _compute_check_on_confirm(self):
+        for rec in self:
+            if rec.exception_ids.check_on_confirm:
+                rec.check_on_confirm = True
+            else:
+                rec.check_on_confirm = False

--- a/stock_exception/views/exception_rule_views.xml
+++ b/stock_exception/views/exception_rule_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="view_exception_rule_form" model="ir.ui.view">
+        <field name="name">exception.rule.form</field>
+        <field name="model">exception.rule</field>
+        <field name="inherit_id" ref="base_exception.view_exception_rule_form" />
+        <field name="arch" type="xml">
+            <field name="model" position="after">
+                <field
+                    name="check_on_confirm"
+                    attrs="{'invisible': [('model', '!=', 'stock.picking')]}"
+                />
+                <field
+                    name="check_on_validate"
+                    attrs="{'invisible': [('model', '!=', 'stock.picking')]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/stock_exception/views/stock_view.xml
+++ b/stock_exception/views/stock_view.xml
@@ -26,7 +26,7 @@
                     class="alert alert-danger"
                     role="alert"
                     style="margin-bottom:0px;"
-                    attrs="{'invisible': [('exceptions_summary', '=', False)]}"
+                    attrs="{'invisible': ['|', ('exceptions_summary', '=', False), ('check_on_validate', '=', False)]}"
                 >
                     <p>
                         <strong
@@ -50,6 +50,8 @@
                     groups='base_exception.group_exception_rule_manager'
                 />
                 <field name="exception_ids" widget="many2many_tags" readonly="True" />
+                <field name="check_on_validate" invisible="1" />
+                <field name="check_on_confirm" invisible="1" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
When we were testing the model, in case we choose 'stock.picking' as the model where we wanted to apply the exception, we noticed that the exception also ran when we confirmed sale orders.
This happens because, by confirming sale orders, the action confirm creates the respective records in stock.picking (IN/OUT, depending on the configuration you have) and run the exception.
What we want is to have the decision when to run the exception, if at the creation of the stock.picking record or if at the validation of the stock.picking record.

Due to this desire, we created two new boolean fields in the stock.exception class (check_on_validate and check_on_confirm) in order to indicate when to run the exception. If you select check_on_confirm, it will run the exception when you create the stock.picking record. If you select check_on_validate, it will run the exception when you validate the stock.picking record.