### PR TITLE
[15.0][FIX] stock_inventory: prevent error when applying inventory without quantities

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -9,6 +9,7 @@ class StockQuant(models.Model):
     def _apply_inventory(self):
         res = super()._apply_inventory()
         record_moves = self.env["stock.move.line"]
+        adjustment = self.env["stock.inventory"].browse()
         for rec in self:
             adjustment = (
                 self.env["stock.inventory"]


### PR DESCRIPTION
Just create an inventory adjustment for all products and select all the quants and click on "apply".

```
  File "/opt/odoo/auto/addons/stock_inventory/models/stock_quant.py", line 54, in _apply_inventory
    if adjustment and self.env.company.stock_inventory_auto_complete:
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
UnboundLocalError: local variable 'adjustment' referenced before assignment
```

cc @ForgeFlow