### PR TITLE
[15.0][IMP] stock_inventory: adjust restriction

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -15,10 +15,14 @@ class StockQuant(models.Model):
                 self.env["stock.inventory"]
                 .search([("state", "=", "in_progress")])
                 .filtered(
-                    lambda x: rec.location_id in x.location_ids
-                    or (
-                        rec.location_id in x.location_ids.child_internal_location_ids
-                        and not x.exclude_sublocation
+                    lambda x: (rec.product_id in x._get_products())
+                    and (
+                        rec.location_id in x.location_ids
+                        or (
+                            rec.location_id
+                            in x.location_ids.child_internal_location_ids
+                            and not x.exclude_sublocation
+                        )
                     )
                 )
             )


### PR DESCRIPTION
This change allows to create several inventory adjustments on the same location if the products involved are different

You may say that creating inventory adjustment in the same location by product category is not efficient and I agree with that. However, the possibility is there, and the constraint should not be raised in this case.

@ ForgeFlow