### PR TITLE
[16.0][FIX] stock_inventory: create missing quants if needed

### DIFF
--- a/stock_inventory/i18n/fr.po
+++ b/stock_inventory/i18n/fr.po
@@ -98,6 +98,11 @@ msgid "Config Settings"
 msgstr ""
 
 #. module: stock_inventory
+#: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__auto_create_missing_quants
+msgid "Create missing quants"
+msgstr "Créer les quants manquants"
+
+#. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__create_uid
 msgid "Created by"
 msgstr "Créé par"

--- a/stock_inventory/i18n/fr.po
+++ b/stock_inventory/i18n/fr.po
@@ -4,17 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-08-01 09:58+0000\n"
-"Last-Translator: \"Benjamin Willig (ACSONE)\" <benjamin.willig@acsone.eu>\n"
-"Language-Team: none\n"
-"Language: fr\n"
+"POT-Creation-Date: 2024-08-01 11:57+0000\n"
+"PO-Revision-Date: 2024-08-01 11:57+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 5.6.2\n"
+"Plural-Forms: \n"
 
 #. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__count_stock_quants
@@ -95,7 +94,7 @@ msgstr "Société"
 #. module: stock_inventory
 #: model:ir.model,name:stock_inventory.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Paramètres de config"
 
 #. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__auto_create_missing_quants
@@ -115,7 +114,7 @@ msgstr "Créé le"
 #. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__date
 msgid "Date"
-msgstr "Date"
+msgstr ""
 
 #. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__display_name
@@ -155,7 +154,7 @@ msgstr ""
 #. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: stock_inventory
 #: model:ir.model.fields,help:stock_inventory.field_stock_inventory__message_needaction
@@ -164,6 +163,7 @@ msgstr ""
 
 #. module: stock_inventory
 #: model:ir.model.fields,help:stock_inventory.field_stock_inventory__message_has_error
+#: model:ir.model.fields,help:stock_inventory.field_stock_inventory__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
 msgstr ""
 
@@ -177,6 +177,14 @@ msgstr ""
 "sélectionnés, et pas leurs enfants."
 
 #. module: stock_inventory
+#: model:ir.model.fields,help:stock_inventory.field_res_company__stock_inventory_auto_create_missing_quants
+#: model:ir.model.fields,help:stock_inventory.field_res_config_settings__stock_inventory_auto_create_missing_quants
+msgid ""
+"If enabled, missing quants will be created on the inventory confirmation"
+msgstr ""
+"Si activé, les quants manquants seront créés au moment de la confirmation de l'inventaire"
+
+#. module: stock_inventory
 #: model:ir.model.fields,help:stock_inventory.field_res_company__stock_inventory_auto_complete
 #: model:ir.model.fields,help:stock_inventory.field_res_config_settings__stock_inventory_auto_complete
 #: model_terms:ir.ui.view,arch_db:stock_inventory.res_config_settings_view_form
@@ -184,7 +192,7 @@ msgid ""
 "If enabled, when all the quants prepared for the adjustment are done, the "
 "adjustment is automatically set to done."
 msgstr ""
-"Si activé, lorsque tout les quants préparés pour l'ajustement sont finis, "
+"Si activé, lorsque tous les quants préparés pour l'ajustement sont finis, "
 "l'inventaire sera automatiquement marqué comme terminé."
 
 #. module: stock_inventory
@@ -276,13 +284,6 @@ msgid "Messages"
 msgstr ""
 
 #. module: stock_inventory
-#. odoo-python
-#: code:addons/stock_inventory/models/stock_quant.py:0
-#, python-format
-msgid "No move lines have been created"
-msgstr "Aucune ligne de mouvement de stock n'a été créée"
-
-#. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__message_needaction_counter
 msgid "Number of Actions"
 msgstr ""
@@ -315,7 +316,7 @@ msgstr "Propriétaire"
 #. module: stock_inventory
 #: model_terms:ir.ui.view,arch_db:stock_inventory.stock_inventory_search_view
 msgid "Product"
-msgstr ""
+msgstr "Produit"
 
 #. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__category_id
@@ -326,7 +327,7 @@ msgstr "Catégorie d'article"
 #. module: stock_inventory
 #: model:ir.model,name:stock_inventory.model_stock_move_line
 msgid "Product Moves (Stock Move Line)"
-msgstr "Mouvements de stock"
+msgstr "Mouvements de produit (Ligne de mouvement de stock)"
 
 #. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__product_selection
@@ -347,7 +348,12 @@ msgstr ""
 #. module: stock_inventory
 #: model:ir.model,name:stock_inventory.model_stock_quant
 msgid "Quants"
-msgstr "Quants"
+msgstr ""
+
+#. module: stock_inventory
+#: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
 
 #. module: stock_inventory
 #: model_terms:ir.ui.view,arch_db:stock_inventory.view_inventory_group_form
@@ -381,6 +387,12 @@ msgid "Stock Inventory Auto Complete"
 msgstr "Fermeture automatique des inventaires"
 
 #. module: stock_inventory
+#: model:ir.model.fields,field_description:stock_inventory.field_res_company__stock_inventory_auto_create_missing_quants
+#: model:ir.model.fields,field_description:stock_inventory.field_res_config_settings__stock_inventory_auto_create_missing_quants
+msgid "Stock Inventory Auto Create Missing Quants"
+msgstr "Création automatique des quants manquants sur un inventaire"
+
+#. module: stock_inventory
 #: model:ir.actions.act_window,name:stock_inventory.action_view_stock_move_line_inventory_tree
 msgid "Stock Move Lines"
 msgstr "Lignes de mouvement de stock"
@@ -395,8 +407,8 @@ msgstr "Lignes de mouvement de stock"
 #: code:addons/stock_inventory/models/stock_inventory.py:0
 #, python-format
 msgid ""
-"There are active adjustments for the requested products: %(names)s. Blocking "
-"adjustments: %(blocking_names)s"
+"There are active adjustments for the requested products: %(names)s. Blocking"
+" adjustments: %(blocking_names)s"
 msgstr ""
 "Il y a des ajustements actifs pour les produits demandées : %(names)s. "
 "Ajustements bloquants: %(blocking_names)s"
@@ -424,6 +436,11 @@ msgid "To Do"
 msgstr "A faire"
 
 #. module: stock_inventory
+#: model:ir.model.fields,field_description:stock_inventory.field_stock_quant__virtual_in_progress_inventory_id
+msgid "Virtual In Progress Inventory"
+msgstr ""
+
+#. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__website_message_ids
 msgid "Website Messages"
 msgstr ""
@@ -438,8 +455,8 @@ msgstr ""
 #: code:addons/stock_inventory/models/stock_inventory.py:0
 #, python-format
 msgid ""
-"When 'Product Selection: Lot Serial Number' is selected you are only able to "
-"add one product."
+"When 'Product Selection: Lot Serial Number' is selected you are only able to"
+" add one product."
 msgstr ""
 "Quand 'Sélection d'article : Lot/Numéro de série' est sélectionné, vous "
 "n'êtes en mesure d'ajouter qu'un seul article."
@@ -452,8 +469,8 @@ msgid ""
 "When 'Product Selection: One Product' is selected you are only able to add "
 "one product."
 msgstr ""
-"Quand 'Sélection d'article : article unique' est sélectionné, vous n'êtes en "
-"mesure d'ajouter qu'un seul article."
+"Quand 'Sélection d'article : article unique' est sélectionné, vous n'êtes en"
+" mesure d'ajouter qu'un seul article."
 
 #. module: stock_inventory
 #. odoo-python
@@ -466,9 +483,3 @@ msgstr "Vous ne pouvez pas annuler cet inventaire %(display_name)s."
 #: model_terms:ir.ui.view,arch_db:stock_inventory.view_inventory_group_form
 msgid "e.g. Annual inventory"
 msgstr "par ex. Inventaire annuel"
-
-#, python-format
-#~ msgid ""
-#~ "There's already an Adjustment in Process using one requested Location: %s"
-#~ msgstr ""
-#~ "Il y a déjà un ajustement en cours qui utilise l'emplacement demandé : %s"

--- a/stock_inventory/i18n/stock_inventory.pot
+++ b/stock_inventory/i18n/stock_inventory.pot
@@ -93,6 +93,11 @@ msgid "Config Settings"
 msgstr ""
 
 #. module: stock_inventory
+#: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__auto_create_missing_quants
+msgid "Create missing quants"
+msgstr ""
+
+#. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__create_uid
 msgid "Created by"
 msgstr ""

--- a/stock_inventory/i18n/stock_inventory.pot
+++ b/stock_inventory/i18n/stock_inventory.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-01 11:57+0000\n"
+"PO-Revision-Date: 2024-08-01 11:57+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -159,6 +161,7 @@ msgstr ""
 
 #. module: stock_inventory
 #: model:ir.model.fields,help:stock_inventory.field_stock_inventory__message_has_error
+#: model:ir.model.fields,help:stock_inventory.field_stock_inventory__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
 msgstr ""
 
@@ -167,6 +170,13 @@ msgstr ""
 msgid ""
 "If enabled, it will only take into account the locations selected, and not "
 "their children."
+msgstr ""
+
+#. module: stock_inventory
+#: model:ir.model.fields,help:stock_inventory.field_res_company__stock_inventory_auto_create_missing_quants
+#: model:ir.model.fields,help:stock_inventory.field_res_config_settings__stock_inventory_auto_create_missing_quants
+msgid ""
+"If enabled, missing quants will be created on the inventory confirmation"
 msgstr ""
 
 #. module: stock_inventory
@@ -267,13 +277,6 @@ msgid "Messages"
 msgstr ""
 
 #. module: stock_inventory
-#. odoo-python
-#: code:addons/stock_inventory/models/stock_quant.py:0
-#, python-format
-msgid "No move lines have been created"
-msgstr ""
-
-#. module: stock_inventory
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__message_needaction_counter
 msgid "Number of Actions"
 msgstr ""
@@ -341,6 +344,11 @@ msgid "Quants"
 msgstr ""
 
 #. module: stock_inventory
+#: model:ir.model.fields,field_description:stock_inventory.field_stock_inventory__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: stock_inventory
 #: model_terms:ir.ui.view,arch_db:stock_inventory.view_inventory_group_form
 msgid "Set to Done"
 msgstr ""
@@ -369,6 +377,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_inventory.field_res_company__stock_inventory_auto_complete
 #: model:ir.model.fields,field_description:stock_inventory.field_res_config_settings__stock_inventory_auto_complete
 msgid "Stock Inventory Auto Complete"
+msgstr ""
+
+#. module: stock_inventory
+#: model:ir.model.fields,field_description:stock_inventory.field_res_company__stock_inventory_auto_create_missing_quants
+#: model:ir.model.fields,field_description:stock_inventory.field_res_config_settings__stock_inventory_auto_create_missing_quants
+msgid "Stock Inventory Auto Create Missing Quants"
 msgstr ""
 
 #. module: stock_inventory
@@ -408,6 +422,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_inventory.field_stock_quant__to_do
 #: model_terms:ir.ui.view,arch_db:stock_inventory.view_stock_quant_search_not_done
 msgid "To Do"
+msgstr ""
+
+#. module: stock_inventory
+#: model:ir.model.fields,field_description:stock_inventory.field_stock_quant__virtual_in_progress_inventory_id
+msgid "Virtual In Progress Inventory"
 msgstr ""
 
 #. module: stock_inventory

--- a/stock_inventory/models/res_company.py
+++ b/stock_inventory/models/res_company.py
@@ -13,3 +13,7 @@ class ResCompany(models.Model):
         "are done, the adjustment is automatically set to done.",
         default=False,
     )
+    stock_inventory_auto_create_missing_quants = fields.Boolean(
+        help="If enabled, missing quants will be created on the inventory confirmation",
+        default=False,
+    )

--- a/stock_inventory/models/res_company.py
+++ b/stock_inventory/models/res_company.py
@@ -11,9 +11,7 @@ class ResCompany(models.Model):
     stock_inventory_auto_complete = fields.Boolean(
         help="If enabled, when all the quants prepared for the adjustment "
         "are done, the adjustment is automatically set to done.",
-        default=False,
     )
     stock_inventory_auto_create_missing_quants = fields.Boolean(
         help="If enabled, missing quants will be created on the inventory confirmation",
-        default=False,
     )

--- a/stock_inventory/models/res_config_settings.py
+++ b/stock_inventory/models/res_config_settings.py
@@ -10,3 +10,6 @@ class ResConfigSettings(models.TransientModel):
     stock_inventory_auto_complete = fields.Boolean(
         related="company_id.stock_inventory_auto_complete", readonly=False
     )
+    stock_inventory_auto_create_missing_quants = fields.Boolean(
+        related="company_id.stock_inventory_auto_create_missing_quants", readonly=False
+    )

--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -395,13 +395,7 @@ class InventoryAdjustmentsGroup(models.Model):
     def action_state_to_done(self):
         self.ensure_one()
         self.state = "done"
-        self.stock_quant_ids.update(
-            {
-                "to_do": False,
-                "user_id": False,
-                "inventory_date": False,
-            }
-        )
+        self._reset_quant_inventory_values()
         return
 
     def action_auto_state_to_done(self):
@@ -413,19 +407,14 @@ class InventoryAdjustmentsGroup(models.Model):
     def action_state_to_draft(self):
         self.ensure_one()
         self.state = "draft"
-        self.stock_quant_ids.update(
-            {
-                "to_do": False,
-                "user_id": False,
-                "inventory_date": False,
-            }
-        )
+        self._reset_quant_inventory_values()
         self.stock_quant_ids = None
         return
 
     def action_state_to_cancel(self):
         self.ensure_one()
         self._check_action_state_to_cancel()
+        self._reset_quant_inventory_values()
         self.write(
             {
                 "state": "cancel",
@@ -472,6 +461,16 @@ class InventoryAdjustmentsGroup(models.Model):
         result["domain"] = [("inventory_adjustment_id", "=", self.id)]
         result["context"] = {}
         return result
+
+    def _reset_quant_inventory_values(self):
+        self.ensure_one()
+        self.stock_quant_ids.write(
+            {
+                "to_do": False,
+                "user_id": False,
+                "inventory_date": False,
+            }
+        )
 
     def _check_inventory_in_progress_not_override(self):
         for rec in self:

--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -155,6 +155,13 @@ class InventoryAdjustmentsGroup(models.Model):
         relation="stock_inventory_product_review_rel",
     )
 
+    auto_create_missing_quants = fields.Boolean(
+        string="Create missing quants",
+        readonly=True,
+        states=READONLY_STATES,
+        default=False,
+    )
+
     def _search_products_under_review_ids(self, operator, value):
         quants = self.env["stock.quant"].search(
             [("to_do", "=", True), ("product_id", operator, value)]
@@ -207,6 +214,13 @@ class InventoryAdjustmentsGroup(models.Model):
         for rec in self:
             rec.action_state_to_cancel_allowed = rec.state == "draft"
 
+    @api.onchange("company_id")
+    def _onchange_load_auto_create_missing_quants(self):
+        for rec in self:
+            rec.auto_create_missing_quants = (
+                rec.company_id.stock_inventory_auto_create_missing_quants
+            )
+
     def _get_quants(self, locations):
         self.ensure_one()
         domain = []
@@ -222,6 +236,40 @@ class InventoryAdjustmentsGroup(models.Model):
         elif self.product_selection == "category":
             domain = self._get_domain_category_quants(base_domain)
         return self.env["stock.quant"].search(domain)
+
+    def _get_or_create_quants(self):
+        """
+        Create or retrieve stock.quant for the given inventory configuration
+        :return: stock.quant
+        """
+        self.ensure_one()
+        quant_ids = []
+        for quant_values in self._get_quants_values():
+            quant = self._get_quant(quant_values)
+            quant_ids.append(quant.id)
+        return self.env["stock.quant"].browse(quant_ids)
+
+    def _get_quant(self, quant_values):
+        """
+        Get an existing or create a new quant based on preloaded quant values
+        product_id, lot_id and location_id must be present.
+        :param quant_values:
+        :return:
+        """
+        self.ensure_one()
+        Quant = self.env["stock.quant"]
+
+        quant = Quant.search(
+            [
+                ("product_id", "=", quant_values.get("product_id")),
+                ("lot_id", "=", quant_values.get("lot_id")),
+                ("location_id", "=", quant_values.get("location_id")),
+            ],
+            limit=1,
+        )
+        if not quant:
+            quant = Quant.create(quant_values)
+        return quant
 
     def _get_base_domain(self, locations):
         return (
@@ -286,7 +334,7 @@ class InventoryAdjustmentsGroup(models.Model):
     def _get_quant_joined_names(self, quants, field):
         return ", ".join(quants.mapped(f"{field}.display_name"))
 
-    def action_state_to_in_progress(self):
+    def _check_existing_in_progress_inventory(self):
         self.ensure_one()
         search_filter = [
             (
@@ -324,6 +372,11 @@ class InventoryAdjustmentsGroup(models.Model):
                     error_message % {"names": names, "blocking_names": blocking_names}
                 )
 
+    def action_state_to_in_progress(self):
+        self.ensure_one()
+        self._check_existing_in_progress_inventory()
+        if self.auto_create_missing_quants:
+            self._get_or_create_quants()
         quants = self._get_quants(self.location_ids)
         self.write(
             {
@@ -334,7 +387,7 @@ class InventoryAdjustmentsGroup(models.Model):
         quants.write(
             {
                 "to_do": True,
-                "user_id": self.responsible_id,
+                "user_id": self.responsible_id.id or self.env.user.id,
                 "inventory_date": self.date,
             }
         )
@@ -399,11 +452,12 @@ class InventoryAdjustmentsGroup(models.Model):
                 "search_default_to_do": 1,
                 "inventory_id": self.id,
                 "default_to_do": True,
+                "default_user_id": self.env.user.id,
             }
         )
         result.update(
             {
-                "domain": [("id", "in", self.stock_quant_ids.ids)],
+                "domain": [("stock_inventory_ids", "in", self.ids)],
                 "search_view_id": self.env.ref("stock.quant_search_view").id,
                 "context": context,
             }
@@ -470,3 +524,117 @@ class InventoryAdjustmentsGroup(models.Model):
                             " you are only able to add one product."
                         )
                     )
+
+    def _get_inventory_product_domain(self):
+        self.ensure_one()
+        product_selection = self.product_selection
+        domain = []
+        if product_selection == "all":
+            domain = self._get_inventory_product_domain_all()
+        elif product_selection == "manual":
+            domain = self._get_inventory_product_domain_manual()
+        elif product_selection == "one":
+            domain = self._get_inventory_product_domain_one()
+        elif product_selection == "lot":
+            domain = self._get_inventory_product_domain_lot()
+        elif product_selection == "category":
+            domain = self._get_inventory_product_domain_category()
+        return expression.AND(
+            [
+                [
+                    ("type", "=", "product"),
+                ],
+                domain,
+            ]
+        )
+
+    def _get_inventory_product_domain_all(self):
+        self.ensure_one()
+        return [
+            ("type", "=", "product"),
+        ]
+
+    def _get_inventory_product_domain_manual(self):
+        self.ensure_one()
+        return [
+            ("id", "in", self.product_ids.ids),
+        ]
+
+    def _get_inventory_product_domain_one(self):
+        self.ensure_one()
+        return [
+            ("id", "in", self.product_ids.ids),
+        ]
+
+    def _get_inventory_product_domain_lot(self):
+        self.ensure_one()
+        return [
+            ("id", "in", self.product_ids.ids),
+        ]
+
+    def _get_inventory_product_domain_category(self):
+        self.ensure_one()
+        category = self.category_id
+        return [
+            "|",
+            ("categ_id", "=", category.id),
+            ("categ_id", "in", category.child_id.ids),
+        ]
+
+    def _get_quants_values(self):
+        self.ensure_one()
+        product_domain = self._get_inventory_product_domain()
+        products = self.env["product.product"].search(product_domain)
+        inv_lots = self.lot_ids
+        quants_values = []
+        locations = self._get_locations()
+        for product in products:
+            if product.tracking in ("lot", "serial"):
+                product_lots = self._get_product_lots(product)
+                for lot in product_lots:
+                    if inv_lots and lot not in inv_lots:
+                        continue
+                    quants_values.extend(
+                        self._get_new_quants_values(product, locations, lot_id=lot.id)
+                    )
+            else:
+                quants_values.extend(self._get_new_quants_values(product, locations))
+        return quants_values
+
+    def _get_new_quant_base_values(self, product, **kwargs):
+        self.ensure_one()
+        values = {
+            "product_id": product.id,
+            "user_id": self.env.user.id,
+            "stock_inventory_ids": [(4, self.id)],
+        }
+        values.update(kwargs)
+        return values
+
+    def _get_new_quants_values(self, product, locations, **kwargs):
+        base_values = self._get_new_quant_base_values(product, **kwargs)
+        quants_values = []
+        for location in locations:
+            values = base_values.copy()
+            values["location_id"] = location.id
+            quants_values.append(values)
+        return quants_values
+
+    def _get_locations(self):
+        self.ensure_one()
+        locations = self.location_ids
+        if self.exclude_sublocation:
+            domain = [("id", "in", locations.ids)]
+        else:
+            domain = [
+                ("location_id", "child_of", locations.child_internal_location_ids.ids)
+            ]
+        return self.env["stock.location"].search(domain)
+
+    def _get_product_lots(self, product):
+        self.ensure_one()
+        return self.env["stock.lot"].search(
+            [
+                ("product_id", "=", product.id),
+            ]
+        )

--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -159,7 +159,6 @@ class InventoryAdjustmentsGroup(models.Model):
         string="Create missing quants",
         readonly=True,
         states=READONLY_STATES,
-        default=False,
     )
 
     def _search_products_under_review_ids(self, operator, value):
@@ -451,6 +450,7 @@ class InventoryAdjustmentsGroup(models.Model):
             {
                 "search_default_to_do": 1,
                 "inventory_id": self.id,
+                "default_stock_inventory_ids": [(4, self.id)],
                 "default_to_do": True,
                 "default_user_id": self.env.user.id,
             }
@@ -605,7 +605,7 @@ class InventoryAdjustmentsGroup(models.Model):
         self.ensure_one()
         values = {
             "product_id": product.id,
-            "user_id": self.env.user.id,
+            "user_id": self.responsible_id.id or self.env.user.id,
             "stock_inventory_ids": [(4, self.id)],
         }
         values.update(kwargs)

--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -37,7 +37,12 @@ class StockQuant(models.Model):
     )
 
     def _apply_inventory(self):
-        res = super()._apply_inventory()
+        context = dict(self.env.context)
+        context.pop("default_to_do", False)
+        context.pop("default_stock_inventory_ids", False)
+        res = super(
+            StockQuant, self.with_context(context)  # pylint: disable=W8121
+        )._apply_inventory()
         record_moves = self.env["stock.move.line"]
         adjustment = self.env["stock.inventory"].browse()
         for rec in self:

--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -1,9 +1,10 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockQuant(models.Model):
     _inherit = "stock.quant"
 
+    to_do = fields.Boolean(default=False)
     virtual_in_progress_inventory_id = fields.Many2one(
         comodel_name="stock.inventory",
         compute="_compute_virtual_in_progress_inventory_id",
@@ -15,20 +16,17 @@ class StockQuant(models.Model):
     )
 
     def _compute_virtual_in_progress_inventory_id(self):
-        Inventory = self.env["stock.inventory"]
+        locations = self.mapped("location_id")
+        inventories = self.env["stock.inventory"].search(
+            self._get_virtual_in_progress_inventory_domain(locations),
+            limit=1,
+        )
         for rec in self:
-            rec.virtual_in_progress_inventory_id = Inventory.search(
-                [
-                    ("state", "=", "in_progress"),
-                    "|",
-                    "&",
-                    ("exclude_sublocation", "=", False),
-                    ("location_ids", "parent_of", rec.location_id.ids),
-                    "&",
-                    ("exclude_sublocation", "=", True),
-                    ("location_ids", "in", rec.location_id.ids),
-                ],
-                limit=1,
+            filtered_inventories = inventories.filtered_domain(
+                self._get_virtual_in_progress_inventory_domain(rec.location_id)
+            )
+            rec.virtual_in_progress_inventory_id = (
+                filtered_inventories[0] if filtered_inventories else False
             )
 
     stock_inventory_ids = fields.Many2many(
@@ -94,3 +92,16 @@ class StockQuant(models.Model):
 
     def _get_inventory_fields_write(self):
         return super()._get_inventory_fields_write() + ["to_do"]
+
+    @api.model
+    def _get_virtual_in_progress_inventory_domain(self, locations):
+        return [
+            ("state", "=", "in_progress"),
+            "|",
+            "&",
+            ("exclude_sublocation", "=", False),
+            ("location_ids", "parent_of", locations.ids),
+            "&",
+            ("exclude_sublocation", "=", True),
+            ("location_ids", "in", locations.ids),
+        ]

--- a/stock_inventory/views/res_config_settings_view.xml
+++ b/stock_inventory/views/res_config_settings_view.xml
@@ -22,6 +22,16 @@
                         </div>
                     </div>
                 </div>
+                <div class="row mt16 o_settings_container">
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="stock_inventory_auto_create_missing_quants" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="stock_inventory_auto_create_missing_quants" />
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>

--- a/stock_inventory/views/stock_inventory.xml
+++ b/stock_inventory/views/stock_inventory.xml
@@ -89,6 +89,10 @@
                                 attrs="{'readonly':[('state', 'in', ['in_progress', 'done'])]}"
                                 required="1"
                             />
+                            <field
+                                name="auto_create_missing_quants"
+                                attrs="{'invisible':[('state', 'in', ['in_progress', 'done'])]}"
+                            />
                         </group>
                         <group>
                             <field name="date" />

--- a/stock_inventory/views/stock_quant.xml
+++ b/stock_inventory/views/stock_quant.xml
@@ -1,4 +1,15 @@
 <odoo>
+    <record model="ir.ui.view" id="view_stock_quant_tree_inventory_editable">
+        <field name="name">stock.quant.tree stock inventory</field>
+        <field name="model">stock.quant</field>
+        <field name="inherit_id" ref="stock.view_stock_quant_tree_inventory_editable" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field name="to_do" invisible="1" />
+                <field name="stock_inventory_ids" invisible="1" />
+            </xpath>
+        </field>
+    </record>
     <record id="view_stock_quant_search_not_done" model="ir.ui.view">
             <field name="name">stock.quant.search.not.done</field>
             <field name="model">stock.quant</field>


### PR DESCRIPTION
Based on https://github.com/OCA/stock-logistics-warehouse/pull/2017

- Display quant smartbutton even when there is no existing quant to allow creating new ones
- Adds a boolean on the inventory to create missing quants with zero quantity

cc @DavidJForgeFlow @rousseldenis 