### PR TITLE
[15.0][FIX] stock_inventory: warning on invalid tracking field

### DIFF
--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -107,7 +107,6 @@ class InventoryAdjustmentsGroup(models.Model):
         string="Assigned to",
         states={"draft": [("readonly", False)]},
         readonly=True,
-        tracking=True,
         help="Specific responsible of Inventory Adjustment.",
     )
 


### PR DESCRIPTION
The model "stock.inventory" does not inherit "mail.thread", so tracking field does nothing and a warning is displayed.

An alternative solution would be adding the "mail.thread" inheritance

T-6225