### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/stock_putaway_method/__manifest__.py
+++ b/stock_putaway_method/__manifest__.py
@@ -6,7 +6,7 @@
     "version": "14.0.1.0.0",
     "category": "Inventory",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
-    "author": "Camptocamp SA, " "Odoo Community Association (OCA)",
+    "author": "Camptocamp, " "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["product", "stock"],
     "data": ["views/product_strategy_views.xml"],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.