### PR TITLE
[12.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/stock_account_internal_move/__manifest__.py
+++ b/stock_account_internal_move/__manifest__.py
@@ -6,7 +6,7 @@
                """ via accounts.""",
     'category': "Warehouse",
     'version': "12.0.1.0.0",
-    'author': "Camptocamp SA,"
+    'author': "Camptocamp,"
               " Odoo Community Association (OCA)",
     'website': "https://github.com/OCA/stock-logistics-warehouse",
     'license': "AGPL-3",

--- a/stock_putaway_method/__manifest__.py
+++ b/stock_putaway_method/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '12.0.1.0.0',
     'category': 'Inventory',
     'website': 'https://github.com/OCA/stock-logistics-warehouse',
-    'author': 'Camptocamp SA, '
+    'author': 'Camptocamp, '
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'depends': [


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 12.0.