### PR TITLE
Backported freezegun to 13.0 requirements.txt from 14.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 # generated from manifests external_dependencies
 cubiscan
+freezegun==0.3.11; python_version < '3.8'
+freezegun==0.3.15; python_version >= '3.8'


### PR DESCRIPTION
My PR https://github.com/OCA/stock-logistics-warehouse/pull/2056 was failing due to the freezegun missing from requirements.txt so I created back-porting 