### PR TITLE
[14.0][FIX] stock_request: write method to update state in _compute_state 

### DIFF
--- a/stock_request/models/stock_request_order.py
+++ b/stock_request/models/stock_request_order.py
@@ -151,13 +151,13 @@ class StockRequestOrder(models.Model):
         for item in self:
             states = item.stock_request_ids.mapped("state")
             if not item.stock_request_ids or all(x == "draft" for x in states):
-                item.state = "draft"
+                item.write({"state": "draft"})
             elif all(x == "cancel" for x in states):
-                item.state = "cancel"
+                item.write({"state": "cancel"})
             elif all(x in ("done", "cancel") for x in states):
-                item.state = "done"
+                item.write({"state": "done"})
             else:
-                item.state = "open"
+                item.write({"state": "open"})
 
     @api.depends("stock_request_ids.allocation_ids")
     def _compute_picking_ids(self):


### PR DESCRIPTION
cc @marcelsavegnago @ForgeFlow @victoralmau @pedrobaeza

As described in issue [#2066](https://github.com/OCA/stock-logistics-warehouse/issues/2066), after implementing the compute_state method in stock_request, a conflict arose with stock_request_tier_validation. When an SRO had tier validation active and pending reviews, it was confirmed without considering the tier validation status.

Upon analyzing the code, I opted to use item.write to set the status instead of simply assigning it with =. Following this change, the behavior aligned with expectations, where each SR and SRO operates individually according to their tier validation. Prior to this, if an SR was confirmed with an SRO having pending reviews, the action was executed while ignoring the pending reviews.