### PR TITLE
[FIX] stock_mts_mto_rule: multiple procs same product

### DIFF
--- a/stock_mts_mto_rule/models/stock_rule.py
+++ b/stock_mts_mto_rule/models/stock_rule.py
@@ -36,14 +36,16 @@ class StockRule(models.Model):
                     ) % (rule.name,)
                     raise ValidationError(msg)
 
-    def get_mto_qty_to_order(self, product, product_qty, product_uom, values):
+    def get_mto_qty_to_order(
+        self, product, product_qty, product_uom, values, done_proc_qty=0.0
+    ):
         self.ensure_one()
         precision = self.env["decimal.precision"].precision_get(
             "Product Unit of Measure"
         )
         src_location_id = self.mts_rule_id.location_src_id.id
         product_location = product.with_context(location=src_location_id)
-        virtual_available = product_location.virtual_available
+        virtual_available = product_location.virtual_available - done_proc_qty
         qty_available = product.uom_id._compute_quantity(virtual_available, product_uom)
         if float_compare(qty_available, 0.0, precision_digits=precision) > 0:
             if (
@@ -59,6 +61,7 @@ class StockRule(models.Model):
         precision = self.env["decimal.precision"].precision_get(
             "Product Unit of Measure"
         )
+        done_procurements_by_product = {}
         for procurement, rule in procurements:
             domain = self.env["procurement.group"]._get_moves_to_assign_domain(
                 procurement.company_id.id
@@ -68,6 +71,9 @@ class StockRule(models.Model):
                 procurement.product_qty,
                 procurement.product_uom,
                 procurement.values,
+                done_proc_qty=done_procurements_by_product.get(
+                    procurement.product_id.id, 0.0
+                ),
             )
             if float_is_zero(needed_qty, precision_digits=precision):
                 getattr(self.env["stock.rule"], "_run_%s" % rule.mts_rule_id.action)(
@@ -104,4 +110,8 @@ class StockRule(models.Model):
                 getattr(self.env["stock.rule"], "_run_%s" % rule.mto_rule_id.action)(
                     [(mto_procurement, rule.mto_rule_id)]
                 )
+            done_procurements_by_product.setdefault(procurement.product_id.id, 0)
+            done_procurements_by_product[
+                procurement.product_id.id
+            ] += procurement.product_qty
         return True

--- a/stock_mts_mto_rule/tests/test_mto_mts_route.py
+++ b/stock_mts_mto_rule/tests/test_mto_mts_route.py
@@ -213,6 +213,50 @@ class TestMtoMtsRoute(TransactionCase):
         self.warehouse.name = new_warehouse_name
         self.assertEqual(new_rule_name, self.warehouse.mts_mto_rule_id.name)
 
+    def test_multiple_procurements(self):
+        mto_mts_route = self.env.ref("stock_mts_mto_rule.route_mto_mts")
+        self.product.route_ids = [(6, 0, [mto_mts_route.id])]
+        self._create_quant(1.0)
+        group2 = self.env["procurement.group"].create({"name": "test_2"})
+        proc_vals2 = {"warehouse_id": self.warehouse, "group_id": group2}
+        self.env["procurement.group"].run(
+            [
+                self.group.Procurement(
+                    self.product,
+                    2.0,
+                    self.uom,
+                    self.customer_loc,
+                    self.product.name,
+                    "test",
+                    self.warehouse.company_id,
+                    self.procurement_vals,
+                ),
+                group2.Procurement(
+                    self.product,
+                    2.0,
+                    self.uom,
+                    self.customer_loc,
+                    self.product.name,
+                    "test",
+                    self.warehouse.company_id,
+                    proc_vals2,
+                ),
+            ]
+        )
+        moves = self.env["stock.move"].search([("group_id", "=", self.group.id)])
+        self.assertEqual(3, len(moves))
+        moves2 = self.env["stock.move"].search([("group_id", "=", group2.id)])
+        self.assertEqual(2, len(moves2))
+        move_mto = self.env["stock.move"].search(
+            [
+                ("group_id", "=", group2.id),
+                ("location_dest_id", "=", self.customer_loc.id),
+                ("procure_method", "=", "make_to_order"),
+            ]
+        )
+        self.assertEqual(1, len(move_mto))
+        self.assertEqual(2.0, move_mto.product_uom_qty)
+
     def setUp(self):
         super().setUp()
         self.move_obj = self.env["stock.move"]


### PR DESCRIPTION
Reopen of https://github.com/OCA/stock-logistics-warehouse/pull/1872

When launching 2 mts+mto procurements for the same product, if the first one has a greater o equal qty than the second, the second won't run it's mto action. This is because the replenishment move gets confirmed whereas the original moves are still in drat state.

Steps to reproduce the issue:
  - Configure a product with the mts+mto rule and some other rule (in my case it was a manufacturing rule)
  - Launch it's rule twice at the same time (i.e. confirming a sales order with two lines of the same product) without having any stock for the product. First line with 10units, second with 5.
  - Only the procurement for the first line will apply it's mto rule (in my case it only creates one manufacturing order with 10 units).

Debugging the code I found out that when the `_run_split_procurement` method calls `get_mto_qty_to_order` for the second procurement the product `virtual_available` includes the qty that from the manufacturing order created by the first proc (it's move is confirmed) but isn't taking into account the sale's move as it is still in draft. So I think we can take this into account by keeping track of what's being replenished for each product.
