### PR TITLE
[14.0][IMP] stock_quant_manual_assign: Add an option to allow hijacking serial numbers

### DIFF
--- a/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants_view.xml
@@ -12,14 +12,21 @@
                         <field name="package_id" />
                         <field name="owner_id" />
                         <field name="location_id" />
-                        <field name="on_hand" />
-                        <field name="reserved" />
+                        <field name="on_hand_view" />
+                        <field name="reserved_view" />
+                        <field name="on_hand" invisible="1" />
+                        <field name="reserved" invisible="1" />
                         <field name="selected" />
+                        <field
+                            name="hijack"
+                            attrs="{'readonly':[('selected', '=', False)], 'invisible':[('reserved', '&lt;=', 0)]}"
+                        />
                         <field
                             name="qty"
                             attrs="{'readonly':[('selected', '=', False)]}"
                             sum="qty"
                         />
+                        <field name="qty_had_hijack" invisible="1" />
                     </tree>
                 </field>
                 <group col='4' colspan="4">


### PR DESCRIPTION
When this option is set on the corresponding stock picking type, it's possible to select a serial number even though it's already reserved in another place. It will be unreserved there, and assigned to where you currently are.

SITUATION: A can't select serial number because it's already reserved by B

![image](https://github.com/OCA/stock-logistics-warehouse/assets/1466356/b27b6c81-b8c7-424a-809f-d78f62782e0f)

AFTER: A selected serial number, and got unreserved at B

![image](https://github.com/OCA/stock-logistics-warehouse/assets/1466356/cef140df-b62e-46a4-9a45-2f8ce868cae0)


