### PR TITLE
[14.0][FIX] stock_move_location: take values from the current transient model

### DIFF
--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -197,8 +197,8 @@ class StockMoveLocationWizard(models.TransientModel):
 
     def _get_move_values(self, picking, lines):
         # locations are same for the products
-        location_from_id = lines[0].origin_location_id.id
-        location_to_id = lines[0].destination_location_id.id
+        location_from_id = self.origin_location_id.id
+        location_to_id = self.destination_location_id.id
         product = lines[0].product_id
         product_uom_id = lines[0].product_uom_id.id
         qty = sum([x.move_quantity for x in lines])


### PR DESCRIPTION
**Issue Description**
The previous implementation of _get_move_values(self, picking, lines) relied on data from the transient model "wiz.stock.move.location.line". This approach led to potential inconsistencies between stock_move_location_line_ids.destination_location_id and self.destination_location_id.


**Previous Implementation**
location_from_id = lines[0].origin_location_id.id
location_to_id = lines[0].destination_location_id.id

The issue arose when the _onchange_destination_location_id(self) method was not properly triggered:
```
@api.onchange("destination_location_id")
def _onchange_destination_location_id(self):
    for line in self.stock_move_location_line_ids:
        line.destination_location_id = self.destination_location_id
```
If this onchange method wasn't called correctly, _get_move_values(self, picking, lines) would use potentially outdated values from lines.destination_location_id.id, leading to errors


**Proposed Solution**
To resolve this issue, we now use values directly from the current transient model "wiz.stock.move.location":
```
location_from_id = self.origin_location_id.id
location_to_id = self.destination_location_id.id
```
This change ensures consistency and eliminates the dependency on the proper execution of the onchange method