### PR TITLE
[15.0][IMP] stock_inventory: improve errors information when inventory is blocked

### DIFF
--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -147,6 +147,34 @@ class InventoryAdjustmentsGroup(models.Model):
         help="Specific responsible of Inventory Adjustment.",
     )
 
+    products_under_review_ids = fields.Many2many(
+        comodel_name="product.product",
+        compute="_compute_products_under_review_ids",
+        search="_search_products_under_review_ids",
+        string="Products Under Review",
+        relation="stock_inventory_product_review_rel",
+    )
+
+    def _search_products_under_review_ids(self, operator, value):
+        quants = self.env["stock.quant"].search(
+            [("to_do", "=", True), ("product_id", operator, value)]
+        )
+        inventories = quants.mapped("stock_inventory_ids")
+        return [("id", "in", inventories.ids), ("state", "=", "in_progress")]
+
+    @api.depends("stock_quant_ids", "stock_quant_ids.to_do", "state")
+    def _compute_products_under_review_ids(self):
+        for record in self:
+            if record.state == "in_progress":
+                products = record.stock_quant_ids.filtered(
+                    lambda quant: quant.to_do
+                ).mapped("product_id")
+                record.products_under_review_ids = (
+                    [(6, 0, products.ids)] if products else [(5, 0, 0)]
+                )
+            else:
+                record.products_under_review_ids = [(5, 0, 0)]
+
     @api.depends("stock_quant_ids")
     def _compute_count_stock_quants(self):
         for rec in self:

--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -273,18 +273,28 @@ class InventoryAdjustmentsGroup(models.Model):
             search_filter.append(("product_id", "in", self.product_ids.ids))
             error_field = "product_id"
             error_message = _(
-                "There are active adjustments for the requested products: %s"
+                "There are active adjustments for the requested products: %(names)s. "
+                "Blocking adjustments: %(blocking_names)s"
             )
         else:
             error_field = "location_id"
             error_message = _(
-                "There's already an Adjustment in Process using one requested Location: %s"
+                "There's already an Adjustment in Process "
+                "using one requested Location: %(names)s. "
+                "Blocking adjustments: %(blocking_names)s"
             )
 
         quants = self.env["stock.quant"].search(search_filter)
         if quants:
-            names = self._get_quant_joined_names(quants, error_field)
-            raise ValidationError(error_message % names)
+            inventory_ids = self.env["stock.inventory"].search(
+                [("stock_quant_ids", "in", quants.ids), ("state", "=", "in_progress")]
+            )
+            if inventory_ids:
+                blocking_names = ", ".join(inventory_ids.mapped("name"))
+                names = self._get_quant_joined_names(quants, error_field)
+                raise ValidationError(
+                    error_message % {"names": names, "blocking_names": blocking_names}
+                )
 
         quants = self._get_quants(self.location_ids)
         self.write(

--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -6,6 +6,13 @@ class StockQuant(models.Model):
 
     to_do = fields.Boolean(default=False)
 
+    stock_inventory_ids = fields.Many2many(
+        "stock.inventory",
+        "stock_inventory_stock_quant_rel",
+        string="Stock Inventories",
+        copy=False,
+    )
+
     def _apply_inventory(self):
         res = super()._apply_inventory()
         record_moves = self.env["stock.move.line"]

--- a/stock_inventory/tests/test_stock_inventory.py
+++ b/stock_inventory/tests/test_stock_inventory.py
@@ -521,3 +521,37 @@ class TestStockInventory(TransactionCase):
         self.assertTrue(inventory.stock_quant_ids)
         inventory.action_state_to_done()
         self.assertTrue(all(not quant.to_do for quant in quants))
+
+    def test_11_products_under_review(self):
+        inventory1 = self.inventory_model.create(
+            {
+                "name": "Inventory_Test_Under_Review_1",
+                "product_selection": "all",
+                "location_ids": [self.location1.id],
+            }
+        )
+        inventory1.action_state_to_in_progress()
+        self.assertEqual(inventory1.state, "in_progress")
+        self.assertIn(self.product, inventory1.products_under_review_ids)
+        inventory1.action_state_to_done()
+        self.assertEqual(inventory1.state, "done")
+        self.assertEqual(inventory1.products_under_review_ids.ids, [])
+
+    def test_12_search_products_under_review(self):
+        inventory = self.inventory_model.create(
+            {
+                "name": "Inventory for Search Test",
+                "product_selection": "all",
+                "location_ids": [self.location1.id],
+            }
+        )
+        inventory.action_state_to_in_progress()
+        search_result = self.inventory_model._search_products_under_review_ids(
+            "=", self.product.id
+        )
+        expected_result = [("id", "in", [inventory.id]), ("state", "=", "in_progress")]
+        self.assertEqual(
+            search_result,
+            expected_result,
+            "The search function did not return the expected results",
+        )

--- a/stock_inventory/views/stock_inventory.xml
+++ b/stock_inventory/views/stock_inventory.xml
@@ -161,6 +161,7 @@
                 <field name="location_ids" />
                 <field name="date" />
                 <field name="state" />
+                <field name="product_ids" string="Product" />
             </search>
         </field>
     </record>

--- a/stock_inventory/views/stock_inventory.xml
+++ b/stock_inventory/views/stock_inventory.xml
@@ -162,6 +162,10 @@
                 <field name="date" />
                 <field name="state" />
                 <field name="product_ids" string="Product" />
+                <field
+                    name="products_under_review_ids"
+                    string="Products Under Review"
+                />
             </search>
         </field>
     </record>


### PR DESCRIPTION
Improves error information when inventory is blocked. It now provides details about the other inventory that is causing the block, not just the product or the location.

It also adds the possibility to search by product
