### PR TITLE
[14.0][FIX] stock_request_tier_validation: action_confirm validation after compute state in SRO

### DIFF
--- a/stock_request_tier_validation/models/stock_request.py
+++ b/stock_request_tier_validation/models/stock_request.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2020 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
 
 
 class StockRequest(models.Model):
@@ -14,3 +15,28 @@ class StockRequest(models.Model):
         res = super()._get_under_validation_exceptions()
         res.append("route_id")
         return res
+
+    def action_confirm(self):
+        """
+        Method to confirm the stock request order.
+        Checks if there are open validation processes for related orders.
+        If found, raises a validation error; otherwise,
+        calls super() method to confirm the action.
+        """
+        for rec in self:
+            # Search for stock request orders related to the current order
+            related_orders = self.env["stock.request.order"].search(
+                [("stock_request_ids", "=", rec.order_id.id)]
+            )
+            for order in related_orders:
+                # Check if there are open validation processes for the related order
+                if order.review_ids and not order.validated:
+                    raise ValidationError(
+                        _(
+                            "A validation process is still open for "
+                            f"at least one related record in {rec.order_id.name}."
+                        )
+                    )
+
+        # Call the super() method action_confirm() only if no open validations are found
+        return super().action_confirm()

--- a/stock_request_tier_validation/models/stock_request_order.py
+++ b/stock_request_tier_validation/models/stock_request_order.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2020 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
 
 
 class StockRequestOrder(models.Model):
@@ -14,3 +15,34 @@ class StockRequestOrder(models.Model):
         res = super()._get_under_validation_exceptions()
         res.append("route_id")
         return res
+
+    def action_confirm(self):
+        """
+        Confirms the stock request order.
+
+        Validates if needed, ensures tier validation,
+        and checks for open validation processes.
+        This method reinforces tier.validation due to
+        the state being a computed method, aligning
+        Stock Request Orders (SROs) with Stock Requests (SRs).
+        """
+        for rec in self:
+            # Validate if needed
+            if rec.need_validation:
+                reviews = rec.request_validation()
+                rec._validate_tier(reviews)
+                if not self._calc_reviews_validated(reviews):
+                    raise ValidationError(
+                        _(
+                            "This action needs to be validated for at least "
+                            "one record. \nPlease request a validation."
+                        )
+                    )
+
+            # Check for open validation processes
+            if rec.review_ids and not rec.validated:
+                raise ValidationError(
+                    _("A validation process is still open for at least one record.")
+                )
+
+        return super().action_confirm()


### PR DESCRIPTION
cc @marcelsavegnago @douglascstd @WesleyOliveira98 @Matthwhy 

The applied fix addresses the issue where, when the action to confirm an SRO is performed, it is not being validated with its pending reviews. After the change in the method by which it obtains the computed status [[14.0][IMP] stock_request: Convert the state field of stock.request.order as compute store to complete all use cases](https://github.com/OCA/stock-logistics-warehouse/pull/1822/), it ignores the pending reviews. Therefore, the goal is to reinforce the validations of this action_confirm in the SR/SRO.