### PR TITLE
[15.0][FIX] stock_inventory: Resolve error when applying inventory with multiple adjustments in the same location for different products

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -12,23 +12,18 @@ class StockQuant(models.Model):
         string="Stock Inventories",
         copy=False,
     )
+    current_inventory_id = fields.Many2one(
+        "stock.inventory",
+        string="Current Inventory",
+        store=True,
+    )
 
     def _apply_inventory(self):
         res = super()._apply_inventory()
         record_moves = self.env["stock.move.line"]
         adjustment = self.env["stock.inventory"].browse()
         for rec in self:
-            adjustment = (
-                self.env["stock.inventory"]
-                .search([("state", "=", "in_progress")])
-                .filtered(
-                    lambda x: rec.location_id in x.location_ids
-                    or (
-                        rec.location_id in x.location_ids.child_internal_location_ids
-                        and not x.exclude_sublocation
-                    )
-                )
-            )
+            adjustment = rec.current_inventory_id
             moves = record_moves.search(
                 [
                     ("product_id", "=", rec.product_id.id),
@@ -59,6 +54,7 @@ class StockQuant(models.Model):
                 }
             )
             rec.to_do = False
+            rec.current_inventory_id = False
         if adjustment and self.env.company.stock_inventory_auto_complete:
             adjustment.action_auto_state_to_done()
         return res

--- a/stock_inventory/tests/test_stock_inventory.py
+++ b/stock_inventory/tests/test_stock_inventory.py
@@ -555,3 +555,37 @@ class TestStockInventory(TransactionCase):
             expected_result,
             "The search function did not return the expected results",
         )
+
+    def test_13_multiple_inventories_different_products_same_location(self):
+        inventory1 = self.inventory_model.create(
+            {
+                "name": "Inventory1 for Product1",
+                "product_ids": [(6, 0, [self.product.id])],
+                "location_ids": [(6, 0, [self.location3.id])],
+                "product_selection": "manual",
+            }
+        )
+        inventory2 = self.inventory_model.create(
+            {
+                "name": "Inventory2 for Product2",
+                "product_ids": [(6, 0, [self.product2.id])],
+                "location_ids": [(6, 0, [self.location3.id])],
+                "product_selection": "manual",
+            }
+        )
+        inventory1.action_state_to_in_progress()
+        inventory2.action_state_to_in_progress()
+        self.assertEqual(inventory1.state, "in_progress")
+        self.assertEqual(inventory2.state, "in_progress")
+        self.assertEqual(
+            inventory1.stock_quant_ids.filtered(
+                lambda q: q.product_id == self.product
+            ).current_inventory_id,
+            inventory1,
+        )
+        self.assertEqual(
+            inventory2.stock_quant_ids.filtered(
+                lambda q: q.product_id == self.product2
+            ).current_inventory_id,
+            inventory2,
+        )


### PR DESCRIPTION
[FIX] stock_inventory: Resolve error when applying inventory with multiple adjustments in the same location for different products

Error resolved:

```
  File "/home/joan/odoo/15.0/odoo/odoo/models.py", line 5243, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/joan/odoo/15.0/odoo/odoo/http.py", line 658, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/joan/odoo/15.0/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: Expected singleton: stock.inventory(105, 104)
```