### PR TITLE
[14.0][IMP] stock_move_auto_assign_auto_release: Release release_ready moves together

### DIFF
--- a/stock_move_auto_assign_auto_release/data/queue_job_function_data.xml
+++ b/stock_move_auto_assign_auto_release/data/queue_job_function_data.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
     <record
-        id="job_function_product_product_moves_auto_release"
+        id="job_function_product_product_pickings_auto_release"
         model="queue.job.function"
     >
         <field name="model_id" ref="product.model_product_product" />
-        <field name="method">moves_auto_release</field>
+        <field name="method">pickings_auto_release</field>
         <field name="channel_id" ref="channel_stock_auto_release" />
-        <field name="retry_pattern" eval="{1: 1, 5: 5, 10: 10, 15: 30}" />
+    </record>
+
+    <record id="job_function_stock_picking_auto_release" model="queue.job.function">
+        <field name="model_id" ref="stock.model_stock_picking" />
+        <field name="method">auto_release_available_to_promise</field>
+        <field name="channel_id" ref="channel_stock_auto_release" />
     </record>
 </odoo>

--- a/stock_move_auto_assign_auto_release/models/product_product.py
+++ b/stock_move_auto_assign_auto_release/models/product_product.py
@@ -1,4 +1,5 @@
 # Copyright 2022 ACSONE SA/NV
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import models
@@ -14,16 +15,15 @@ class ProductProduct(models.Model):
             ("is_auto_release_allowed", "=", True),
         ]
 
-    def moves_auto_release(self):
-        """Job trying to auto release moves based on product
+    def pickings_auto_release(self):
+        """Job trying to auto release pickings based on product
 
-        It searches all* the moves auto releasable and trigger the release
-        available to promise process.
+        It searches all* the moves auto releasable
+        and triggers a delayed release available to promise for their pickings.
         """
         self.ensure_one()
         moves = self.env["stock.move"].search(self._moves_auto_release_domain())
         pickings = moves.picking_id
         if not pickings:
             return
-        self._lock_pickings_or_retry(pickings)
-        moves.release_available_to_promise()
+        pickings._delay_auto_release_available_to_promise()

--- a/stock_move_auto_assign_auto_release/models/stock_move.py
+++ b/stock_move_auto_assign_auto_release/models/stock_move.py
@@ -1,4 +1,5 @@
 # Copyright 2022 ACSONE SA/NV
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -67,6 +68,6 @@ class StockMove(models.Model):
         )
         job_options.setdefault("identity_key", identity_exact)
         delayable = product.delayable(**job_options)
-        release_job = delayable.moves_auto_release()
+        release_job = delayable.pickings_auto_release()
         job.on_done(release_job)
         return job

--- a/stock_move_auto_assign_auto_release/models/stock_picking.py
+++ b/stock_move_auto_assign_auto_release/models/stock_picking.py
@@ -1,8 +1,11 @@
 # Copyright 2022 ACSONE SA/NV
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.osv.expression import NEGATIVE_TERM_OPERATORS
+
+from odoo.addons.queue_job.job import identity_exact
 
 
 class StockPicking(models.Model):
@@ -47,3 +50,17 @@ class StockPicking(models.Model):
         if not is_auto_release_allowed:
             domain = [("id", "not in", self.search(domain).ids)]
         return domain
+
+    def _delay_auto_release_available_to_promise(self):
+        for picking in self:
+            picking.with_delay(
+                identity_key=identity_exact,
+                description=_(
+                    "Auto release available to promise %(name)s", name=picking.name
+                ),
+            ).auto_release_available_to_promise()
+
+    def auto_release_available_to_promise(self):
+        to_release = self.filtered("is_auto_release_allowed")
+        to_release.release_available_to_promise()
+        return to_release

--- a/stock_move_auto_assign_auto_release/readme/CONTRIBUTORS.rst
+++ b/stock_move_auto_assign_auto_release/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Laurent Mignon <laurent.mignon@acsone.eu>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>


### PR DESCRIPTION
A a transfer is waiting for more than product to release and the release policy is "one".
The whole transfer should be released, instead of only the last received one. 

Within this PR
Also releaseable siblings will be released. 