### PR TITLE
[16.0][FIX] stock_mts_mto_rule: make route noupdate

### DIFF
--- a/stock_mts_mto_rule/data/stock_data.xml
+++ b/stock_mts_mto_rule/data/stock_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo>
+<odoo noupdate="1">
     <!--
          Procurement rules
     -->


### PR DESCRIPTION
See https://github.com/OCA/stock-logistics-warehouse/issues/2125
This is just a quick workaround that keeps the initial rule, allows for persistent customization of it and prevents raise on module upgrade if the DB happens to have the wrong configuration case.