### PR TITLE
[16.0][FIX] stock_inventory: Expected singleton error when applying the inventory adjustments

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -18,11 +18,10 @@ class StockQuant(models.Model):
         record_moves = self.env["stock.move.line"]
         adjustment = self.env["stock.inventory"].browse()
         for rec in self:
-            adjustment = (
-                self.env["stock.inventory"]
-                .search([("state", "=", "in_progress")])
-                .filtered(
-                    lambda x: rec.location_id in x.location_ids
+            adjustment = rec.stock_inventory_ids.filtered(
+                lambda x: x.state == "in_progress"
+                and (
+                    rec.location_id in x.location_ids
                     or (
                         rec.location_id in x.location_ids.child_internal_location_ids
                         and not x.exclude_sublocation


### PR DESCRIPTION
Happens when you have more than one inventory adjustment in progress in the same location for different products


Create an inventory adjustment in stock and choose "Manual Selection" and a single product:

![image](https://github.com/user-attachments/assets/54d567e0-579a-4168-a94e-81ceb8c5d58e)

Put it in progress, and modify the counted quantity:
![image](https://github.com/user-attachments/assets/2abe8301-b909-425b-a2cc-e3d3c3facd05)


Create another inventory adjustment for another product in the same location and put it "In Progress" . Modify the counted quantity. Try to apply the inventory. Boom.

Solution is not doing a search by trusting in the stock_inventory_ids field filtering by the ones in progress and by location. Maybe we can use a sanity check, and if no adjustment is found show a user error or similar.

@ForgeFlow

