### PR TITLE
[14.0][IMP] stock_request: Improve _check_qty constrain (moved to stock.request)

### DIFF
--- a/stock_request/i18n/es.po
+++ b/stock_request/i18n/es.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-23 08:52+0000\n"
-"PO-Revision-Date: 2024-02-23 09:53+0100\n"
+"POT-Creation-Date: 2024-08-07 07:30+0000\n"
+"PO-Revision-Date: 2024-08-07 09:31+0200\n"
 "Last-Translator: Víctor Martínez <victor.martinez@tecnativa.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -553,7 +553,6 @@ msgstr "Nombre"
 
 #. module: stock_request
 #: model:ir.model.constraint,message:stock_request.constraint_stock_request_abstract_name_uniq
-#: model:ir.model.constraint,message:stock_request.constraint_stock_request_kanban_name_uniq
 msgid "Name must be unique"
 msgstr "El nombre debe ser único"
 
@@ -952,7 +951,14 @@ msgid "Stock Request name must be unique"
 msgstr "El nombre de la solicitud debe ser único"
 
 #. module: stock_request
-#: code:addons/stock_request/models/stock_request_abstract.py:0
+#: code:addons/stock_request/models/stock_request.py:0
+#, python-format
+msgid "Stock Request product quantity cannot be negative."
+msgstr ""
+"La cantidad de producto de la solicitud de stock no puede ser negativa."
+
+#. module: stock_request
+#: code:addons/stock_request/models/stock_request.py:0
 #, python-format
 msgid "Stock Request product quantity has to be strictly positive."
 msgstr ""

--- a/stock_request/i18n/stock_request.pot
+++ b/stock_request/i18n/stock_request.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-07 07:30+0000\n"
+"PO-Revision-Date: 2024-08-07 07:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -534,7 +536,6 @@ msgstr ""
 
 #. module: stock_request
 #: model:ir.model.constraint,message:stock_request.constraint_stock_request_abstract_name_uniq
-#: model:ir.model.constraint,message:stock_request.constraint_stock_request_kanban_name_uniq
 msgid "Name must be unique"
 msgstr ""
 
@@ -925,7 +926,13 @@ msgid "Stock Request name must be unique"
 msgstr ""
 
 #. module: stock_request
-#: code:addons/stock_request/models/stock_request_abstract.py:0
+#: code:addons/stock_request/models/stock_request.py:0
+#, python-format
+msgid "Stock Request product quantity cannot be negative."
+msgstr ""
+
+#. module: stock_request
+#: code:addons/stock_request/models/stock_request.py:0
 #, python-format
 msgid "Stock Request product quantity has to be strictly positive."
 msgstr ""

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -137,6 +137,18 @@ class StockRequest(models.Model):
         ("name_uniq", "unique(name, company_id)", "Stock Request name must be unique")
     ]
 
+    @api.constrains("state", "product_qty")
+    def _check_qty(self):
+        for rec in self:
+            if rec.state == "draft" and rec.product_qty <= 0:
+                raise ValidationError(
+                    _("Stock Request product quantity has to be strictly positive.")
+                )
+            elif rec.state != "draft" and rec.product_qty < 0:
+                raise ValidationError(
+                    _("Stock Request product quantity cannot be negative.")
+                )
+
     @api.depends(
         "route_id",
         "product_id",

--- a/stock_request/models/stock_request_abstract.py
+++ b/stock_request/models/stock_request_abstract.py
@@ -206,14 +206,6 @@ class StockRequest(models.AbstractModel):
                 )
             )
 
-    @api.constrains("product_qty")
-    def _check_qty(self):
-        for rec in self:
-            if rec.product_qty <= 0:
-                raise ValidationError(
-                    _("Stock Request product quantity has to be strictly positive.")
-                )
-
     @api.onchange("warehouse_id")
     def onchange_warehouse_id(self):
         """Finds location id for changed warehouse."""


### PR DESCRIPTION
Improve _check_qty constrain (moved to `stock.request`)

Example use case:
- A request (not draft) must be able to be changed to quantity 0 (although not negative).

@Tecnativa TT50450