### PR TITLE
[16.0][FIX] stock_vlm_mgmt: location general inventory

### DIFF
--- a/stock_vlm_mgmt/models/stock_location.py
+++ b/stock_vlm_mgmt/models/stock_location.py
@@ -131,6 +131,7 @@ class StockLocation(models.Model):
         action["context"] = dict(
             self.env.context,
             vlm_inventory_mode=True,
+            default_location_id=self.id,
         )
         view_id = self.env.ref("stock_vlm_mgmt.view_stock_quant_inventory_tree").id
         action.update(

--- a/stock_vlm_mgmt/models/vlm_tray_cell_position_mixin.py
+++ b/stock_vlm_mgmt/models/vlm_tray_cell_position_mixin.py
@@ -38,7 +38,7 @@ class VlmTrayCellPositionMixin(models.AbstractModel):
 
     @api.depends("tray_matrix")
     def _compute_pos(self):
-        for record in self:
+        for record in self.filtered("tray_matrix"):
             if not record.tray_matrix["selected"]:
                 continue
             record.update(


### PR DESCRIPTION
We were lacking the default location id so we could select the tray. It was also needed to avoid compting a pos when no tray is selected.

please review @pedrobaeza @victoralmau 