### PR TITLE
[15.0][FIX] stock_inventory: error when creating new quant

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -60,7 +60,7 @@ class StockQuant(models.Model):
         return res
 
     def _get_inventory_fields_write(self):
-        return super()._get_inventory_fields_write() + ["to_do"]
+        return super()._get_inventory_fields_write() + ["to_do", "current_inventory_id"]
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
We need to add the new field in  _get_inventory_fields_write if not we will receive this error when creating new quants: 

`Quant's creation is restricted, you can't do this operation.`