### PR TITLE
[16.0][FIX] stock_vlm_mgmt: error when creating new quant

### DIFF
--- a/stock_vlm_mgmt/models/stock_quant.py
+++ b/stock_vlm_mgmt/models/stock_quant.py
@@ -21,6 +21,12 @@ class StockQuant(models.Model):
         )
         return action
 
+    @api.model
+    def _get_inventory_fields_create(self):
+        fields = super()._get_inventory_fields_create()
+        fields.extend(["vlm_quant_ids"])
+        return fields
+
 
 class StockQuantVlm(models.Model):
     _name = "stock.quant.vlm"


### PR DESCRIPTION
We need to add the new field in _get_inventory_fields_write if not we will receive this error when creating new quants:

![Screenshot from 2024-08-27 14-30-12](https://github.com/user-attachments/assets/23b232a2-0fa5-4cf2-ba27-d1f0b7b145e2)

