### PR TITLE
[14.0][FIX] stock_picking_volume: pre_init_hook, replace column type from 'numeric' to 'double precision'

### DIFF
--- a/stock_picking_volume/hooks.py
+++ b/stock_picking_volume/hooks.py
@@ -27,6 +27,6 @@ def post_init_hook(cr, registry):
 def pre_init_hook(cr):
     """Pre init create volume column on stock.picking and stock.move"""
     if not column_exists(cr, "stock_move", "volume"):
-        create_column(cr, "stock_move", "volume", "numeric")
+        create_column(cr, "stock_move", "volume", "double precision")
     if not column_exists(cr, "stock_picking", "volume"):
-        create_column(cr, "stock_picking", "volume", "numeric")
+        create_column(cr, "stock_picking", "volume", "double precision")


### PR DESCRIPTION
As no digits parameters are provided on `<stock.move>.volume` and `<stock.picking>.volume` fields, the 'double precision' type is used instead of 'numeric'.

This avoids time consuming SQL requests 'ALTER TABLE...' at module install.