### PR TITLE
[16.0][FW] procurement_auto_create_group: partial ports of #1821

### DIFF
--- a/procurement_auto_create_group/models/procurement_group.py
+++ b/procurement_auto_create_group/models/procurement_group.py
@@ -13,11 +13,6 @@ class ProcurementGroup(models.Model):
         rule = super()._get_rule(product_id, location_id, values)
         # If there isn't a date planned in the values it means that this
         # method has been called outside of a procurement process.
-        if (
-            rule
-            and not values.get("group_id")
-            and rule.auto_create_group
-            and values.get("date_planned")
-        ):
+        if rule and rule.auto_create_group and values.get("date_planned"):
             values["group_id"] = rule._get_auto_procurement_group(product_id)
         return rule

--- a/procurement_auto_create_group/models/procurement_group.py
+++ b/procurement_auto_create_group/models/procurement_group.py
@@ -19,7 +19,5 @@ class ProcurementGroup(models.Model):
             and rule.auto_create_group
             and values.get("date_planned")
         ):
-            group_data = rule._prepare_auto_procurement_group_data()
-            group = self.env["procurement.group"].create(group_data)
-            values["group_id"] = group
+            values["group_id"] = rule._get_auto_procurement_group(product_id)
         return rule

--- a/procurement_auto_create_group/models/stock_rule.py
+++ b/procurement_auto_create_group/models/stock_rule.py
@@ -16,15 +16,18 @@ class StockRule(models.Model):
         if self.group_propagation_option != "propagate":
             self.auto_create_group = False
 
+    def _get_auto_procurement_group(self, product):
+        group_data = self._prepare_auto_procurement_group_data(product)
+        return self.env["procurement.group"].create(group_data)
+
     def _push_prepare_move_copy_values(self, move_to_copy, new_date):
         new_move_vals = super()._push_prepare_move_copy_values(move_to_copy, new_date)
         if self.auto_create_group:
-            group_data = self._prepare_auto_procurement_group_data()
-            group = self.env["procurement.group"].create(group_data)
+            group = self._get_auto_procurement_group(move_to_copy.product_id)
             new_move_vals["group_id"] = group.id
         return new_move_vals
 
-    def _prepare_auto_procurement_group_data(self):
+    def _prepare_auto_procurement_group_data(self, product):
         name = self.env["ir.sequence"].next_by_code("procurement.group") or False
         if not name:
             raise UserError(_("No sequence defined for procurement group."))

--- a/procurement_auto_create_group/tests/test_auto_create.py
+++ b/procurement_auto_create_group/tests/test_auto_create.py
@@ -116,9 +116,13 @@ class TestProcurementAutoCreateGroup(TransactionCase):
             }
         )
 
+        cls.group = cls.group_obj.create({"name": "SO0001"})
+
     @classmethod
     def _procure(cls, product):
-        values = {}
+        values = {
+            "group_id": cls.group,
+        }
         cls.group_obj.run(
             [
                 cls.env["procurement.group"].Procurement(
@@ -175,8 +179,10 @@ class TestProcurementAutoCreateGroup(TransactionCase):
             [("product_id", "=", self.prod_no_auto_pull_push.id)]
         )
         self.assertTrue(move)
-        self.assertFalse(
-            move.group_id, "Procurement Group should not have been assigned."
+        self.assertEqual(
+            move.group_id,
+            self.group,
+            "Procurement Group should not have been assigned.",
         )
 
     def test_02_pull_push_auto_create_group(self):

--- a/procurement_auto_create_group/tests/test_auto_create.py
+++ b/procurement_auto_create_group/tests/test_auto_create.py
@@ -27,7 +27,7 @@ class TestProcurementAutoCreateGroup(TransactionCase):
 
         # Create rules and routes:
         pull_push_route_auto = cls.route_obj.create({"name": "Auto Create Group"})
-        cls.rule_1 = cls.rule_obj.create(
+        cls.pull_push_rule_auto = cls.rule_obj.create(
             {
                 "name": "rule with autocreate",
                 "route_id": pull_push_route_auto.id,
@@ -56,7 +56,7 @@ class TestProcurementAutoCreateGroup(TransactionCase):
             }
         )
         push_route_auto = cls.route_obj.create({"name": "Auto Create Group"})
-        cls.rule_1 = cls.rule_obj.create(
+        cls.push_rule_auto = cls.rule_obj.create(
             {
                 "name": "route_auto",
                 "location_src_id": cls.location.id,
@@ -194,7 +194,7 @@ class TestProcurementAutoCreateGroup(TransactionCase):
 
     def test_03_onchange_method(self):
         """Test onchange method for stock rule."""
-        proc_rule = self.rule_1
+        proc_rule = self.push_rule_auto
         self.assertTrue(proc_rule.auto_create_group)
         proc_rule.write({"group_propagation_option": "none"})
         proc_rule._onchange_group_propagation_option()


### PR DESCRIPTION
Port commits related to `procurement_auto_create_group` from the following PR from 14.0 to 16.0:
- https://github.com/OCA/stock-logistics-warehouse/pull/1821

Required by:
- https://github.com/OCA/stock-logistics-workflow/pull/1718