### PR TITLE
[FIX] fix odoo traces

### DIFF
--- a/base_product_merge/wizard/base_product_merge.py
+++ b/base_product_merge/wizard/base_product_merge.py
@@ -42,14 +42,14 @@ class BaseProductMerge(models.Model):
         [("product.product", "Product"), ("product.template", "Template")]
     )
     dst_product_tmpl_id = fields.Many2one(
-        "product.template", string="Destination product"
+        "product.template", string="Destination product template"
     )
     product_tmpl_ids = fields.Many2many(
         "product.template",
         "product_tmpl_rel",
         "product_tmpl_merge_id",
         "product_tmpl_id",
-        string="Products to merge",
+        string="Products Template to merge",
     )
     merge_method = fields.Selection([("sql", "SQL"), ("orm", "ORM")], default="sql")
 


### PR DESCRIPTION
fix odoo trace at install or update base_product_merge module : 
- 'Two fields (dst_product_tmpl_id, dst_product_id) of base.product.merge() have the same label: Destination product. [Modules: base_product_merge and base_product_merge]'
- 'Two fields (product_tmpl_ids, product_ids) of base.product.merge() have the same label: Products to merge. [Modules: base_product_merge and base_product_merge]'