### PR TITLE
[14.0][IMP] stock_location_warehouse: change development_status

### DIFF
--- a/stock_location_warehouse/README.rst
+++ b/stock_location_warehouse/README.rst
@@ -10,9 +10,9 @@ Stock Location Warehouse
    !! source digest: sha256:04c9a3a8cd079ed0fe57a9cb5c63a20ab28d2e36579a830aac1fc102f95a79ab
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-.. |badge1| image:: https://img.shields.io/badge/maturity-Alpha-red.png
+.. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
     :target: https://odoo-community.org/page/development-status
-    :alt: Alpha
+    :alt: Beta
 .. |badge2| image:: https://img.shields.io/badge/licence-LGPL--3-blue.png
     :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
     :alt: License: LGPL-3
@@ -30,11 +30,6 @@ Stock Location Warehouse
 
 This module adds the associated warehouse to every location. If we have a tree of locations and sublocations, this module will update the associated warehouse every time we modify a location parent.
 If a location changes its father location, it will change its associated warehouse and all its childs too.
-
-.. IMPORTANT::
-   This is an alpha version, the data model and design can change at any time without warning.
-   Only for development or testing purpose, do not use in production.
-   `More details on development status <https://odoo-community.org/page/development-status>`_
 
 **Table of contents**
 

--- a/stock_location_warehouse/__manifest__.py
+++ b/stock_location_warehouse/__manifest__.py
@@ -11,6 +11,6 @@
     "depends": ["stock"],
     "data": ["views/stock_location.xml"],
     "installable": True,
-    "development_status": "Alpha",
+    "development_status": "Beta",
     "license": "LGPL-3",
 }


### PR DESCRIPTION
Change `development_status` in the manifest from Alpha to Beta to reflect the maturity level of the module and to allow to use it as a dependency by other modules in the Beta status