### PR TITLE
[15.0][IMP] stock_request: Improve _check_qty constrain (moved to stock.request)

### DIFF
--- a/stock_request/i18n/es.po
+++ b/stock_request/i18n/es.po
@@ -509,7 +509,6 @@ msgstr "Nombre"
 
 #. module: stock_request
 #: model:ir.model.constraint,message:stock_request.constraint_stock_request_abstract_name_uniq
-#: model:ir.model.constraint,message:stock_request.constraint_stock_request_kanban_name_uniq
 msgid "Name must be unique"
 msgstr "El nombre debe ser único"
 
@@ -906,7 +905,14 @@ msgid "Stock Request name must be unique"
 msgstr "El nombre de la solicitud debe ser único"
 
 #. module: stock_request
-#: code:addons/stock_request/models/stock_request_abstract.py:0
+#: code:addons/stock_request/models/stock_request.py:0
+#, python-format
+msgid "Stock Request product quantity cannot be negative."
+msgstr ""
+"La cantidad de producto de la solicitud de stock no puede ser negativa."
+
+#. module: stock_request
+#: code:addons/stock_request/models/stock_request.py:0
 #, python-format
 msgid "Stock Request product quantity has to be strictly positive."
 msgstr ""

--- a/stock_request/i18n/stock_request.pot
+++ b/stock_request/i18n/stock_request.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-07 07:30+0000\n"
+"PO-Revision-Date: 2024-08-07 07:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -490,7 +492,6 @@ msgstr ""
 
 #. module: stock_request
 #: model:ir.model.constraint,message:stock_request.constraint_stock_request_abstract_name_uniq
-#: model:ir.model.constraint,message:stock_request.constraint_stock_request_kanban_name_uniq
 msgid "Name must be unique"
 msgstr ""
 
@@ -879,7 +880,13 @@ msgid "Stock Request name must be unique"
 msgstr ""
 
 #. module: stock_request
-#: code:addons/stock_request/models/stock_request_abstract.py:0
+#: code:addons/stock_request/models/stock_request.py:0
+#, python-format
+msgid "Stock Request product quantity cannot be negative."
+msgstr ""
+
+#. module: stock_request
+#: code:addons/stock_request/models/stock_request.py:0
 #, python-format
 msgid "Stock Request product quantity has to be strictly positive."
 msgstr ""

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -125,6 +125,18 @@ class StockRequest(models.Model):
         ("name_uniq", "unique(name, company_id)", "Stock Request name must be unique")
     ]
 
+    @api.constrains("state", "product_qty")
+    def _check_qty(self):
+        for rec in self:
+            if rec.state == "draft" and rec.product_qty <= 0:
+                raise ValidationError(
+                    _("Stock Request product quantity has to be strictly positive.")
+                )
+            elif rec.state != "draft" and rec.product_qty < 0:
+                raise ValidationError(
+                    _("Stock Request product quantity cannot be negative.")
+                )
+
     def _get_all_origin_moves(self, move):
         all_moves = move
         if move.move_orig_ids:

--- a/stock_request/models/stock_request_abstract.py
+++ b/stock_request/models/stock_request_abstract.py
@@ -208,14 +208,6 @@ class StockRequest(models.AbstractModel):
                 )
             )
 
-    @api.constrains("product_qty")
-    def _check_qty(self):
-        for rec in self:
-            if rec.product_qty <= 0:
-                raise ValidationError(
-                    _("Stock Request product quantity has to be strictly positive.")
-                )
-
     @api.onchange("warehouse_id")
     def onchange_warehouse_id(self):
         """Finds location id for changed warehouse."""

--- a/stock_request_purchase/models/stock_request.py
+++ b/stock_request_purchase/models/stock_request.py
@@ -42,10 +42,11 @@ class StockRequest(models.Model):
     def action_cancel(self):
         """Propagate the cancellation to the generated purchase orders."""
         res = super().action_cancel()
-        self.sudo().purchase_ids.filtered(
-            lambda x: x.state not in ("purchase", "done", "cancel")
-            and x.stock_request_ids == self
-        ).button_cancel()
+        if not self.env.context.get("skip_cancel_po_from_stock_request"):
+            self.sudo().purchase_ids.filtered(
+                lambda x: x.state not in ("purchase", "done", "cancel")
+                and x.stock_request_ids == self
+            ).button_cancel()
         return res
 
     def action_view_purchase(self):


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/2135 + https://github.com/OCA/stock-logistics-warehouse/pull/2134

Improve _check_qty constrain (moved to `stock.request`)

Example use case:
- A request (not draft) must be able to be changed to quantity 0 (although not negative).

Add context key to skip cancel purchase.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT50450