### PR TITLE
[16.0][IMP] stock_secondary_unit: make the secondary unit and secondary quantity fields optional

### DIFF
--- a/stock_secondary_unit/views/stock_move_views.xml
+++ b/stock_secondary_unit/views/stock_move_views.xml
@@ -13,6 +13,7 @@
                     attrs="{'readonly': [('state', 'in', ('done', 'cancel')), ('is_locked', '=', True)]}"
                     force_save="1"
                     groups="uom.group_uom"
+                    optional="show"
                 />
                 <field
                     name="secondary_uom_id"
@@ -22,6 +23,7 @@
                     attrs="{'readonly': [('state', '!=', 'draft'), ('id', '!=', False)]}"
                     options="{'no_create': True}"
                     groups="uom.group_uom"
+                    optional="show"
                 />
             </field>
         </field>
@@ -40,6 +42,7 @@
                     attrs="{'readonly': [('state', 'in', ('done', 'cancel')), ('is_locked', '=', True)]}"
                     force_save="1"
                     groups="uom.group_uom"
+                    optional="show"
                 />
                 <field
                     name="secondary_uom_id"
@@ -49,6 +52,7 @@
                     attrs="{'readonly': [('state', '!=', 'draft'), ('id', '!=', False)]}"
                     options="{'no_create': True}"
                     groups="uom.group_uom"
+                    optional="show"
                 />
             </field>
         </field>

--- a/stock_secondary_unit/views/stock_picking_views.xml
+++ b/stock_secondary_unit/views/stock_picking_views.xml
@@ -15,6 +15,7 @@
                     name="secondary_uom_qty"
                     attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"
                     groups="uom.group_uom"
+                    optional="show"
                 />
                 <field
                     name="secondary_uom_id"
@@ -24,6 +25,7 @@
                     options="{'no_create': True}"
                     attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"
                     groups="uom.group_uom"
+                    optional="show"
                 />
             </xpath>
             <xpath


### PR DESCRIPTION
fwd port of https://github.com/OCA/stock-logistics-warehouse/pull/2080

cc @tecnativa TT49686

@CarlosRoca13 @carlos-lopez-tecnativa please review