### PR TITLE
[16.0][FIX] stock_secondary_unit: use @api.model_create_multi decorator in create method of StockMoveLine

### DIFF
--- a/stock_secondary_unit/models/stock_move.py
+++ b/stock_secondary_unit/models/stock_move.py
@@ -50,12 +50,13 @@ class StockMoveLine(models.Model):
         store=True, readonly=False, compute="_compute_qty_done", precompute=True
     )
 
-    @api.model
-    def create(self, vals):
-        move = self.env["stock.move"].browse(vals.get("move_id", False))
-        if move.secondary_uom_id:
-            vals["secondary_uom_id"] = move.secondary_uom_id.id
-        return super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            move = self.env["stock.move"].browse(vals.get("move_id", False))
+            if move.secondary_uom_id:
+                vals["secondary_uom_id"] = move.secondary_uom_id.id
+        return super().create(vals_list)
 
     @api.depends("secondary_uom_id", "secondary_uom_qty")
     def _compute_qty_done(self):


### PR DESCRIPTION
This fix updates the create method in the StockMoveLine model of the stock_secondary_unit module to use the @api.model_create_multi  decorator, as is done in Odoo's native stock.move.line model.
This update ensures the method aligns with Odoo’s standard multi-record creation approach.