### PR TITLE
[15.0][FIX] stock_request: Remove route_ids fields from requests

### DIFF
--- a/stock_request/models/stock_request_abstract.py
+++ b/stock_request/models/stock_request_abstract.py
@@ -98,46 +98,13 @@ class StockRequest(models.AbstractModel):
     route_id = fields.Many2one(
         "stock.location.route",
         string="Route",
-        domain="[('id', 'in', route_ids)]",
+        domain=[("product_selectable", "=", True)],
         ondelete="restrict",
-    )
-
-    route_ids = fields.Many2many(
-        "stock.location.route",
-        string="Routes",
-        compute="_compute_route_ids",
-        readonly=True,
     )
 
     _sql_constraints = [
         ("name_uniq", "unique(name, company_id)", "Name must be unique")
     ]
-
-    @api.depends("product_id", "warehouse_id", "location_id")
-    def _compute_route_ids(self):
-        route_obj = self.env["stock.location.route"]
-        routes = route_obj.search(
-            [("warehouse_ids", "in", self.mapped("warehouse_id").ids)]
-        )
-        routes_by_warehouse = {}
-        for route in routes:
-            for warehouse in route.warehouse_ids:
-                routes_by_warehouse.setdefault(
-                    warehouse.id, self.env["stock.location.route"]
-                )
-                routes_by_warehouse[warehouse.id] |= route
-        for record in self:
-            routes = route_obj
-            if record.product_id:
-                routes += record.product_id.mapped(
-                    "route_ids"
-                ) | record.product_id.mapped("categ_id").mapped("total_route_ids")
-            if record.warehouse_id and routes_by_warehouse.get(record.warehouse_id.id):
-                routes |= routes_by_warehouse[record.warehouse_id.id]
-            parents = record.get_parents().ids
-            record.route_ids = routes.filtered(
-                lambda r: any(p.location_id.id in parents for p in r.rule_ids)
-            )
 
     def get_parents(self):
         location = self.location_id

--- a/stock_request/models/stock_request_order.py
+++ b/stock_request/models/stock_request_order.py
@@ -139,13 +139,6 @@ class StockRequestOrder(models.Model):
         string="Stock requests", compute="_compute_stock_request_count", readonly=True
     )
 
-    route_ids = fields.Many2many(
-        "stock.location.route",
-        string="Routes",
-        compute="_compute_route_ids",
-        readonly=True,
-    )
-
     route_id = fields.Many2one(
         "stock.location.route",
         compute="_compute_route_id",
@@ -154,43 +147,12 @@ class StockRequestOrder(models.Model):
         states={"draft": [("readonly", False)]},
         store=True,
         help="The route related to a stock request order",
-        domain="[('id', 'in', route_ids)]",
+        domain=[("product_selectable", "=", True)],
     )
 
     _sql_constraints = [
         ("name_uniq", "unique(name, company_id)", "Stock Request name must be unique")
     ]
-
-    @api.depends("warehouse_id", "location_id", "stock_request_ids")
-    def _compute_route_ids(self):
-        route_obj = self.env["stock.location.route"]
-        routes = route_obj.search(
-            [("warehouse_ids", "in", self.mapped("warehouse_id").ids)]
-        )
-        routes_by_warehouse = {}
-        for route in routes:
-            for warehouse in route.warehouse_ids:
-                routes_by_warehouse.setdefault(
-                    warehouse.id, self.env["stock.location.route"]
-                )
-                routes_by_warehouse[warehouse.id] |= route
-        for record in self:
-            routes = route_obj
-            if record.warehouse_id and routes_by_warehouse.get(record.warehouse_id.id):
-                routes |= routes_by_warehouse[record.warehouse_id.id]
-            parents = record.get_parents().ids
-            filtered_routes = routes.filtered(
-                lambda r: any(p.location_id.id in parents for p in r.rule_ids)
-            )
-            if record.stock_request_ids:
-                all_routes = record.stock_request_ids.mapped("route_ids")
-                common_routes = all_routes
-                for line in record.stock_request_ids:
-                    common_routes &= line.route_ids
-                final_routes = filtered_routes | common_routes
-                record.route_ids = [(6, 0, final_routes.ids)]
-            else:
-                record.route_ids = [(6, 0, filtered_routes.ids)]
 
     def get_parents(self):
         location = self.location_id

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -276,7 +276,6 @@ class TestStockRequestBase(TestStockRequest):
         vals = stock_request.default_get(["warehouse_id", "company_id"])
         stock_request.update(vals)
         stock_request.onchange_product_id()
-        self.assertIn(self.route.id, stock_request.route_ids.ids)
 
         self.stock_request_user.company_id = self.company_2
         stock_request.company_id = self.company_2

--- a/stock_request/views/stock_request_order_views.xml
+++ b/stock_request/views/stock_request_order_views.xml
@@ -91,7 +91,6 @@
                                 name="location_id"
                                 groups="stock.group_stock_multi_locations"
                             />
-                            <field name="route_ids" invisible="1" />
                             <field
                                 name="route_id"
                                 groups="stock.group_stock_multi_locations"
@@ -138,7 +137,6 @@
                                         options="{'no_create': True}"
                                         groups="stock.group_stock_multi_locations"
                                     />
-                                    <field name="route_ids" invisible="1" />
                                     <field name="product_uom_qty" />
                                     <field name="qty_in_progress" />
                                     <field name="qty_done" />

--- a/stock_request/views/stock_request_views.xml
+++ b/stock_request/views/stock_request_views.xml
@@ -182,7 +182,6 @@
                                 options="{'no_create': True}"
                                 groups="stock.group_stock_multi_locations"
                             />
-                            <field name="route_ids" invisible="1" />
                             <field
                                 name="procurement_group_id"
                                 groups="stock.group_adv_location"

--- a/stock_request_kanban/tests/test_kanban.py
+++ b/stock_request_kanban/tests/test_kanban.py
@@ -89,7 +89,6 @@ class TestKanban(TestBaseKanban):
         kanban.product_uom_qty = 1
         kanban = kanban.create(kanban._convert_to_write(kanban._cache))
         self.assertTrue(kanban.company_id)
-        self.assertIn(self.route, kanban.route_ids)
 
     def test_order_barcodes(self):
         kanban_1 = self.env["stock.request.kanban"].create(

--- a/stock_request_kanban/views/stock_request_kanban_views.xml
+++ b/stock_request_kanban/views/stock_request_kanban_views.xml
@@ -97,7 +97,6 @@
                                 options="{'no_create': True}"
                                 groups="stock.group_stock_multi_locations"
                             />
-                            <field name="route_ids" invisible="1" />
                             <field
                                 name="procurement_group_id"
                                 groups="stock.group_adv_location"


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-warehouse/pull/2179

Remove `route_ids` field from requests

It is not correct to set the `route_ids` field with the product routes, you must be able to select any route (similar to what is shown in the product form view).

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT50610