### PR TITLE
[15.0][IMP] stock_inventory_verification_request: compute involved lines and quant

### DIFF
--- a/stock_inventory_verification_request/models/stock_slot_verification_request.py
+++ b/stock_inventory_verification_request/models/stock_slot_verification_request.py
@@ -100,6 +100,8 @@ class SlotVerificationRequest(models.Model):
         column1="slot_verification_request_id",
         column2="move_line_id",
         string="Involved Stock Moves",
+        compute="_compute_involved_move_lines",
+        store=False,
     )
     involved_move_line_count = fields.Integer(
         compute="_compute_involved_move_line_count"
@@ -110,6 +112,8 @@ class SlotVerificationRequest(models.Model):
         column1="slot_verification_request_id",
         column2="quant_id",
         string="Involved Inventory Quants",
+        compute="_compute_involved_quants",
+        store=False,
     )
     involved_quant_count = fields.Integer(compute="_compute_involved_quant_count")
     created_inventory_ids = fields.One2many(
@@ -119,6 +123,29 @@ class SlotVerificationRequest(models.Model):
         help="These inventory adjustment were created from this SVR.",
     )
     created_inventory_count = fields.Integer(compute="_compute_created_inventory_count")
+
+    @api.depends("location_id", "product_id", "lot_id", "state")
+    def _compute_involved_move_lines(self):
+        for rec in self:
+            # Only compute when state is 'open' to prevent irrelevant data accumulation.
+            # No need to accumulate movements for a 'solved' or 'cancelled'
+            # SVR a lot of time after resolution.
+            if rec.state == "open":
+                rec.involved_move_line_ids = self.env["stock.move.line"].search(
+                    rec._get_involved_move_lines_domain()
+                )
+            else:
+                rec.involved_move_line_ids = self.env["stock.move.line"]
+
+    @api.depends("location_id", "product_id", "lot_id", "state")
+    def _compute_involved_quants(self):
+        for rec in self:
+            if rec.state == "open":
+                rec.involved_quant_ids = self.env["stock.quant"].search(
+                    rec._get_involved_quants_domain()
+                )
+            else:
+                rec.involved_quant_ids = self.env["stock.quant"]
 
     def _get_involved_move_lines_domain(self):
         domain = [
@@ -140,24 +167,8 @@ class SlotVerificationRequest(models.Model):
             domain.append(("lot_id", "=", self.lot_id.id))
         return domain
 
-    def _get_involved_quants_and_locations(self):
-        involved_move_lines = self.env["stock.move.line"].search(
-            self._get_involved_move_lines_domain()
-        )
-        involved_quants = self.env["stock.quant"].search(
-            self._get_involved_quants_domain()
-        )
-        return involved_move_lines, involved_quants
-
     def action_confirm(self):
         self.write({"state": "open"})
-        for rec in self:
-            (
-                involved_moves_lines,
-                involved_quants,
-            ) = rec._get_involved_quants_and_locations()
-            rec.involved_move_line_ids = involved_moves_lines
-            rec.involved_quant_ids = involved_quants
         return True
 
     def action_cancel(self):

--- a/stock_inventory_verification_request/tests/test_verification_request.py
+++ b/stock_inventory_verification_request/tests/test_verification_request.py
@@ -76,7 +76,7 @@ class TestStockVerificationRequest(common.TransactionCase):
             }
         ).action_apply_inventory()
 
-    def test_svr_creation(self):
+    def test_01_svr_creation(self):
         """Tests the creation of Slot Verification Requests."""
         inventory = self.obj_inventory.create(
             {
@@ -104,7 +104,7 @@ class TestStockVerificationRequest(common.TransactionCase):
         for quant in inventory.stock_quant_ids:
             quant.action_open_svr()
 
-    def test_svr_workflow(self):
+    def test_02_svr_workflow(self):
         """Tests workflow of Slot Verification Request."""
         test_svr = self.env["stock.slot.verification.request"].create(
             {
@@ -135,7 +135,7 @@ class TestStockVerificationRequest(common.TransactionCase):
             "Slot Verification Request not marked as cancelled.",
         )
 
-    def test_view_methods(self):
+    def test_03_view_methods(self):
         """Tests the methods used to handle de UI."""
         test_svr = self.env["stock.slot.verification.request"].create(
             {
@@ -152,7 +152,7 @@ class TestStockVerificationRequest(common.TransactionCase):
         test_svr.action_view_move_lines()
         test_svr.action_view_quants()
 
-    def test_svr_full_workflow(self):
+    def test_04_svr_full_workflow(self):
         test_svr = self.env["stock.slot.verification.request"].create(
             {
                 "location_id": self.test_loc.id,
@@ -182,7 +182,7 @@ class TestStockVerificationRequest(common.TransactionCase):
             "Slot Verification Request not marked as cancelled.",
         )
 
-    def test_user_permissions_on_svr(self):
+    def test_05_user_permissions_on_svr(self):
         """Tests that users without the correct permissions cannot change SVR state."""
         test_svr = self.env["stock.slot.verification.request"].create(
             {
@@ -197,17 +197,69 @@ class TestStockVerificationRequest(common.TransactionCase):
         with self.assertRaises(AccessError):
             test_svr.with_user(self.user).action_solved()
 
+    def test_06_action_view_methods(self):
+        """Tests the view methods in Slot Verification Request."""
+        svr = self.obj_svr.create(
+            {
+                "location_id": self.test_loc.id,
+                "state": "wait",
+                "product_id": self.product1.id,
+            }
+        )
+        svr.action_view_move_lines()
+        svr.action_view_quants()
+        svr.action_create_inventory_adjustment()
+        svr.action_view_inventories()
 
-def test_action_view_methods(self):
-    """Tests the view methods in Slot Verification Request."""
-    svr = self.obj_svr.create(
-        {
-            "location_id": self.test_loc.id,
-            "state": "wait",
-            "product_id": self.product1.id,
-        }
-    )
-    svr.action_view_move_lines()
-    svr.action_view_quants()
-    svr.action_create_inventory_adjustment()
-    svr.action_view_inventories()
+    def test_07_involved_move_lines_compute(self):
+        move = self.obj_move.create(
+            {
+                "name": "Test Move",
+                "product_id": self.product1.id,
+                "product_uom_qty": 10,
+                "product_uom": self.product1.uom_id.id,
+                "location_id": self.test_loc.id,
+                "location_dest_id": self.test_loc.id,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        move_line = move.move_line_ids[0]
+        test_svr = self.obj_svr.create(
+            {
+                "location_id": self.test_loc.id,
+                "state": "wait",
+                "product_id": self.product1.id,
+            }
+        )
+        test_svr.action_confirm()
+        self.assertEqual(
+            test_svr.state, "open", "Slot Verification Request not confirmed properly."
+        )
+        self.assertIn(
+            move_line,
+            test_svr.involved_move_line_ids,
+            "Move line not found in involved_move_line_ids",
+        )
+
+    def test_08_involved_quants_compute(self):
+        self.quant3 = self.env["stock.quant"].create(
+            {
+                "location_id": self.test_loc.id,
+                "product_id": self.product1.id,
+                "quantity": 20.0,
+            }
+        )
+        test_svr = self.obj_svr.create(
+            {
+                "location_id": self.test_loc.id,
+                "state": "wait",
+                "product_id": self.product1.id,
+            }
+        )
+        test_svr.action_confirm()
+        self.assertIn(
+            self.quant3,
+            test_svr.involved_quant_ids,
+            "Quant3 not found in involved_quant_ids",
+        )

--- a/stock_inventory_verification_request/views/stock_slot_verification_request_view.xml
+++ b/stock_inventory_verification_request/views/stock_slot_verification_request_view.xml
@@ -71,6 +71,7 @@
                             type="object"
                             class="oe_stat_button"
                             icon="fa-building-o"
+                            attrs="{'invisible':[('created_inventory_count', '=', 0)]}"
                         >
                               <field
                                 name="created_inventory_count"

--- a/stock_inventory_verification_request/views/stock_slot_verification_request_view.xml
+++ b/stock_inventory_verification_request/views/stock_slot_verification_request_view.xml
@@ -11,6 +11,7 @@
                 <field name="name" />
                 <field name="location_id" />
                 <field name="product_id" />
+                <field name="lot_id" groups="stock.group_production_lot" />
                 <field name="create_uid" readonly="1" />
                 <field name="create_date" readonly="1" />
                 <field name="responsible_id" />
@@ -120,7 +121,7 @@
                         <group>
                             <field name="location_id" />
                             <field name="product_id" />
-                            <field name="lot_id" />
+                            <field name="lot_id" groups="stock.group_production_lot" />
                             <field
                                 name="company_id"
                                 groups="base.group_multi_company"


### PR DESCRIPTION
If new moves are completed in that location for the specified product after confirming, they should automatically appear in the related lines.

 Otherwise, it breaks traceability and hinders easy understanding of the process

Extra commit: do not show related inventory adjustments button if created_inventory_count is zero
2nd Extra commit: show lot_id for stock.group_production_lot group