### PR TITLE
[14.0] Revert "[FIX] stock_request: Remove route_ids fields from requests"

### DIFF
--- a/stock_request/models/stock_request_abstract.py
+++ b/stock_request/models/stock_request_abstract.py
@@ -96,13 +96,46 @@ class StockRequest(models.AbstractModel):
     route_id = fields.Many2one(
         "stock.location.route",
         string="Route",
-        domain=[("product_selectable", "=", True)],
+        domain="[('id', 'in', route_ids)]",
         ondelete="restrict",
+    )
+
+    route_ids = fields.Many2many(
+        "stock.location.route",
+        string="Routes",
+        compute="_compute_route_ids",
+        readonly=True,
     )
 
     _sql_constraints = [
         ("name_uniq", "unique(name, company_id)", "Name must be unique")
     ]
+
+    @api.depends("product_id", "warehouse_id", "location_id")
+    def _compute_route_ids(self):
+        route_obj = self.env["stock.location.route"]
+        routes = route_obj.search(
+            [("warehouse_ids", "in", self.mapped("warehouse_id").ids)]
+        )
+        routes_by_warehouse = {}
+        for route in routes:
+            for warehouse in route.warehouse_ids:
+                routes_by_warehouse.setdefault(
+                    warehouse.id, self.env["stock.location.route"]
+                )
+                routes_by_warehouse[warehouse.id] |= route
+        for record in self:
+            routes = route_obj
+            if record.product_id:
+                routes += record.product_id.mapped(
+                    "route_ids"
+                ) | record.product_id.mapped("categ_id").mapped("total_route_ids")
+            if record.warehouse_id and routes_by_warehouse.get(record.warehouse_id.id):
+                routes |= routes_by_warehouse[record.warehouse_id.id]
+            parents = record.get_parents().ids
+            record.route_ids = routes.filtered(
+                lambda r: any(p.location_id.id in parents for p in r.rule_ids)
+            )
 
     def get_parents(self):
         location = self.location_id

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -254,6 +254,7 @@ class TestStockRequestBase(TestStockRequest):
         vals = stock_request.default_get(["warehouse_id", "company_id"])
         stock_request.update(vals)
         stock_request.onchange_product_id()
+        self.assertIn(self.route.id, stock_request.route_ids.ids)
 
         self.stock_request_user.company_id = self.company_2
         stock_request.company_id = self.company_2

--- a/stock_request/views/stock_request_order_views.xml
+++ b/stock_request/views/stock_request_order_views.xml
@@ -132,6 +132,7 @@
                                         options="{'no_create': True}"
                                         groups="stock.group_stock_multi_locations"
                                     />
+                                    <field name="route_ids" invisible="1" />
                                     <field name="product_uom_qty" />
                                     <field name="qty_in_progress" />
                                     <field name="qty_done" />

--- a/stock_request/views/stock_request_views.xml
+++ b/stock_request/views/stock_request_views.xml
@@ -182,6 +182,7 @@
                                 options="{'no_create': True}"
                                 groups="stock.group_stock_multi_locations"
                             />
+                            <field name="route_ids" invisible="1" />
                             <field
                                 name="procurement_group_id"
                                 groups="stock.group_adv_location"

--- a/stock_request_kanban/tests/test_kanban.py
+++ b/stock_request_kanban/tests/test_kanban.py
@@ -89,6 +89,7 @@ class TestKanban(TestBaseKanban):
         kanban.product_uom_qty = 1
         kanban = kanban.create(kanban._convert_to_write(kanban._cache))
         self.assertTrue(kanban.company_id)
+        self.assertIn(self.route, kanban.route_ids)
 
     def test_order_barcodes(self):
         kanban_1 = self.env["stock.request.kanban"].create(

--- a/stock_request_kanban/views/stock_request_kanban_views.xml
+++ b/stock_request_kanban/views/stock_request_kanban_views.xml
@@ -97,6 +97,7 @@
                                 options="{'no_create': True}"
                                 groups="stock.group_stock_multi_locations"
                             />
+                            <field name="route_ids" invisible="1" />
                             <field
                                 name="procurement_group_id"
                                 groups="stock.group_adv_location"


### PR DESCRIPTION
This reverts commit 8b4cb1829ec6281074c038465279e03608fb06e2.

This one reverts https://github.com/OCA/stock-logistics-warehouse/pull/2179 as discussed there.