### PR TITLE
[17.0] [FIX] stock_inventory: remove invalid states attribute on resp…

### DIFF
--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -127,7 +127,6 @@ class InventoryAdjustmentsGroup(models.Model):
     responsible_id = fields.Many2one(
         comodel_name="res.users",
         string="Assigned to",
-        states={"draft": [("readonly", False)]},
         readonly=True,
         help="Specific responsible of Inventory Adjustment.",
     )


### PR DESCRIPTION
…onsible_id

stock.inventory.responsible_id.states is no longer supported.

The form view is the only opportunity for this field to be edited and it already has `readonly="state != 'draft'"` see (https://github.com/OCA/stock-logistics-warehouse/blob/17.0/stock_inventory/views/stock_inventory.xml#L105)