### PR TITLE
[14.0][IMP] stock_location_last_inventory_date: Make last_inventory_date storeable

### DIFF
--- a/stock_location_last_inventory_date/__init__.py
+++ b/stock_location_last_inventory_date/__init__.py
@@ -1,3 +1,5 @@
 # Copyright 2021 Camptocamp SA
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from .hooks import post_init_hook
 from . import models

--- a/stock_location_last_inventory_date/__manifest__.py
+++ b/stock_location_last_inventory_date/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Stock Location Last Inventory Date",
     "summary": "Show the last inventory date for a leaf location",
-    "version": "14.0.1.0.0",
+    "version": "14.0.2.0.0",
     "development_status": "Alpha",
     "category": "Warehouse",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
@@ -13,4 +13,5 @@
     "installable": True,
     "depends": ["product", "stock"],
     "data": ["views/stock_location_views.xml"],
+    "post_init_hook": "post_init_hook",
 }

--- a/stock_location_last_inventory_date/hooks.py
+++ b/stock_location_last_inventory_date/hooks.py
@@ -1,0 +1,36 @@
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def set_initial_last_inventory_date(cr):
+    cr.execute(
+        """
+    Update
+        stock_location
+    set
+        last_inventory_date = sub.date
+    from (
+        Select
+            line.location_id,
+            max(inventory.date) as date
+        from
+            stock_inventory_line as line
+        join
+            stock_inventory as inventory
+        on
+            inventory.id = line.inventory_id
+        group by
+            line.location_id
+    ) as sub
+    where
+        stock_location.id = sub.location_id;
+    """
+    )
+
+
+def post_init_hook(cr, registry):
+    logger.info("Calculate last inventory date for locations")
+    set_initial_last_inventory_date(cr)

--- a/stock_location_last_inventory_date/migrations/14.0.2.0.0/post-migration.py
+++ b/stock_location_last_inventory_date/migrations/14.0.2.0.0/post-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.addons.stock_location_last_inventory_date.hooks import (
+    set_initial_last_inventory_date,
+)
+
+
+def migrate(cr, version):
+    set_initial_last_inventory_date(cr)

--- a/stock_location_last_inventory_date/models/__init__.py
+++ b/stock_location_last_inventory_date/models/__init__.py
@@ -1,3 +1,5 @@
 # Copyright 2021 Camptocamp SA
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from . import stock_location
+from . import stock_inventory

--- a/stock_location_last_inventory_date/models/stock_inventory.py
+++ b/stock_location_last_inventory_date/models/stock_inventory.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockInventory(models.Model):
+    _inherit = "stock.inventory"
+
+    def _action_done(self):
+        super()._action_done()
+        for inventory in self:
+            last_inventory_date = inventory.date
+            done_locations = inventory.line_ids.location_id
+            done_locations.write({"last_inventory_date": last_inventory_date})

--- a/stock_location_last_inventory_date/models/stock_location.py
+++ b/stock_location_last_inventory_date/models/stock_location.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Camptocamp SA
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import fields, models
 
@@ -8,20 +9,6 @@ class StockLocation(models.Model):
 
     last_inventory_date = fields.Datetime(
         "Last Inventory Date",
-        compute="_compute_last_inventory_date",
         help="Indicates the last inventory date for the location, "
         "including inventory done on parents location.",
     )
-
-    def _compute_last_inventory_date(self):
-        for location in self:
-            location_ids = [
-                int(location_id)
-                for location_id in location.parent_path.rstrip("/").split("/")
-            ]
-            last_inventory = self.env["stock.inventory"].search(
-                [("location_ids", "in", location_ids), ("state", "=", "done")],
-                order="date desc",
-                limit=1,
-            )
-            location.last_inventory_date = last_inventory.date

--- a/stock_location_last_inventory_date/readme/CONTRIBUTORS.rst
+++ b/stock_location_last_inventory_date/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Carlos Serra-Toro <carlos.serra@camptocamp.com>
 * `Trobz <https://trobz.com>`_:
+* Michael Tietz (MT Software) <mtietz@mt-software.de>


### PR DESCRIPTION
I wanted to make this field searchable. At first i tried to create a search method for it, but it was not nice to implement, since the location of `stock.inventory` is used. Storing the date is easier. Therefor i changed the computation to use `stock.inventory.line` instead of `stock.inventory` , because this record contains a direct link to a location. 
