### PR TITLE
[FIX]stock_secondary_unit: partial delivery

### DIFF
--- a/stock_secondary_unit/models/__init__.py
+++ b/stock_secondary_unit/models/__init__.py
@@ -4,3 +4,4 @@ from . import stock_product_secondary_unit_mixin
 from . import product_product
 from . import product_template
 from . import stock_move
+from . import stock_picking

--- a/stock_secondary_unit/models/__init__.py
+++ b/stock_secondary_unit/models/__init__.py
@@ -4,5 +4,6 @@ from . import stock_product_secondary_unit_mixin
 from . import product_product
 from . import product_template
 from . import stock_move
+from . import stock_move_line
 from . import stock_picking
 from . import stock_return_picking

--- a/stock_secondary_unit/models/__init__.py
+++ b/stock_secondary_unit/models/__init__.py
@@ -5,3 +5,4 @@ from . import product_product
 from . import product_template
 from . import stock_move
 from . import stock_picking
+from . import stock_return_picking

--- a/stock_secondary_unit/models/stock_move_line.py
+++ b/stock_secondary_unit/models/stock_move_line.py
@@ -1,0 +1,116 @@
+from odoo.tools import float_is_zero
+
+from odoo.addons.stock.models.stock_move_line import StockMoveLine
+
+
+def _new_get_aggregated_product_quantities(self, **kwargs):
+    """Returns a dictionary of products (key = id+name+description+uom)
+    and corresponding values of interest.
+    Allows aggregation of data across separate move lines for the same product.
+    This is expected to be useful in things such as delivery reports.
+    Dict key is made as a combination of values we expect to want to group
+    the products by (i.e. so data is not lost).
+    This function purposely ignores lots/SNs because these are
+    expected to already be properly grouped by line.
+    returns: dictionary {product_id+name+description+uom:
+    {product, name, description, qty_done, product_uom}, ...}
+    """
+    aggregated_move_lines = {}
+
+    # Loops to get backorders, backorders' backorders, and so and so...
+    backorders = self.env["stock.picking"]
+    pickings = self.picking_id
+    while pickings.backorder_ids:
+        backorders |= pickings.backorder_ids
+        pickings = pickings.backorder_ids
+
+    for move_line in self:
+
+        if kwargs.get("except_package") and move_line.result_package_id:
+            continue
+        aggregated_properties = self._get_aggregated_properties(move_line=move_line)
+        line_key = f"{aggregated_properties['line_key']}_{move_line.id}"
+        uom = aggregated_properties["product_uom"]
+        qty_done = move_line.product_uom_id._compute_quantity(move_line.qty_done, uom)
+        if line_key not in aggregated_move_lines:
+            qty_ordered = None
+            if backorders and not kwargs.get("strict"):
+                qty_ordered = move_line.move_id.product_uom_qty
+                # Filters on the aggregation key (product, description and uom) to add the
+                # quantities delayed to backorders to retrieve the original ordered qty.
+                following_move_lines = backorders.move_line_ids.filtered(
+                    lambda ml: self._get_aggregated_properties(move=ml.move_id)[
+                        "line_key"
+                    ]
+                    == line_key
+                )
+                qty_ordered += sum(
+                    following_move_lines.move_id.mapped("product_uom_qty")
+                )
+                # Remove the done quantities of the other move lines of the stock move
+                previous_move_lines = move_line.move_id.move_line_ids.filtered(
+                    lambda ml: self._get_aggregated_properties(move=ml.move_id)[
+                        "line_key"
+                    ]
+                    == line_key
+                    and ml.id != move_line.id
+                )
+                qty_ordered -= sum(
+                    map(
+                        lambda m: m.product_uom_id._compute_quantity(
+                            m.qty_done, aggregated_properties["product_uom"]
+                        ),
+                        previous_move_lines,
+                    )
+                )
+            aggregated_move_lines[line_key] = {
+                **aggregated_properties,
+                "qty_done": qty_done,
+                "qty_ordered": qty_ordered or qty_done,
+                "product": move_line.product_id,
+                "secondary_uom_qty": move_line.secondary_uom_qty,
+                "secondary_uom_id": move_line.secondary_uom_id.name,
+            }
+        else:
+            aggregated_move_lines[line_key]["qty_ordered"] += qty_done
+            aggregated_move_lines[line_key]["qty_done"] += qty_done
+
+    # Does the same for empty move line to retrieve the ordered qty. for partially done moves
+    # (as they are splitted when the transfer is done and empty moves don't have move lines).
+    if kwargs.get("strict"):
+        return aggregated_move_lines
+    pickings = self.picking_id | backorders
+    for empty_move in pickings.move_ids:
+        to_bypass = False
+        if not (
+            empty_move.product_uom_qty
+            and float_is_zero(
+                empty_move.quantity_done,
+                precision_rounding=empty_move.product_uom.rounding,
+            )
+        ):
+            continue
+        if empty_move.state != "cancel":
+            if empty_move.state != "confirmed" or empty_move.move_line_ids:
+                continue
+            else:
+                to_bypass = True
+        aggregated_properties = self._get_aggregated_properties(move=empty_move)
+        line_key = aggregated_properties["line_key"]
+
+        if line_key not in aggregated_move_lines and not to_bypass:
+            qty_ordered = empty_move.product_uom_qty
+            aggregated_move_lines[line_key] = {
+                **aggregated_properties,
+                "qty_done": False,
+                "qty_ordered": qty_ordered,
+                "product": empty_move.product_id,
+            }
+        elif line_key in aggregated_move_lines:
+            aggregated_move_lines[line_key]["qty_ordered"] += empty_move.product_uom_qty
+    return aggregated_move_lines
+
+
+StockMoveLine._get_aggregated_product_quantities = (
+    _new_get_aggregated_product_quantities
+)

--- a/stock_secondary_unit/models/stock_picking.py
+++ b/stock_secondary_unit/models/stock_picking.py
@@ -1,0 +1,24 @@
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _create_backorder(self):
+        res = super(StockPicking, self)._create_backorder()
+
+        for original_move in self.move_ids:
+            corresponding_move = next(
+                (
+                    move
+                    for move in res.move_ids
+                    if move.product_id == original_move.product_id
+                ),
+                None,
+            )
+
+            if corresponding_move and corresponding_move.secondary_uom_qty:
+                corresponding_move._compute_secondary_uom_qty()
+            else:
+                continue
+        return res

--- a/stock_secondary_unit/models/stock_return_picking.py
+++ b/stock_secondary_unit/models/stock_return_picking.py
@@ -1,0 +1,16 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class StockReturnPicking(models.TransientModel):
+    _inherit = "stock.return.picking"
+
+    def _create_returns(self):
+        # Computes the second quantity for the return picking
+        new_picking, pick_type_id = super()._create_returns()
+        picking = self.env["stock.picking"].browse(new_picking)
+        for move in picking.move_ids:
+            if move.product_uom_qty and move.secondary_uom_id:
+                factor = move.secondary_uom_id.factor or 1.0
+                move.secondary_uom_qty = move.product_uom_qty / factor
+        return new_picking, pick_type_id

--- a/stock_secondary_unit/report/report_deliveryslip.xml
+++ b/stock_secondary_unit/report/report_deliveryslip.xml
@@ -41,4 +41,20 @@
             </td>
         </xpath>
     </template>
+
+    <template
+        id="stock_report_delivery_aggregated_move_lines_ux"
+        inherit_id="stock.stock_report_delivery_aggregated_move_lines"
+    >
+        <xpath expr="//td[@name='move_line_aggregated_qty_done']" position="before">
+            <td class="text-center" name="move_line_aggregated_secondary_unit">
+                <t t-if="aggregated_lines[line]['qty_done']">
+                    <span t-esc="aggregated_lines[line]['secondary_uom_qty']" />
+                    <span t-esc="aggregated_lines[line]['secondary_uom_id']" />
+
+                </t>
+            </td>
+
+        </xpath>
+    </template>
 </odoo>


### PR DESCRIPTION
When partial deliveries are created, in the second delivery it does not calculate the secondary unit quantity and simply puts the original quantity.
