### PR TITLE
[16.0][IMP] stock_inventory: forward port feature, add index

### DIFF
--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -483,3 +483,14 @@ class InventoryAdjustmentsGroup(models.Model):
                             " you are only able to add one product."
                         )
                     )
+
+    def unlink(self):
+        for adjustment in self:
+            if adjustment.state != "draft":
+                raise UserError(
+                    _(
+                        "You can only delete inventory adjustments groups in"
+                        " draft state."
+                    )
+                )
+        return super().unlink()

--- a/stock_inventory/models/stock_move_line.py
+++ b/stock_inventory/models/stock_move_line.py
@@ -4,4 +4,4 @@ from odoo import fields, models
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    inventory_adjustment_id = fields.Many2one("stock.inventory")
+    inventory_adjustment_id = fields.Many2one("stock.inventory", ondelete="restrict")

--- a/stock_inventory/models/stock_move_line.py
+++ b/stock_inventory/models/stock_move_line.py
@@ -4,4 +4,6 @@ from odoo import fields, models
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    inventory_adjustment_id = fields.Many2one("stock.inventory", ondelete="restrict")
+    inventory_adjustment_id = fields.Many2one(
+        "stock.inventory", ondelete="restrict", index=True
+    )


### PR DESCRIPTION
- [x] Migrate over https://github.com/OCA/stock-logistics-warehouse/pull/1781
- [x] Add index on `inventory_adjustment_id` on stock.move.line as described below

On a system with many move lines, opening an inventory adjustment view can result in the following slow query:

```
SELECT
    min(l.id) AS id,
    count(l.id),
    l.inventory_adjustment_id
FROM stock_move_line l
LEFT JOIN stock_inventory i ON l.inventory_adjustment_id = i.id
WHERE l.inventory_adjustment_id = 17
AND ((l.company_id = 1) OR l.company_id IS NULL)
GROUP BY l.inventory_adjustment_id,i.date,i.id;
ORDER BY  "stock_move_line__inventory_adjustment_id"."date" DESC,"stock_move_line__inventory_adjustment_id"."id" DESC;
```

The system will have to churn through all the millions of move lines to find the matching ones. This index makes that search quicker.