### PR TITLE
[16.0][FIX] stock_move_location: prevent putaway rules when we don't need them

### DIFF
--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -285,6 +285,10 @@ class StockMoveLocationWizard(models.TransientModel):
             picking = self._create_picking()
         else:
             picking = self.picking_id
+        # Prevent putaway rules to be excuted when we don't need to
+        picking = picking.with_context(
+            avoid_putaway_rules=not self.apply_putaway_strategy
+        )
         self._create_moves(picking)
         if not self.env.context.get("planned"):
             moves_to_reassign = self._unreserve_moves()


### PR DESCRIPTION
fw of

- #2233 

If we disable in the wizard the "Apply putaway rules" toggle we wan't to prevent those to be applied by any automatic logic. Simply injecting the avoid_putaway_rules context the core does so ignoring them.

TT52561

cc @cesar-tecnativa 

please review @carlosdauden @sergio-teruel 