### PR TITLE
[16.0][FIX] stock_valuation_layer_accounting_date: update tests

### DIFF
--- a/stock_valuation_layer_accounting_date/tests/test_stock_valuation_layer_accounting_date.py
+++ b/stock_valuation_layer_accounting_date/tests/test_stock_valuation_layer_accounting_date.py
@@ -5,6 +5,7 @@ from datetime import date
 
 from freezegun import freeze_time
 
+from odoo import fields
 from odoo.tests import tagged
 
 from odoo.addons.stock_account.tests.test_stockvaluationlayer import (
@@ -34,9 +35,10 @@ class TestStockValuationStandard(TestStockValuationStandard):
     def test_svl_accounting_date_manual_periodic(self):
         # Not using freeze_time() in this test since it cannot be applied to create_date
         # without a hack.
-        self.product1.product_tmpl_id.categ_id.property_valuation = "manual_periodic"
+        self.product1.categ_id.property_valuation = "manual_periodic"
         self._make_in_move(self.product1, 10)
         valuation_layer = self.product1.stock_valuation_layer_ids
         self.assertEqual(
-            valuation_layer.accounting_date, valuation_layer.create_date.date()
+            valuation_layer.accounting_date,
+            fields.Date.context_today(valuation_layer, valuation_layer.create_date),
         )


### PR DESCRIPTION
This PR fixes the tests to ensure the same timezone is used for both create_date and accounting_date.

@qrtl QT5096