### PR TITLE
[17.0][FIX] stock_quant_reservation_info: do not show done lines

### DIFF
--- a/stock_quant_reservation_info/models/stock_quant.py
+++ b/stock_quant_reservation_info/models/stock_quant.py
@@ -28,6 +28,7 @@ class StockQuant(models.Model):
             "context": {},
             "domain": [
                 ("product_id", "=", self.product_id.id),
+                ("state", "not in", ["done", "cancel"]),
                 ("quantity_product_uom", ">", 0),
                 ("location_id", "=", self.location_id.id),
                 ("lot_id", "=", self.lot_id.id),


### PR DESCRIPTION
Done lines are not reservations, this went unnoticed during migration to 17