### PR TITLE
[14.0][FIX] stock_reserve_rule: favor largest package when reserving full packaging

### DIFF
--- a/stock_reserve_rule/models/stock_reserve_rule.py
+++ b/stock_reserve_rule/models/stock_reserve_rule.py
@@ -284,19 +284,22 @@ class StockReserveRuleRemoval(models.Model):
         def is_greater_eq(value, other):
             return float_compare(value, other, precision_rounding=rounding) >= 0
 
-        for location, location_quants in quants_per_bin:
-            location_quantity = sum(location_quants.mapped("quantity")) - sum(
-                location_quants.mapped("reserved_quantity")
-            )
-            if location_quantity <= 0:
+        # first search for the largest packaging in all locations
+        for packaging_quantity in packaging_quantities:
+            # check if asked at least packaging quantity
+            if not is_greater_eq(need, packaging_quantity):
                 continue
+            for location, location_quants in quants_per_bin:
+                location_quantity = sum(location_quants.mapped("quantity")) - sum(
+                    location_quants.mapped("reserved_quantity")
+                )
+                if location_quantity <= 0:
+                    continue
 
-            for pack_quantity in packaging_quantities:
-                enough_for_packaging = is_greater_eq(location_quantity, pack_quantity)
-                asked_at_least_packaging_qty = is_greater_eq(need, pack_quantity)
-                if enough_for_packaging and asked_at_least_packaging_qty:
+                # check if quantity is enough for packaging
+                if is_greater_eq(location_quantity, packaging_quantity):
                     # compute how much packaging we can get
-                    take = (need // pack_quantity) * pack_quantity
+                    take = (need // packaging_quantity) * packaging_quantity
                     need = yield location, location_quantity, take, None, None
 
     def _apply_strategy_full_bin(self, quants):

--- a/stock_reserve_rule/models/stock_reserve_rule.py
+++ b/stock_reserve_rule/models/stock_reserve_rule.py
@@ -298,8 +298,12 @@ class StockReserveRuleRemoval(models.Model):
 
                 # check if quantity is enough for packaging
                 if is_greater_eq(location_quantity, packaging_quantity):
-                    # compute how much packaging we can get
-                    take = (need // packaging_quantity) * packaging_quantity
+                    # compute how many packagings we can get
+                    available_packagings = location_quantity // packaging_quantity
+                    need_packagings = need // packaging_quantity
+                    take = (
+                        min(available_packagings, need_packagings) * packaging_quantity
+                    )
                     need = yield location, location_quantity, take, None, None
 
     def _apply_strategy_full_bin(self, quants):

--- a/stock_reserve_rule/tests/test_reserve_rule.py
+++ b/stock_reserve_rule/tests/test_reserve_rule.py
@@ -826,6 +826,69 @@ class TestReserveRule(common.SavepointCase):
         )
         self.assertEqual(move.state, "assigned")
 
+    def test_rule_packaging_does_not_exceed_location_qty(self):
+        self._setup_packagings(
+            self.product1,
+            [("Retail Box", 5, self.retail_box)],
+        )
+        self._update_qty_in_location(self.loc_zone1_bin1, self.product1, 16)
+        picking = self._create_picking(self.wh, [(self.product1, 25)])
+        self._create_rule(
+            {},
+            [
+                {
+                    "location_id": self.loc_zone1.id,
+                    "sequence": 1,
+                    "removal_strategy": "packaging",
+                },
+            ],
+        )
+        picking.with_context(testing=True).action_assign()
+        move = picking.move_lines
+        ml = move.move_line_ids
+        # picking quantity is more than the location quantity so make sure
+        # that the incomplete picking quantity is still divisable by the
+        # packaging quantity
+        self.assertRecordValues(
+            ml,
+            [
+                {"location_id": self.loc_zone1_bin1.id, "product_qty": 15.0},
+            ],
+        )
+        self.assertEqual(move.state, "partially_available")
+
+    def test_rule_packaging_multiple_reservations_from_same_location(self):
+        self._setup_packagings(
+            self.product1,
+            [
+                ("Retail Box", 5, self.retail_box),
+                ("Transport Box", 50, self.transport_box),
+            ],
+        )
+        self._update_qty_in_location(self.loc_zone1_bin1, self.product1, 51)
+        picking = self._create_picking(self.wh, [(self.product1, 55)])
+        self._create_rule(
+            {},
+            [
+                {
+                    "location_id": self.loc_zone1.id,
+                    "sequence": 1,
+                    "removal_strategy": "packaging",
+                },
+            ],
+        )
+        picking.with_context(testing=True).action_assign()
+        move = picking.move_lines
+        ml = move.move_line_ids
+        # should only reserve the 50 from the location
+        self.assertRecordValues(
+            ml,
+            [
+                {"location_id": self.loc_zone1_bin1.id, "product_qty": 50.0},
+            ],
+        )
+        self.assertEqual(move.state, "partially_available")
+
     def test_rule_excluded_not_child_location(self):
         self._update_qty_in_location(self.loc_zone1_bin1, self.product1, 100)
         self._update_qty_in_location(self.loc_zone1_bin2, self.product1, 100)

--- a/stock_reserve_rule/tests/test_reserve_rule.py
+++ b/stock_reserve_rule/tests/test_reserve_rule.py
@@ -796,6 +796,36 @@ class TestReserveRule(common.SavepointCase):
         )
         self.assertEqual(move.state, "assigned")
 
+    def test_rule_packaging_favor_largest_packaging(self):
+        self._setup_packagings(
+            self.product1,
+            [("Pallet", 1000, self.pallet), ("Retail Box", 100, self.retail_box)],
+        )
+        self._update_qty_in_location(self.loc_zone1_bin1, self.product1, 100)
+        self._update_qty_in_location(self.loc_zone1_bin2, self.product1, 1000)
+        picking = self._create_picking(self.wh, [(self.product1, 1000)])
+        self._create_rule(
+            {},
+            [
+                {
+                    "location_id": self.loc_zone1.id,
+                    "sequence": 1,
+                    "removal_strategy": "packaging",
+                },
+            ],
+        )
+        picking.with_context(testing=True).action_assign()
+        move = picking.move_lines
+        ml = move.move_line_ids
+        # since bin2 has 1000 units, it should be used to favor larger packaging
+        self.assertRecordValues(
+            ml,
+            [
+                {"location_id": self.loc_zone1_bin2.id, "product_qty": 1000.0},
+            ],
+        )
+        self.assertEqual(move.state, "assigned")
+
     def test_rule_excluded_not_child_location(self):
         self._update_qty_in_location(self.loc_zone1_bin1, self.product1, 100)
         self._update_qty_in_location(self.loc_zone1_bin2, self.product1, 100)


### PR DESCRIPTION
Fixes issue where a smaller packaging is selected for picking even if another bin would have a larger one available.

Switched the inner and outer loop in `apply_strategy_packaging` to check the largest packaging size for all locations first before considering smaller sizes.