### PR TITLE
[17.0][FIX] stock_quant_manual_assign: fix calculation in the quant manual reservation for MO

### DIFF
--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -185,7 +185,7 @@ class AssignManualQuantsLines(models.TransientModel):
             # validation.
             quant_qty = self.on_hand - self.reserved
             remaining_qty = self.assign_wizard.move_qty
-            self.qty = min(quant_qty, remaining_qty)
+            self.qty = max(0, min(quant_qty, remaining_qty))
 
     @api.constrains("qty")
     def _check_qty(self):


### PR DESCRIPTION
When manually assigning the quants for a MO, in case the previously reserved quantity was higher than the on-hand quantity, the line quantity was negative. This PR fixes the problem so the amount can only be 0 or positive.

@DavidJForgeFlow 