### PR TITLE
[17.0][FIX] stock_quant_manual_assign: manual assign option was enabled in 'done' transfers

### DIFF
--- a/stock_quant_manual_assign/views/stock_move_view.xml
+++ b/stock_quant_manual_assign/views/stock_move_view.xml
@@ -12,7 +12,7 @@
                     icon="fa-tags"
                     title="Manual Quants"
                     options='{"warn": true}'
-                    attrs="{'invisible':['|',('picking_code','=','incoming'),('state','not in',('confirmed','assigned','partially_available'))]}"
+                    invisible="picking_code == 'incoming' or state not in ('confirmed', 'assigned', 'partially_available')"
                 />
             </button>
         </field>


### PR DESCRIPTION
Previous to this fix, the option of manually assigning quants was shown in 'done' transfers.

