### PR TITLE
[15.0][IMP]stock_move_purchase_uom: assign purchase UoM on move creation

### DIFF
--- a/stock_move_purchase_uom/models/stock_move.py
+++ b/stock_move_purchase_uom/models/stock_move.py
@@ -6,6 +6,28 @@ from odoo import api, models
 class StockMove(models.Model):
     _inherit = "stock.move"
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        moves = super().create(vals_list)
+        for move in moves:
+            purchase_uom = move.product_id.uom_po_id
+            if (
+                move.product_id
+                and move.picking_type_id
+                and move.picking_type_id.use_purchase_uom
+                and purchase_uom
+                and move.product_uom != purchase_uom
+                and not move.origin_returned_move_id
+            ):
+                updated_product_uom_qty = move.product_uom._compute_quantity(
+                    move.product_uom_qty,
+                    purchase_uom,
+                    rounding_method=move.picking_type_id.purchase_uom_rounding_method,
+                )
+                move.product_uom = move.product_id.uom_po_id
+                move.product_uom_qty = updated_product_uom_qty
+        return moves
+
     @api.onchange("product_id", "picking_type_id")
     def _onchange_product_id(self):
         res = super()._onchange_product_id()

--- a/stock_move_purchase_uom/models/stock_picking_type.py
+++ b/stock_move_purchase_uom/models/stock_picking_type.py
@@ -10,3 +10,9 @@ class PickingType(models.Model):
         help="Use the product purchase UoM instead of the default UoM "
         "for the moves belonging to this operation type"
     )
+    purchase_uom_rounding_method = fields.Selection(
+        selection=[("HALF-UP", "Closest"), ("UP", "Up")],
+        default="HALF-UP",
+        help="The tie-breaking rule used for float rounding operations when using the "
+        "Purchase UoM",
+    )

--- a/stock_move_purchase_uom/tests/test_common.py
+++ b/stock_move_purchase_uom/tests/test_common.py
@@ -44,3 +44,12 @@ class TestCommon(TransactionCase):
                 "product_uom": cls.cm_uom.id,
             }
         )
+        cls.stock_picking_type_2 = cls.env["stock.picking.type"].create(
+            {
+                "name": "Internal transfer 2",
+                "code": "internal",
+                "sequence_code": "INT",
+                "use_purchase_uom": True,
+                "show_operations": True,
+            }
+        )

--- a/stock_move_purchase_uom/tests/test_stock_move.py
+++ b/stock_move_purchase_uom/tests/test_stock_move.py
@@ -1,5 +1,7 @@
 # Copyright 2024 ForgeFlow S.L. (https://www.forgeflow.com)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from odoo.tests import Form
+
 from .test_common import TestCommon
 
 
@@ -16,3 +18,32 @@ class TestStockMove(TestCommon):
 
         self.stock_move._onchange_product_id()
         self.assertEqual(self.stock_move.product_uom.id, self.product.uom_po_id.id)
+
+    def test_create_move_rounding_method_half_up(self):
+        picking_form = Form(self.env["stock.picking"])
+        picking_form.partner_id = self.partner
+        picking_form.picking_type_id = self.stock_picking_type_2
+        picking_form.location_id = self.location
+        picking_form.location_dest_id = self.location_dest
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = self.product
+            move.product_uom = self.cm_uom
+            move.product_uom_qty = 0.4
+        picking = picking_form.save()
+        move = picking.move_lines[0]
+        self.assertEqual(move.product_uom_qty, 0.0)
+
+    def test_create_move_rounding_method_up(self):
+        self.stock_picking_type_2.purchase_uom_rounding_method = "UP"
+        picking_form = Form(self.env["stock.picking"])
+        picking_form.partner_id = self.partner
+        picking_form.picking_type_id = self.stock_picking_type_2
+        picking_form.location_id = self.location
+        picking_form.location_dest_id = self.location_dest
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = self.product
+            move.product_uom = self.cm_uom
+            move.product_uom_qty = 0.4
+        picking = picking_form.save()
+        move = picking.move_lines[0]
+        self.assertEqual(move.product_uom_qty, 0.01)

--- a/stock_move_purchase_uom/tests/test_stock_move_purchase_uom.py
+++ b/stock_move_purchase_uom/tests/test_stock_move_purchase_uom.py
@@ -10,16 +10,6 @@ class TestStockMovePurchaseUom(TestCommon):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.stock_picking_type_2 = cls.env["stock.picking.type"].create(
-            {
-                "name": "Internal transfer 2",
-                "code": "internal",
-                "sequence_code": "INT",
-                "use_purchase_uom": True,
-                "show_operations": True,
-            }
-        )
-
     def test_stock_move_purchase_uom_unlinked_move_line(self):
         picking_form = Form(self.env["stock.picking"])
         picking_form.partner_id = self.partner

--- a/stock_move_purchase_uom/views/stock_picking_type_views.xml
+++ b/stock_move_purchase_uom/views/stock_picking_type_views.xml
@@ -7,6 +7,10 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='show_reserved']" position="after">
                 <field name="use_purchase_uom" />
+                <field
+                    name="purchase_uom_rounding_method"
+                    attrs="{'invisible': [('use_purchase_uom', '=', False)], 'required': [('use_purchase_uom', '=', True)]}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
When a stock move is created, directly assign the purchase UoM if it's not yet assigned. On top of that, the quantity is updated based on the new UoM by converting it. In order to add more flexibility on the conversion, add a setting on Operation Type to specify the rounding method that will be done when converting the quantity.

cc @ForgeFlow