### PR TITLE
[16.0] Remove warnings in tests

### DIFF
--- a/stock_cycle_count/tests/test_stock_cycle_count.py
+++ b/stock_cycle_count/tests/test_stock_cycle_count.py
@@ -590,8 +590,10 @@ class TestStockCycleCount(common.TransactionCase):
                 "Quant user does not match inventory responsible.",
             )
         self.cycle_count_1.responsible_id = additional_user.id
-        inventory.invalidate_cache()
-        self.cycle_count_1.stock_adjustment_ids[0].stock_quant_ids.invalidate_cache()
+        inventory.invalidate_recordset()
+        self.cycle_count_1.stock_adjustment_ids[
+            0
+        ].stock_quant_ids.invalidate_recordset()
         self.assertEqual(
             inventory.responsible_id.id,
             additional_user.id,

--- a/stock_cycle_count/tests/test_stock_cycle_count.py
+++ b/stock_cycle_count/tests/test_stock_cycle_count.py
@@ -499,7 +499,7 @@ class TestStockCycleCount(common.TransactionCase):
                 "manual_deadline_date": "2026-11-30",
             }
         )
-        cycle_count_1.flush()
+        cycle_count_1.flush_recordset()
         # Confirm the Cycle Count
         cycle_count_1.action_create_inventory_adjustment()
         # Inventory adjustments change their state to in_progress

--- a/stock_location_children/tests/test_stock_location_children.py
+++ b/stock_location_children/tests/test_stock_location_children.py
@@ -74,7 +74,5 @@ class TestStockLocationChildren(BaseCommon):
     def test_action(self):
         # Check the action to view all children
         action = self.stock_shelf_2.action_show_children_locations()
-        self.assertDictContainsSubset(
-            {"domain": [("id", "in", self.stock_shelf_2.children_ids.ids)]},
-            action,
-        )
+        expected = {"domain": [("id", "in", self.stock_shelf_2.children_ids.ids)]}
+        self.assertLessEqual(expected.items(), action.items())

--- a/stock_location_pending_move/tests/test_location_pending_move.py
+++ b/stock_location_pending_move/tests/test_location_pending_move.py
@@ -27,7 +27,9 @@ class TestLocationPendingMove(BaseCommon):
         )
         moves = self.env["stock.move"].search(domain)
         action = self.stock.action_show_pending_stock_moves()
-        self.assertDictContainsSubset({"domain": [("id", "in", moves.ids)]}, action)
+        self.assertLessEqual(
+            {"domain": [("id", "in", moves.ids)]}.items(), action.items()
+        )
 
     def test_location_pending_move_line(self):
         # Check that the action domain is well filled with pending move lines ids.
@@ -43,6 +45,6 @@ class TestLocationPendingMove(BaseCommon):
         )
         move_lines = self.env["stock.move.line"].search(domain)
         action = self.stock.action_show_pending_stock_move_lines()
-        self.assertDictContainsSubset(
-            {"domain": [("id", "in", move_lines.ids)]}, action
+        self.assertLessEqual(
+            {"domain": [("id", "in", move_lines.ids)]}.items(), action.items()
         )

--- a/stock_move_auto_assign_auto_release/tests/test_assign_auto_release.py
+++ b/stock_move_auto_assign_auto_release/tests/test_assign_auto_release.py
@@ -193,8 +193,8 @@ class TestAssignAutoRelease(PromiseReleaseCommonCase):
         )
         with trap_jobs() as trap:
             self._receive_product(self.product1, 100)
-            shipping.invalidate_cache()
-            shipping.move_ids.invalidate_cache()
+            shipping.invalidate_recordset()
+            shipping.move_ids.invalidate_recordset()
             trap.perform_enqueued_jobs()
             job = self._get_job_for_method(
                 trap.enqueued_jobs, shipping.auto_release_available_to_promise
@@ -202,8 +202,8 @@ class TestAssignAutoRelease(PromiseReleaseCommonCase):
             self.assertFalse(job)
         with trap_jobs() as trap:
             self._receive_product(self.product2, 100)
-            shipping.invalidate_cache()
-            shipping.move_ids.invalidate_cache()
+            shipping.invalidate_recordset()
+            shipping.move_ids.invalidate_recordset()
             trap.perform_enqueued_jobs()
             job = self._get_job_for_method(
                 trap.enqueued_jobs, shipping.auto_release_available_to_promise

--- a/stock_picking_volume/tests/test_stock_picking_volume.py
+++ b/stock_picking_volume/tests/test_stock_picking_volume.py
@@ -179,10 +179,10 @@ class TestStockPickingVolume(TransactionCase):
         )
         self.picking.action_confirm()
         self.picking.action_assign()
-        self.picking.invalidate_cache()
+        self.picking.invalidate_recordset()
         self.assertEqual(self.picking.volume, 750 * 2)
         self.picking.move_ids[1]._action_cancel()
-        self.picking.invalidate_cache()
+        self.picking.invalidate_recordset()
         self.assertEqual(self.picking.volume, 750)
 
     def test_product_volume(self):

--- a/stock_quant_safe_inventory/tests/test_safe_inventory.py
+++ b/stock_quant_safe_inventory/tests/test_safe_inventory.py
@@ -59,7 +59,7 @@ class TestSafeInventory(BaseCommon):
         self.picking.action_assign()
         self.picking.move_line_ids.write({"qty_done": 5.0})
         self.env.company.stock_quant_no_inventory_if_being_picked = True
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             UserError,
             "You cannot update the quantity of a quant that is currently being picked",
         ):

--- a/stock_reserve_rule/tests/test_reserve_rule.py
+++ b/stock_reserve_rule/tests/test_reserve_rule.py
@@ -117,7 +117,7 @@ class TestReserveRule(common.TransactionCase):
         rule_config.update(rule_values)
         self.env["stock.reserve.rule"].create(rule_config)
         # workaround for https://github.com/odoo/odoo/pull/41900
-        self.env["stock.reserve.rule"].invalidate_cache()
+        self.env["stock.reserve.rule"].invalidate_model()
 
     def _setup_packagings(self, product, packagings):
         """Create packagings on a product


### PR DESCRIPTION
- [FIX] stock_location_children/pending_move: Remove deprecated assertDictContainsSubset() in tests
- [FIX] stock_picking_volume: Use invalidate_recordset() in tests
- [FIX] stock_quant_safe_inventory: Don't use assertRaisesRegexp() anymore in tests
- [FIX] stock_cycle_count: Don't use flush() anymore in tests
- [FIX] stock_reserve_rule: Don't use invalidate_cache() anymore in tests