### PR TITLE
[16.0] base_product_merge : unable to merge inactive product

### DIFF
--- a/base_product_merge/tests/test_base_product_merge.py
+++ b/base_product_merge/tests/test_base_product_merge.py
@@ -35,3 +35,31 @@ class TestBaseProductMerge(TransactionCase):
         self.assertEqual(len(self.product_model.search([])), total_products + 2)
         # check product_3 exists
         self.assertTrue(product_3.exists())
+
+    def test_product_merge_with_inactive(self):
+        # take current product count
+        total_products = len(self.product_model.search([]))
+        # create products
+        product_active = self.product_model.create({"name": "test product 1"})
+        product_inactive = self.product_model.create({"name": "test product 2"})
+        product_inactive.active = False
+
+        # check product count before merge
+        self.assertEqual(
+            len(self.product_model.with_context(active_test=False).search([])),
+            total_products + 2,
+        )
+
+        # merge product_2 and product_4 with product_1
+        product_merge = self.base_product_merge_model.with_context(
+            active_ids=[product_active.id, product_inactive.id],
+            active_model="product.product",
+        ).create({})
+        product_merge.dst_product_id = product_active
+        product_merge.action_merge()
+
+        # check product count after merge
+        self.assertEqual(
+            len(self.product_model.with_context(active_test=False).search([])),
+            total_products + 1,
+        )

--- a/base_product_merge/wizard/base_product_merge.py
+++ b/base_product_merge/wizard/base_product_merge.py
@@ -37,6 +37,7 @@ class BaseProductMerge(models.Model):
         "product_merge_id",
         "product_id",
         string="Products to merge",
+        context={"active_test": False},
     )
     ptype = fields.Selection(
         [("product.product", "Product"), ("product.template", "Template")]
@@ -50,6 +51,7 @@ class BaseProductMerge(models.Model):
         "product_tmpl_merge_id",
         "product_tmpl_id",
         string="Products Template to merge",
+        context={"active_test": False},
     )
     merge_method = fields.Selection([("sql", "SQL"), ("orm", "ORM")], default="sql")
 


### PR DESCRIPTION
## Module
base_product_merge

## Describe the bug
It's not possible to merge inactive / archived products to active ones

## To Reproduce
**16.0**:

Steps to reproduce the behavior:
1. Create two products
2. Archive one of them
3. Try to merge the archived product with the active one as destination

**Expected behavior**
Only the active product exists 

**Additional context**
When opening the wizard, only the active one is selected and even when adding the archived one, clicking on "Merge products" leads to UserError "Error occurred while merging products."