### PR TITLE
[14.0][fix] stock_request: use deadline date in procurement and other fixes

### DIFF
--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -40,6 +40,9 @@ class StockRequest(models.Model):
     requested_by = fields.Many2one(
         "res.users",
         "Requested by",
+        compute="_compute_requested_by",
+        store=True,
+        readonly=False,
         required=True,
         tracking=True,
         default=lambda s: s._get_default_requested_by(),
@@ -48,6 +51,8 @@ class StockRequest(models.Model):
         "Expected Date",
         index=True,
         default=_get_expected_date,
+        compute="_compute_expected_date",
+        store=True,
         required=True,
         readonly=True,
         states={"draft": [("readonly", False)]},
@@ -59,6 +64,8 @@ class StockRequest(models.Model):
             ("one", "Receive all products at once"),
         ],
         string="Shipping Policy",
+        compute="_compute_picking_policy",
+        store=True,
         required=True,
         readonly=True,
         states={"draft": [("readonly", False)]},
@@ -112,10 +119,16 @@ class StockRequest(models.Model):
     )
     order_id = fields.Many2one("stock.request.order", readonly=True)
     warehouse_id = fields.Many2one(
-        states={"draft": [("readonly", False)]}, readonly=True
+        states={"draft": [("readonly", False)]},
+        readonly=True,
+        compute="_compute_warehouse_id",
+        store=True,
     )
     location_id = fields.Many2one(
-        states={"draft": [("readonly", False)]}, readonly=True
+        states={"draft": [("readonly", False)]},
+        readonly=True,
+        compute="_compute_location_id",
+        store=True,
     )
     product_id = fields.Many2one(states={"draft": [("readonly", False)]}, readonly=True)
     product_uom_id = fields.Many2one(
@@ -125,9 +138,17 @@ class StockRequest(models.Model):
         states={"draft": [("readonly", False)]}, readonly=True
     )
     procurement_group_id = fields.Many2one(
-        states={"draft": [("readonly", False)]}, readonly=True
+        states={"draft": [("readonly", False)]},
+        readonly=True,
+        compute="_compute_procurement_group_id",
+        store=True,
     )
-    company_id = fields.Many2one(states={"draft": [("readonly", False)]}, readonly=True)
+    company_id = fields.Many2one(
+        states={"draft": [("readonly", False)]},
+        readonly=True,
+        compute="_compute_company_id",
+        store=True,
+    )
     route_id = fields.Many2one(states={"draft": [("readonly", False)]}, readonly=True)
     rule_ids = fields.Many2many(
         "stock.rule", string="Rules used", compute="_compute_rules"
@@ -148,6 +169,62 @@ class StockRequest(models.Model):
                 raise ValidationError(
                     _("Stock Request product quantity cannot be negative.")
                 )
+
+    @api.depends("order_id.warehouse_id")
+    def _compute_warehouse_id(self):
+        for request in self:
+            if request.order_id.warehouse_id:
+                request.warehouse_id = request.order_id.warehouse_id
+            else:
+                request.warehouse_id = request.warehouse_id
+
+    @api.depends("order_id.location_id")
+    def _compute_location_id(self):
+        for request in self:
+            if request.order_id.location_id:
+                request.location_id = request.order_id.location_id
+            else:
+                request.location_id = request.location_id
+
+    @api.depends("order_id.requested_by")
+    def _compute_requested_by(self):
+        for request in self:
+            if request.order_id.requested_by:
+                request.requested_by = request.order_id.requested_by
+            else:
+                request.requested_by = request.requested_by
+
+    @api.depends("order_id.expected_date")
+    def _compute_expected_date(self):
+        for request in self:
+            if request.order_id.expected_date:
+                request.expected_date = request.order_id.expected_date
+            else:
+                request.expected_date = request.expected_date
+
+    @api.depends("order_id.picking_policy")
+    def _compute_picking_policy(self):
+        for request in self:
+            if request.order_id.picking_policy:
+                request.picking_policy = request.order_id.picking_policy
+            else:
+                request.picking_policy = request.picking_policy
+
+    @api.depends("order_id.procurement_group_id")
+    def _compute_procurement_group_id(self):
+        for request in self:
+            if request.order_id.procurement_group_id:
+                request.procurement_group_id = request.order_id.procurement_group_id
+            else:
+                request.procurement_group_id = request.procurement_group_id
+
+    @api.depends("order_id.company_id")
+    def _compute_company_id(self):
+        for request in self:
+            if request.order_id.company_id:
+                request.company_id = request.order_id.company_id
+            else:
+                request.company_id = request.company_id
 
     @api.depends(
         "route_id",

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -367,6 +367,7 @@ class StockRequest(models.Model):
             "date_planned": max(
                 [self.expected_date, datetime.combine(self.lead_days_date, time.min)]
             ),
+            "date_deadline": self.expected_date,
             "warehouse_id": self.warehouse_id,
             "stock_request_allocation_ids": self.id,
             "group_id": group_id or self.procurement_group_id.id or False,

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -19,8 +19,7 @@ class StockRequest(models.Model):
     def _get_default_requested_by(self):
         return self.env["res.users"].browse(self.env.uid)
 
-    @staticmethod
-    def _get_expected_date():
+    def _get_expected_date(self):
         return fields.Datetime.now()
 
     name = fields.Char(states={"draft": [("readonly", False)]})
@@ -48,6 +47,7 @@ class StockRequest(models.Model):
     expected_date = fields.Datetime(
         "Expected Date",
         index=True,
+        default=_get_expected_date,
         required=True,
         readonly=True,
         states={"draft": [("readonly", False)]},
@@ -498,8 +498,6 @@ class StockRequest(models.Model):
         if "order_id" in upd_vals:
             order_id = self.env["stock.request.order"].browse(upd_vals["order_id"])
             upd_vals["expected_date"] = order_id.expected_date
-        else:
-            upd_vals["expected_date"] = self._get_expected_date()
         return super().create(upd_vals)
 
     def unlink(self):

--- a/stock_request/models/stock_request.py
+++ b/stock_request/models/stock_request.py
@@ -233,41 +233,70 @@ class StockRequest(models.Model):
 
     @api.constrains("order_id", "requested_by")
     def check_order_requested_by(self):
-        if self.order_id and self.order_id.requested_by != self.requested_by:
-            raise ValidationError(_("Requested by must be equal to the order"))
+        for stock_request in self:
+            if (
+                stock_request.order_id
+                and stock_request.order_id.requested_by != stock_request.requested_by
+            ):
+                raise ValidationError(_("Requested by must be equal to the order"))
 
     @api.constrains("order_id", "warehouse_id")
     def check_order_warehouse_id(self):
-        if self.order_id and self.order_id.warehouse_id != self.warehouse_id:
-            raise ValidationError(_("Warehouse must be equal to the order"))
+        for stock_request in self:
+            if (
+                stock_request.order_id
+                and stock_request.order_id.warehouse_id != stock_request.warehouse_id
+            ):
+                raise ValidationError(_("Warehouse must be equal to the order"))
 
     @api.constrains("order_id", "location_id")
     def check_order_location(self):
-        if self.order_id and self.order_id.location_id != self.location_id:
-            raise ValidationError(_("Location must be equal to the order"))
+        for stock_request in self:
+            if (
+                stock_request.order_id
+                and stock_request.order_id.location_id != stock_request.location_id
+            ):
+                raise ValidationError(_("Location must be equal to the order"))
 
     @api.constrains("order_id", "procurement_group_id")
     def check_order_procurement_group(self):
-        if (
-            self.order_id
-            and self.order_id.procurement_group_id != self.procurement_group_id
-        ):
-            raise ValidationError(_("Procurement group must be equal to the order"))
+        for stock_request in self:
+            if (
+                stock_request.order_id
+                and stock_request.order_id.procurement_group_id
+                != stock_request.procurement_group_id
+            ):
+                raise ValidationError(_("Procurement group must be equal to the order"))
 
     @api.constrains("order_id", "company_id")
     def check_order_company(self):
-        if self.order_id and self.order_id.company_id != self.company_id:
-            raise ValidationError(_("Company must be equal to the order"))
+        for stock_request in self:
+            if (
+                stock_request.order_id
+                and stock_request.order_id.company_id != stock_request.company_id
+            ):
+                raise ValidationError(_("Company must be equal to the order"))
 
     @api.constrains("order_id", "expected_date")
     def check_order_expected_date(self):
-        if self.order_id and self.order_id.expected_date != self.expected_date:
-            raise ValidationError(_("Expected date must be equal to the order"))
+        for stock_request in self:
+            if (
+                stock_request.order_id
+                and stock_request.order_id.expected_date != stock_request.expected_date
+            ):
+                raise ValidationError(_("Expected date must be equal to the order"))
 
     @api.constrains("order_id", "picking_policy")
     def check_order_picking_policy(self):
-        if self.order_id and self.order_id.picking_policy != self.picking_policy:
-            raise ValidationError(_("The picking policy must be equal to the order"))
+        for stock_request in self:
+            if (
+                stock_request.order_id
+                and stock_request.order_id.picking_policy
+                != stock_request.picking_policy
+            ):
+                raise ValidationError(
+                    _("The picking policy must be equal to the order")
+                )
 
     def _action_confirm(self):
         self._action_launch_procurement_rule()

--- a/stock_request/models/stock_request_abstract.py
+++ b/stock_request/models/stock_request_abstract.py
@@ -228,7 +228,7 @@ class StockRequest(models.AbstractModel):
             loc_wh = self.location_id.get_warehouse()
             if loc_wh and self.warehouse_id != loc_wh:
                 self.warehouse_id = loc_wh
-                self.with_context(no_change_childs=True).onchange_warehouse_id()
+                self.onchange_warehouse_id()
 
     @api.onchange("company_id")
     def onchange_company_id(self):

--- a/stock_request/models/stock_request_order.py
+++ b/stock_request/models/stock_request_order.py
@@ -175,26 +175,12 @@ class StockRequestOrder(models.Model):
         for record in self:
             record.stock_request_count = len(record.stock_request_ids)
 
-    @api.onchange("requested_by")
-    def onchange_requested_by(self):
-        self.change_childs()
-
-    @api.onchange("expected_date")
-    def onchange_expected_date(self):
-        self.change_childs()
-
-    @api.onchange("picking_policy")
-    def onchange_picking_policy(self):
-        self.change_childs()
-
     @api.onchange("location_id")
     def onchange_location_id(self):
         if self.location_id:
             loc_wh = self.location_id.get_warehouse()
             if loc_wh and self.warehouse_id != loc_wh:
                 self.warehouse_id = loc_wh
-                self.with_context(no_change_childs=True).onchange_warehouse_id()
-        self.change_childs()
 
     @api.onchange("warehouse_id")
     def onchange_warehouse_id(self):
@@ -203,15 +189,8 @@ class StockRequestOrder(models.Model):
             loc_wh = self.location_id.get_warehouse()
             if self.warehouse_id != loc_wh:
                 self.location_id = self.warehouse_id.lot_stock_id
-                self.with_context(no_change_childs=True).onchange_location_id()
             if self.warehouse_id.company_id != self.company_id:
                 self.company_id = self.warehouse_id.company_id
-                self.with_context(no_change_childs=True).onchange_company_id()
-        self.change_childs()
-
-    @api.onchange("procurement_group_id")
-    def onchange_procurement_group_id(self):
-        self.change_childs()
 
     @api.onchange("company_id")
     def onchange_company_id(self):
@@ -221,19 +200,7 @@ class StockRequestOrder(models.Model):
             self.warehouse_id = self.env["stock.warehouse"].search(
                 [("company_id", "=", self.company_id.id)], limit=1
             )
-            self.with_context(no_change_childs=True).onchange_warehouse_id()
-        self.change_childs()
-
-    def change_childs(self):
-        if not self._context.get("no_change_childs", False):
-            for line in self.stock_request_ids:
-                line.warehouse_id = self.warehouse_id
-                line.location_id = self.location_id
-                line.company_id = self.company_id
-                line.picking_policy = self.picking_policy
-                line.expected_date = self.expected_date
-                line.requested_by = self.requested_by
-                line.procurement_group_id = self.procurement_group_id
+            self.onchange_warehouse_id()
 
     def action_confirm(self):
         if not self.stock_request_ids:

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -336,7 +336,9 @@ class TestStockRequestBase(TestStockRequest):
                 )
             ],
         }
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegexp(
+            exceptions.ValidationError, r"Warehouse must be equal to the order"
+        ):
             self.request_order.with_user(self.stock_request_user).create(vals)
 
     def test_stock_request_order_validations_02(self):
@@ -364,7 +366,9 @@ class TestStockRequestBase(TestStockRequest):
                 )
             ],
         }
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegex(
+            exceptions.ValidationError, "Location must be equal to the order"
+        ):
             self.request_order.with_user(self.stock_request_user).create(vals)
 
     def test_stock_request_order_validations_03(self):
@@ -394,7 +398,9 @@ class TestStockRequestBase(TestStockRequest):
                 )
             ],
         }
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegex(
+            exceptions.ValidationError, "Requested by must be equal to the order"
+        ):
             self.request_order.with_user(self.stock_request_user).create(vals)
 
     def test_stock_request_order_validations_04(self):
@@ -426,10 +432,42 @@ class TestStockRequestBase(TestStockRequest):
                 )
             ],
         }
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegex(
+            exceptions.ValidationError, "Procurement group must be equal to the order"
+        ):
             self.request_order.with_user(self.stock_request_user).create(vals)
 
     def test_stock_request_order_validations_05(self):
+        """Testing the discrepancy in company between
+        stock request and order"""
+        expected_date = fields.Datetime.now()
+        vals = {
+            "company_id": self.company_2.id,
+            "warehouse_id": self.wh2.id,
+            "location_id": self.wh2.lot_stock_id.id,
+            "expected_date": expected_date,
+            "stock_request_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "product_uom_id": self.product.uom_id.id,
+                        "product_uom_qty": 5.0,
+                        "company_id": self.main_company.id,
+                        "warehouse_id": self.warehouse.id,
+                        "location_id": self.warehouse.lot_stock_id.id,
+                        "expected_date": expected_date,
+                    },
+                )
+            ],
+        }
+        with self.assertRaisesRegex(
+            exceptions.ValidationError, "Company must be equal to the order"
+        ):
+            self.request_order.with_user(self.stock_request_user).create(vals)
+
+    def test_stock_request_order_validations_location_from_another_company(self):
         """Testing the discrepancy in company between
         stock request and order"""
         expected_date = fields.Datetime.now()
@@ -454,16 +492,19 @@ class TestStockRequestBase(TestStockRequest):
                 )
             ],
         }
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegex(
+            exceptions.ValidationError,
+            r"You have entered a location that is assigned to another company\.",
+        ):
             self.request_order.with_user(self.stock_request_user).create(vals)
 
-    def test_stock_request_order_validations_06(self):
-        """Testing the discrepancy in expected dates between
-        stock request and order"""
+    def test_stock_request_expected_date_use_stock_order_expected_date_06(self):
+        """Testing stock request expected date from stock request order
+        expected date"""
         expected_date = fields.Datetime.now()
         child_expected_date = "2015-01-01"
         vals = {
-            "company_id": self.company_2.id,
+            "company_id": self.main_company.id,
             "warehouse_id": self.warehouse.id,
             "location_id": self.warehouse.lot_stock_id.id,
             "expected_date": expected_date,
@@ -483,8 +524,11 @@ class TestStockRequestBase(TestStockRequest):
                 )
             ],
         }
-        with self.assertRaises(exceptions.ValidationError):
-            self.request_order.create(vals)
+        order = self.request_order.create(vals)
+        # It won't raise, stock requests are computed from order
+        # date
+        self.assertEqual(order.expected_date, expected_date)
+        self.assertEqual(order.stock_request_ids.expected_date, expected_date)
 
     def test_stock_request_order_validations_07(self):
         """Testing the discrepancy in picking policy between
@@ -512,7 +556,10 @@ class TestStockRequestBase(TestStockRequest):
                 )
             ],
         }
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegex(
+            exceptions.ValidationError,
+            "The picking policy must be equal to the order",
+        ):
             self.request_order.with_user(self.stock_request_user).create(vals)
 
     def test_stock_request_order_available_stock_01(self):
@@ -643,7 +690,11 @@ class TestStockRequestBase(TestStockRequest):
             "location_id": self.warehouse.lot_stock_id.id,
         }
         # Select a UoM that is incompatible with the product's UoM
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegex(
+            exceptions.ValidationError,
+            "You have to select a product unit of measure in the same "
+            "category than the default unit of measure of the product",
+        ):
             self.stock_request.with_user(self.stock_request_user).create(vals)
 
     def test_create_request_01(self):
@@ -928,7 +979,7 @@ class TestStockRequestBase(TestStockRequest):
         self.assertEqual(action["type"], "ir.actions.act_window")
         self.assertEqual(action["res_id"], stock_request.id)
 
-    def test_stock_request_constrains(self):
+    def test_stock_request_constrains_01_warehouse(self):
         vals = {
             "product_id": self.product.id,
             "product_uom_id": self.product.uom_id.id,
@@ -943,16 +994,61 @@ class TestStockRequestBase(TestStockRequest):
         )
 
         # Cannot assign a warehouse that belongs to another company
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegex(exceptions.ValidationError, "warehouse"):
             stock_request.warehouse_id = self.wh2
+
+    def test_stock_request_constrains_02_product(self):
+        vals = {
+            "product_id": self.product.id,
+            "product_uom_id": self.product.uom_id.id,
+            "product_uom_qty": 5.0,
+            "company_id": self.main_company.id,
+            "warehouse_id": self.warehouse.id,
+            "location_id": self.warehouse.lot_stock_id.id,
+        }
+
+        stock_request = self.stock_request.with_user(self.stock_request_user).create(
+            vals
+        )
+
         # Cannot assign a product that belongs to another company
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegex(exceptions.ValidationError, "product"):
             stock_request.product_id = self.product_company_2
+
+    def test_stock_request_constrains_03_location(self):
+        vals = {
+            "product_id": self.product.id,
+            "product_uom_id": self.product.uom_id.id,
+            "product_uom_qty": 5.0,
+            "company_id": self.main_company.id,
+            "warehouse_id": self.warehouse.id,
+            "location_id": self.warehouse.lot_stock_id.id,
+        }
+
+        stock_request = self.stock_request.with_user(self.stock_request_user).create(
+            vals
+        )
+
         # Cannot assign a location that belongs to another company
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegex(exceptions.ValidationError, "location"):
             stock_request.location_id = self.wh2.lot_stock_id
+
+    def test_stock_request_constrains_04_route(self):
+        vals = {
+            "product_id": self.product.id,
+            "product_uom_id": self.product.uom_id.id,
+            "product_uom_qty": 5.0,
+            "company_id": self.main_company.id,
+            "warehouse_id": self.warehouse.id,
+            "location_id": self.warehouse.lot_stock_id.id,
+        }
+
+        stock_request = self.stock_request.with_user(self.stock_request_user).create(
+            vals
+        )
+
         # Cannot assign a route that belongs to another company
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegex(exceptions.ValidationError, "route"):
             stock_request.route_id = self.route_2
 
     def test_stock_request_order_from_products(self):
@@ -1045,7 +1141,7 @@ class TestStockRequestBase(TestStockRequest):
         )
 
         # Wrong model should just raise ValidationError
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegexp(exceptions.ValidationError, "e"):
             order._create_from_product_multiselect(self.stock_request_user)
 
     def test_allow_virtual_location(self):

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -346,27 +346,21 @@ class TestStockRequestBase(TestStockRequest):
 
         procurement_group = self.env["procurement.group"].create({"name": "TEST"})
         order.procurement_group_id = procurement_group
-        order.onchange_procurement_group_id()
         self.assertEqual(
             order.procurement_group_id, order.stock_request_ids.procurement_group_id
         )
 
         order.procurement_group_id = procurement_group
-        order.onchange_procurement_group_id()
         self.assertEqual(
             order.procurement_group_id, order.stock_request_ids.procurement_group_id
         )
         order.picking_policy = "one"
-
-        order.onchange_picking_policy()
         self.assertEqual(order.picking_policy, order.stock_request_ids.picking_policy)
 
         order.expected_date = datetime.now()
-        order.onchange_expected_date()
         self.assertEqual(order.expected_date, order.stock_request_ids.expected_date)
 
         order.requested_by = self.stock_request_manager
-        order.onchange_requested_by()
         self.assertEqual(order.requested_by, order.stock_request_ids.requested_by)
 
     def test_onchanges(self):
@@ -438,66 +432,6 @@ class TestStockRequestBase(TestStockRequest):
         with self.assertRaises(exceptions.ValidationError):
             request_order.save()
 
-    def test_stock_request_order_validations_01(self):
-        """Testing the discrepancy in warehouse_id between
-        stock request and order"""
-        expected_date = fields.Datetime.now()
-        vals = {
-            "company_id": self.main_company.id,
-            "warehouse_id": self.wh2.id,
-            "location_id": self.warehouse.lot_stock_id.id,
-            "expected_date": expected_date,
-            "stock_request_ids": [
-                (
-                    0,
-                    0,
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 5.0,
-                        "company_id": self.main_company.id,
-                        "warehouse_id": self.warehouse.id,
-                        "location_id": self.warehouse.lot_stock_id.id,
-                        "expected_date": expected_date,
-                    },
-                )
-            ],
-        }
-        with self.assertRaisesRegexp(
-            exceptions.ValidationError, r"Warehouse must be equal to the order"
-        ):
-            self.request_order.with_user(self.stock_request_user).create(vals)
-
-    def test_stock_request_order_validations_02(self):
-        """Testing the discrepancy in location_id between
-        stock request and order"""
-        expected_date = fields.Datetime.now()
-        vals = {
-            "company_id": self.main_company.id,
-            "warehouse_id": self.warehouse.id,
-            "location_id": self.wh2.lot_stock_id.id,
-            "expected_date": expected_date,
-            "stock_request_ids": [
-                (
-                    0,
-                    0,
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 5.0,
-                        "company_id": self.main_company.id,
-                        "warehouse_id": self.warehouse.id,
-                        "location_id": self.warehouse.lot_stock_id.id,
-                        "expected_date": expected_date,
-                    },
-                )
-            ],
-        }
-        with self.assertRaisesRegex(
-            exceptions.ValidationError, "Location must be equal to the order"
-        ):
-            self.request_order.with_user(self.stock_request_user).create(vals)
-
     def test_stock_request_order_validations_03(self):
         """Testing the discrepancy in requested_by between
         stock request and order"""
@@ -527,101 +461,6 @@ class TestStockRequestBase(TestStockRequest):
         }
         with self.assertRaisesRegex(
             exceptions.ValidationError, "Requested by must be equal to the order"
-        ):
-            self.request_order.with_user(self.stock_request_user).create(vals)
-
-    def test_stock_request_order_validations_04(self):
-        """Testing the discrepancy in procurement_group_id between
-        stock request and order"""
-        procurement_group = self.env["procurement.group"].create(
-            {"name": "Procurement"}
-        )
-        expected_date = fields.Datetime.now()
-        vals = {
-            "company_id": self.main_company.id,
-            "warehouse_id": self.warehouse.id,
-            "location_id": self.warehouse.lot_stock_id.id,
-            "procurement_group_id": procurement_group.id,
-            "expected_date": expected_date,
-            "stock_request_ids": [
-                (
-                    0,
-                    0,
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 5.0,
-                        "company_id": self.main_company.id,
-                        "warehouse_id": self.warehouse.id,
-                        "location_id": self.warehouse.lot_stock_id.id,
-                        "expected_date": expected_date,
-                    },
-                )
-            ],
-        }
-        with self.assertRaisesRegex(
-            exceptions.ValidationError, "Procurement group must be equal to the order"
-        ):
-            self.request_order.with_user(self.stock_request_user).create(vals)
-
-    def test_stock_request_order_validations_05(self):
-        """Testing the discrepancy in company between
-        stock request and order"""
-        expected_date = fields.Datetime.now()
-        vals = {
-            "company_id": self.company_2.id,
-            "warehouse_id": self.wh2.id,
-            "location_id": self.wh2.lot_stock_id.id,
-            "expected_date": expected_date,
-            "stock_request_ids": [
-                (
-                    0,
-                    0,
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 5.0,
-                        "company_id": self.main_company.id,
-                        "warehouse_id": self.warehouse.id,
-                        "location_id": self.warehouse.lot_stock_id.id,
-                        "expected_date": expected_date,
-                    },
-                )
-            ],
-        }
-        with self.assertRaisesRegex(
-            exceptions.ValidationError, "Company must be equal to the order"
-        ):
-            self.request_order.with_user(self.stock_request_user).create(vals)
-
-    def test_stock_request_order_validations_location_from_another_company(self):
-        """Testing the discrepancy in company between
-        stock request and order"""
-        expected_date = fields.Datetime.now()
-        vals = {
-            "company_id": self.company_2.id,
-            "warehouse_id": self.wh2.id,
-            "location_id": self.wh2.lot_stock_id.id,
-            "expected_date": expected_date,
-            "stock_request_ids": [
-                (
-                    0,
-                    0,
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 5.0,
-                        "company_id": self.company_2.id,
-                        "warehouse_id": self.warehouse.id,
-                        "location_id": self.warehouse.lot_stock_id.id,
-                        "expected_date": expected_date,
-                    },
-                )
-            ],
-        }
-        with self.assertRaisesRegex(
-            exceptions.ValidationError,
-            r"You have entered a location that is assigned to another company\.",
         ):
             self.request_order.with_user(self.stock_request_user).create(vals)
 
@@ -693,38 +532,6 @@ class TestStockRequestBase(TestStockRequest):
             )
         )
         self.assertEqual(stock_request.expected_date, expected_date)
-
-    def test_stock_request_order_validations_07(self):
-        """Testing the discrepancy in picking policy between
-        stock request and order"""
-        expected_date = fields.Datetime.now()
-        vals = {
-            "company_id": self.main_company.id,
-            "warehouse_id": self.warehouse.id,
-            "location_id": self.warehouse.lot_stock_id.id,
-            "picking_policy": "one",
-            "expected_date": expected_date,
-            "stock_request_ids": [
-                (
-                    0,
-                    0,
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "product_uom_qty": 5.0,
-                        "company_id": self.main_company.id,
-                        "warehouse_id": self.warehouse.id,
-                        "location_id": self.warehouse.lot_stock_id.id,
-                        "expected_date": expected_date,
-                    },
-                )
-            ],
-        }
-        with self.assertRaisesRegex(
-            exceptions.ValidationError,
-            "The picking policy must be equal to the order",
-        ):
-            self.request_order.with_user(self.stock_request_user).create(vals)
 
     def test_stock_request_order_available_stock_01(self):
         self.main_company.stock_request_check_available_first = True
@@ -1585,6 +1392,13 @@ class TestStockRequestOrderState(TestStockRequest):
         self.request_b = self.order.stock_request_ids.filtered(
             lambda x: x.product_id == self.product_b
         )
+
+    def test_stock_request_requested_by(self):
+        self.order.requested_by = self.stock_request_user
+        stock_requests = self.order.stock_request_ids
+        self.assertEqual(stock_requests.requested_by, self.stock_request_user)
+        stock_requests.order_id = False
+        self.assertEqual(stock_requests.requested_by, self.stock_request_user)
 
     def test_stock_request_order_state_01(self):
         """Request A: Done + Request B: Done = Done."""

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -1,9 +1,11 @@
 # Copyright 2017 ForgeFlow S.L.
 # Copyright 2022-2023 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
-
 from collections import Counter
 from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 from odoo import exceptions, fields
 from odoo.tests import Form, common, new_test_user
@@ -654,6 +656,43 @@ class TestStockRequestBase(TestStockRequest):
         # date
         self.assertEqual(order.expected_date, expected_date)
         self.assertEqual(order.stock_request_ids.expected_date, expected_date)
+
+    def test_create_default_date(self):
+        with freeze_time("2022-06-15 12:24"):
+            stock_request = (
+                self.env["stock.request"]
+                .with_user(self.stock_request_user)
+                .create(
+                    {
+                        "product_id": self.product.id,
+                        "product_uom_id": self.product.uom_id.id,
+                        "product_uom_qty": 4.0,
+                        "company_id": self.main_company.id,
+                        "warehouse_id": self.warehouse.id,
+                        "location_id": self.warehouse.lot_stock_id.id,
+                    }
+                )
+            )
+            self.assertEqual(stock_request.expected_date, fields.Datetime.now())
+
+    def test_create_with_given_date_wont_force_new_date(self):
+        expected_date = fields.Datetime.now() + relativedelta(days=1)
+        stock_request = (
+            self.env["stock.request"]
+            .with_user(self.stock_request_user)
+            .create(
+                {
+                    "product_id": self.product.id,
+                    "product_uom_id": self.product.uom_id.id,
+                    "product_uom_qty": 4.0,
+                    "company_id": self.main_company.id,
+                    "warehouse_id": self.warehouse.id,
+                    "location_id": self.warehouse.lot_stock_id.id,
+                    "expected_date": expected_date,
+                }
+            )
+        )
+        self.assertEqual(stock_request.expected_date, expected_date)
 
     def test_stock_request_order_validations_07(self):
         """Testing the discrepancy in picking policy between

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -142,6 +142,131 @@ class TestStockRequest(common.TransactionCase):
         )
 
 
+class TestStockRequestConstraintsOnWrite(TestStockRequest):
+    def setUp(self):
+        super().setUp()
+        expected_date = fields.Datetime.now()
+        self.stock_order = self.request_order.with_user(self.stock_request_user).create(
+            {
+                "company_id": self.main_company.id,
+                "warehouse_id": self.warehouse.id,
+                "location_id": self.warehouse.lot_stock_id.id,
+                "expected_date": expected_date,
+                "stock_request_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_id": self.product.uom_id.id,
+                            "product_uom_qty": 5.0,
+                            "company_id": self.main_company.id,
+                            "warehouse_id": self.warehouse.id,
+                            "location_id": self.warehouse.lot_stock_id.id,
+                            "expected_date": expected_date,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_id": self.product.uom_id.id,
+                            "product_uom_qty": 2.0,
+                            "company_id": self.main_company.id,
+                            "warehouse_id": self.warehouse.id,
+                            "location_id": self.warehouse.lot_stock_id.id,
+                            "expected_date": expected_date,
+                        },
+                    ),
+                ],
+            }
+        )
+
+    def test_stock_request_order_validations_01(self):
+        """Testing the check order warehouse id with recordset
+
+        The mismatch between company and warehouse raise before
+        """
+        self.stock_order.stock_request_ids.check_order_warehouse_id()
+
+    def test_stock_request_order_validations_02(self):
+        """Testing the check order location id with recordset
+
+        The mismatch between company and warehouse/location
+        raise before
+        """
+        self.stock_order.stock_request_ids.check_order_location()
+
+    def test_stock_request_order_validations_03(self):
+        """Testing the discrepancy in requested_by between
+        stock request and order"""
+        with self.assertRaisesRegex(
+            exceptions.ValidationError, "Requested by must be equal to the order"
+        ):
+            self.stock_order.stock_request_ids.write(
+                {
+                    "requested_by": self.stock_request_manager.id,
+                }
+            )
+
+    def test_stock_request_order_validations_04(self):
+        """Testing the discrepancy in procurement_group_id between
+        stock request and order"""
+        procurement_group = self.env["procurement.group"].create(
+            {"name": "Procurement"}
+        )
+        with self.assertRaisesRegex(
+            exceptions.ValidationError, "Procurement group must be equal to the order"
+        ):
+            self.stock_order.stock_request_ids.write(
+                {
+                    "procurement_group_id": procurement_group.id,
+                }
+            )
+
+    def test_stock_request_order_validations_05(self):
+        """Testing the discrepancy in company between
+        stock request and order"""
+        with self.assertRaisesRegex(
+            exceptions.ValidationError, "Company must be equal to the order"
+        ):
+            self.stock_order.stock_request_ids.write(
+                {
+                    "company_id": self.company_2.id,
+                    "warehouse_id": self.wh2.id,
+                    "location_id": self.wh2.lot_stock_id.id,
+                }
+            )
+
+    def test_stock_request_expected_date_use_stock_order_expected_date_06(self):
+        """Testing stock request expected date from stock request order
+        expected date"""
+        child_expected_date = "2015-01-01"
+
+        with self.assertRaisesRegex(
+            exceptions.ValidationError, "Expected date must be equal to the order"
+        ):
+            self.stock_order.stock_request_ids.write(
+                {
+                    "expected_date": child_expected_date,
+                }
+            )
+
+    def test_stock_request_order_validations_07(self):
+        """Testing the discrepancy in picking policy between
+        stock request and order"""
+        with self.assertRaisesRegex(
+            exceptions.ValidationError,
+            "The picking policy must be equal to the order",
+        ):
+            self.stock_order.stock_request_ids.write(
+                {
+                    "picking_policy": "one",
+                }
+            )
+
+
 class TestStockRequestBase(TestStockRequest):
     def setUp(self):
         super().setUp()

--- a/stock_request/tests/test_stock_request.py
+++ b/stock_request/tests/test_stock_request.py
@@ -1027,6 +1027,68 @@ class TestStockRequestBase(TestStockRequest):
         self.assertEqual(stock_request_2.qty_cancelled, 6)
         self.assertEqual(stock_request_2.state, "cancel")
 
+    def test_create_request_with_different_dates(self):
+        self.product.route_ids = [(6, 0, self.route.ids)]
+        now = fields.Datetime.now()
+        stock_request_1 = (
+            self.env["stock.request"]
+            .with_user(self.stock_request_user)
+            .create(
+                {
+                    "product_id": self.product.id,
+                    "product_uom_id": self.product.uom_id.id,
+                    "product_uom_qty": 4.0,
+                    "company_id": self.main_company.id,
+                    "warehouse_id": self.warehouse.id,
+                    "location_id": self.warehouse.lot_stock_id.id,
+                    "expected_date": now + relativedelta(days=1),
+                }
+            )
+        )
+        stock_request_2 = (
+            self.env["stock.request"]
+            .with_user(self.stock_request_manager.id)
+            .create(
+                {
+                    "product_id": self.product.id,
+                    "product_uom_id": self.product.uom_id.id,
+                    "product_uom_qty": 6.0,
+                    "company_id": self.main_company.id,
+                    "warehouse_id": self.warehouse.id,
+                    "location_id": self.warehouse.lot_stock_id.id,
+                    "expected_date": now + relativedelta(days=2),
+                }
+            )
+        )
+        self.assertNotEqual(
+            stock_request_1.expected_date,
+            stock_request_2.expected_date,
+        )
+        stock_request_1.sudo().action_confirm()
+        stock_request_2.sudo().action_confirm()
+        # expected 2 moves on the same picking
+        self.assertEqual(
+            stock_request_1.sudo().picking_ids, stock_request_2.sudo().picking_ids
+        )
+        self.assertNotEqual(
+            stock_request_1.sudo().move_ids, stock_request_2.sudo().move_ids
+        )
+        self.assertEqual(len(stock_request_1.sudo().move_ids), 1)
+        self.assertEqual(len(stock_request_1.sudo().picking_ids.move_lines), 2)
+        self.assertEqual(
+            stock_request_1.sudo().move_ids.date_deadline, now + relativedelta(days=1)
+        )
+        self.assertEqual(
+            stock_request_1.sudo().move_ids.date, now + relativedelta(days=1)
+        )
+
+        self.assertEqual(
+            stock_request_2.sudo().move_ids.date_deadline, now + relativedelta(days=2)
+        )
+        self.assertEqual(
+            stock_request_2.sudo().move_ids.date, now + relativedelta(days=2)
+        )
+
     def test_cancel_request(self):
         expected_date = fields.Datetime.now()
         vals = {


### PR DESCRIPTION
replace #1637 

In this PR I've multiple changes; let me now It you prefer distincts PRs:

* improves unit test to make sure `assetRaises` realy test what it expected to test
* makes api.constraints working with recordset
* do not force default expected date on stock.request if user provide one at creation without stock.request.order
* use the expected date as deadline_date on procurement creation to avoid merging `stock.move` from different stock.request with different expected date. I wonder the impact on running prod env and wonder if I should do something less impacting ? 
* refactor code to replace api.onchange per api.depends: which helps to reuse code while using inherits on stock.request.order