### PR TITLE
[16.0][IMP] stock_quant_manual_assign: Improve assign_quants() performance

### DIFF
--- a/stock_quant_manual_assign/README.rst
+++ b/stock_quant_manual_assign/README.rst
@@ -29,7 +29,7 @@ Stock - Manual Quant Assignment
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module allows you to make stock reservations manually in a
-transfer, changing the selection that Odoo automatically made.This
+transfer, changing the selection that Odoo automatically made. This
 functionality is essential for detailed and specific control over
 inventory transfers, ensuring that the correct products are moved
 between precise locations within the warehouse.

--- a/stock_quant_manual_assign/readme/DESCRIPTION.md
+++ b/stock_quant_manual_assign/readme/DESCRIPTION.md
@@ -1,1 +1,4 @@
-This module allows you to make stock reservations manually in a transfer, changing the selection that Odoo automatically made.This functionality is essential for detailed and specific control over inventory transfers, ensuring that the correct products are moved between precise locations within the warehouse.
+This module allows you to make stock reservations manually in a transfer, changing the
+selection that Odoo automatically made. This functionality is essential for detailed
+and specific control over inventory transfers, ensuring that the correct products are
+moved between precise locations within the warehouse.

--- a/stock_quant_manual_assign/static/description/index.html
+++ b/stock_quant_manual_assign/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -371,7 +370,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/stock-logistics-warehouse/tree/16.0/stock_quant_manual_assign"><img alt="OCA/stock-logistics-warehouse" src="https://img.shields.io/badge/github-OCA%2Fstock--logistics--warehouse-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/stock-logistics-warehouse-16-0/stock-logistics-warehouse-16-0-stock_quant_manual_assign"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/stock-logistics-warehouse&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module allows you to make stock reservations manually in a
-transfer, changing the selection that Odoo automatically made.This
+transfer, changing the selection that Odoo automatically made. This
 functionality is essential for detailed and specific control over
 inventory transfers, ensuring that the correct products are moved
 between precise locations within the warehouse.</p>
@@ -502,9 +501,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/stock_quant_manual_assign/tests/test_stock_quant_manual_assign.py
+++ b/stock_quant_manual_assign/tests/test_stock_quant_manual_assign.py
@@ -172,3 +172,23 @@ class TestStockQuantManualAssign(TransactionCase):
             sum(line.qty for line in wizard.quants_lines),
             self.move.reserved_availability,
         )
+
+    def test_quant_assign_get_discrepancies(self):
+        self.move._action_assign()
+        # There should be no move lines to unlink and no quant lines to assign
+        # if there is no discrepancy between move lines and quant lines
+        wizard = self._create_wizard()
+        self.assertEqual(
+            len(wizard.quants_lines.ids),
+            3,
+            "Three quants created, three quants got by default",
+        )
+        move_lines_to_unlink, quant_lines_to_assign = wizard._get_discrepancies()
+        self.assertFalse(move_lines_to_unlink)
+        self.assertFalse(quant_lines_to_assign)
+        # There should be a move line to unlink
+        # and a quant line to assisgn (due to qty discrepancy)
+        wizard.quants_lines[2].write({"selected": True, "qty": 50.0})
+        move_lines_to_unlink, quant_lines_to_assign = wizard._get_discrepancies()
+        self.assertEqual(move_lines_to_unlink, self.move.move_line_ids[2])
+        self.assertEqual(quant_lines_to_assign, wizard.quants_lines[2])

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -58,11 +58,54 @@ class AssignManualQuants(models.TransientModel):
         string="Move",
     )
 
+    def _get_discrepancies(self):
+        """Get discrepancies between quant lines and move lines.
+
+        This is so that we can work on the minimum sets of records to unlink or assign.
+
+        :return: two recordsets, one with move lines to unlink and the other with quant
+            lines to assign.
+        """
+        self.ensure_one()
+        ml_to_unlink = self.env["stock.move.line"].browse()
+        ql_to_assign = self.env["assign.manual.quants.lines"].browse()
+        ml_dict = {
+            ml: [
+                ml.location_id.id,
+                ml.lot_id.id,
+                ml.package_id.id,
+                ml.owner_id.id,
+                ml.reserved_uom_qty,
+            ]
+            for ml in self.move_id.move_line_ids
+        }
+        quant_lines = self.quants_lines.filtered(lambda x: x.qty > 0)
+        ql_dict = {
+            ql: [
+                ql.location_id.id,
+                ql.lot_id.id,
+                ql.package_id.id,
+                ql.owner_id.id,
+                ql.qty,
+            ]
+            for ql in quant_lines
+        }
+        ml_vals = {tuple(v) for v in ml_dict.values()}
+        ql_vals = {tuple(v) for v in ql_dict.values()}
+        for k, v in ml_dict.items():
+            if tuple(v) not in ql_vals:
+                ml_to_unlink |= k
+        for k, v in ql_dict.items():
+            if tuple(v) not in ml_vals:
+                ql_to_assign |= k
+        return ml_to_unlink, ql_to_assign
+
     def assign_quants(self):
-        move = self.move_id
-        self.move_id.move_line_ids.unlink()
-        for line in self.quants_lines:
+        move_lines, quant_lines = self._get_discrepancies()
+        move_lines.unlink()
+        for line in quant_lines:
             line._assign_quant_line()
+        move = self.move_id
         if move.picking_type_id.auto_fill_qty_done:
             if move.from_immediate_transfer:
                 move.quantity_done = self.lines_qty


### PR DESCRIPTION
Previously, when there were hundreds of quants assigned to a stock move, it would take a very long time for assign_quants() to complete, as the system would try to reassign all selected quants.

This PR mitigates the issue by identifying only the necessary changes — specifically, the move lines to be unlinked and the quant lines to be assigned — so that updates are made only to those records.

@qrtl QT5295