### PR TITLE
[18.0][FWD][FIX] stock_vertical_lift: put package multiple lines

### DIFF
--- a/stock_vertical_lift/models/vertical_lift_operation_put.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_put.py
@@ -155,7 +155,7 @@ class VerticalLiftOperationPut(models.Model):
                     line_keep = fields.first(lines)
                     if self._check_move_lines_to_merge(lines):
                         values = {
-                            "product_uom_qty": sum(lines.mapped("product_uom_qty")),
+                            "quantity": sum(lines.mapped("quantity")),
                         }
                         line_keep.write(values)
                         other_lines = lines - line_keep

--- a/stock_vertical_lift/models/vertical_lift_operation_put.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_put.py
@@ -123,11 +123,45 @@ class VerticalLiftOperationPut(models.Model):
         if product:
             return self._find_move_line_for_product(product)
 
+    def _check_move_lines_to_merge(self, lines):
+        check_fields = ["product_id", "lot_id", "product_uom_id"]
+        for field in check_fields:
+            values = lines.mapped(field)
+            if len(values) > 1:
+                return False
+            if len(values) == 1 and lines.filtered(
+                lambda line, field=field: not line[field]
+            ):
+                return False
+        return True
+
     def _find_move_line_for_package(self, package):
         domain = AND(
             [self._domain_move_lines_to_do_all(), [("package_id", "in", package.ids)]]
         )
-        return self.env["stock.move.line"].search(domain, limit=1)
+        lines = self.env["stock.move.line"].search(domain)
+        if len(lines) > 1:
+            # Multiple move lines in the same package,
+            # they need to be merged if possible
+            # Or Odoo will raise an exception
+            # because the move is done one line at at time
+            picking = fields.first(lines.picking_id)
+            if picking._check_move_lines_map_quant_package(package):
+                # Fist merge all lines in the same move
+                move = lines.move_id._merge_moves()
+                if len(move) == 1 and len(move.move_line_ids) > 1:
+                    # Now we have one move, let's merge the move lines together
+                    lines = move.move_line_ids
+                    line_keep = fields.first(lines)
+                    if self._check_move_lines_to_merge(lines):
+                        values = {
+                            "product_uom_qty": sum(lines.mapped("product_uom_qty")),
+                        }
+                        line_keep.write(values)
+                        other_lines = lines - line_keep
+                        other_lines.unlink()
+                    lines = line_keep
+        return fields.first(lines)
 
     def _find_move_line_for_lot(self, lot):
         domain = AND(

--- a/stock_vertical_lift/tests/test_inventory.py
+++ b/stock_vertical_lift/tests/test_inventory.py
@@ -2,12 +2,16 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import Form
+from odoo.tests import Form, RecordCapturer
+from odoo.tools import mute_logger
 
 from .common import VerticalLiftCase
 
+SHUTTLE_LOGGER = "odoo.addons.stock_vertical_lift.models.vertical_lift_shuttle"
+
 
 class TestInventory(VerticalLiftCase):
+    @mute_logger(SHUTTLE_LOGGER)
     def test_switch_inventory(self):
         self.shuttle.switch_inventory()
         self.assertEqual(self.shuttle.mode, "inventory")
@@ -16,6 +20,7 @@ class TestInventory(VerticalLiftCase):
             self.env["stock.quant"].browse(),
         )
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_inventory_action_open_screen(self):
         self.shuttle.switch_inventory()
         action = self.shuttle.action_open_screen()
@@ -24,6 +29,7 @@ class TestInventory(VerticalLiftCase):
         self.assertEqual(action["res_model"], "vertical.lift.operation.inventory")
         self.assertEqual(action["res_id"], operation.id)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_inventory_actions(self):
         self.shuttle.switch_inventory()
         action = self.shuttle.action_menu()
@@ -66,6 +72,7 @@ class TestInventory(VerticalLiftCase):
         vls_manual = ClassWithContext.browse(rec_id)
         vls_manual.button_save()
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_inventory_count_ops(self):
         self._update_qty_in_location(self.location_1a_x1y1, self.product_socks, 10)
         self._update_qty_in_location(self.location_1a_x2y1, self.product_recovery, 10)
@@ -82,6 +89,7 @@ class TestInventory(VerticalLiftCase):
         self.assertEqual(operation.number_of_ops, 2)
         self.assertEqual(operation.number_of_ops_all, 3)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_process_current_inventory(self):
         stock_quant = self._create_stock_quants(
             [(self.location_1a_x1y1, self.product_socks)]
@@ -108,6 +116,7 @@ class TestInventory(VerticalLiftCase):
         }
         self.assertEqual(result, expected_result)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_wrong_quantity(self):
         quant = self._create_stock_quants(
             [(self.location_1a_x1y1, self.product_socks)]
@@ -126,12 +135,17 @@ class TestInventory(VerticalLiftCase):
 
         # entering the same quantity a second time validates
         operation.quantity_input = 12.0
-        operation.button_save()
+        with RecordCapturer(self.env["stock.move"], []) as capt:
+            operation.button_save()
+            move = capt.records[0]
+            self.assertEqual(move.state, "done")
+            self.assertEqual(move.quantity, 2.0)
         self.assertFalse(operation.quant_id)
         self.assertTrue(quant.vertical_lift_done)
         self.assertEqual(quant.quantity, 12.0)
         self.assertFalse(operation.quant_id)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_confirm_wrong_quantity(self):
         stock_quant = self._create_stock_quants(
             [(self.location_1a_x1y1, self.product_socks)]
@@ -150,6 +164,7 @@ class TestInventory(VerticalLiftCase):
         operation.button_save()
         self.assertEqual(operation.state, "quantity")
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_inventory_next_line(self):
         stock_quants = self._create_stock_quants(
             [
@@ -172,6 +187,7 @@ class TestInventory(VerticalLiftCase):
         self.assertEqual(operation.last_quantity_input, 0.0)
         self.assertEqual(operation.quantity_input, 0.0)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_inventory_locations(self):
         self.shuttle.switch_inventory()
         opr_inventory = self.shuttle._operation_for_mode()

--- a/stock_vertical_lift/tests/test_lift_command.py
+++ b/stock_vertical_lift/tests/test_lift_command.py
@@ -8,8 +8,11 @@ from odoo.tools import mute_logger
 
 from .common import VerticalLiftCase
 
+SHUTTLE_LOGGER = "odoo.addons.stock_vertical_lift.models.vertical_lift_shuttle"
+
 
 class TestLiftCommand(VerticalLiftCase):
+    @mute_logger(SHUTTLE_LOGGER)
     def test_lift_commands(self):
         self.shuttle.switch_inventory()
         command_id = self.shuttle.command_ids[0]
@@ -26,7 +29,10 @@ class TestLiftCommand(VerticalLiftCase):
             }
         )
 
-    @mute_logger("odoo.addons.stock_vertical_lift.models.vertical_lift_command")
+    @mute_logger(
+        "odoo.addons.stock_vertical_lift.models.vertical_lift_command",
+        "odoo.models.unlink",
+    )
     def test_lift_commands_autovacuum(self):
         command_obj = self.env["vertical.lift.command"]
         param_obj = self.env["ir.config_parameter"].sudo()

--- a/stock_vertical_lift/tests/test_location.py
+++ b/stock_vertical_lift/tests/test_location.py
@@ -2,8 +2,11 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import exceptions
+from odoo.tools import mute_logger
 
 from .common import VerticalLiftCase
+
+SHUTTLE_LOGGER = "odoo.addons.stock_vertical_lift.models.vertical_lift_shuttle"
 
 
 class TestVerticalLiftLocation(VerticalLiftCase):
@@ -27,6 +30,7 @@ class TestVerticalLiftLocation(VerticalLiftCase):
             all(location.vertical_lift_kind == "cell" for location in cells)
         )
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_fetch_vertical_lift_tray(self):
         shuttles = self.vertical_lift_loc.child_ids
         trays = shuttles.mapped("child_ids")

--- a/stock_vertical_lift/tests/test_pick.py
+++ b/stock_vertical_lift/tests/test_pick.py
@@ -2,9 +2,12 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import logging
 
+from odoo.tools import mute_logger
+
 from .common import VerticalLiftCase
 
 _logger = logging.getLogger(__name__)
+SHUTTLE_LOGGER = "odoo.addons.stock_vertical_lift.models.vertical_lift_shuttle"
 
 
 class TestPick(VerticalLiftCase):
@@ -18,6 +21,7 @@ class TestPick(VerticalLiftCase):
         # stock_picking_out_demo_vertical_lift_1
         cls.out_move_line = cls.picking_out.move_line_ids[0]
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_switch_pick(self):
         self.shuttle.switch_pick()
         self.assertEqual(self.shuttle.mode, "pick")
@@ -25,6 +29,7 @@ class TestPick(VerticalLiftCase):
             self.shuttle._operation_for_mode().current_move_line_id, self.out_move_line
         )
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_pick_action_open_screen(self):
         self.shuttle.switch_pick()
         action = self.shuttle.action_open_screen()
@@ -34,6 +39,7 @@ class TestPick(VerticalLiftCase):
         self.assertEqual(action["res_model"], "vertical.lift.operation.pick")
         self.assertEqual(action["res_id"], operation.id)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_pick_select_next_move_line(self):
         operation = self._open_screen("pick")
         operation.select_next_move_line()
@@ -42,6 +48,7 @@ class TestPick(VerticalLiftCase):
         )
         self.assertEqual(operation.state, "scan_destination")
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_pick_select_next_move_line_was_skipped(self):
         """Previously skipped moves can be reprocessed"""
         self.picking_out.move_line_ids.write({"vertical_lift_skipped": True})
@@ -61,6 +68,7 @@ class TestPick(VerticalLiftCase):
             operation.current_move_line_id, self.picking_out.move_line_ids[0]
         )
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_pick_save(self):
         operation = self._open_screen("pick")
         # assume we already scanned the destination, current state is save
@@ -70,14 +78,17 @@ class TestPick(VerticalLiftCase):
         self.assertEqual(operation.current_move_line_id.state, "done")
         self.assertEqual(operation.state, "release")
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_pick_skip_from_scan_destination(self):
         """Being in state Scan Destination, skip it"""
         self._test_pick_skip_from_state("scan_destination")
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_pick_skip_from_save(self):
         """Being in state Save, skip it"""
         self._test_pick_skip_from_state("save")
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_pick_skip_from_release(self):
         """Being in state Release, skip it"""
         self._test_pick_skip_from_state("release")
@@ -95,6 +106,7 @@ class TestPick(VerticalLiftCase):
         self.assertEqual(operation.current_move_line_id.state, "assigned")
         self.assertEqual(operation.state, "scan_destination")
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_pick_related_fields(self):
         operation = self._open_screen("pick")
         ml = operation.current_move_line_id = self.out_move_line
@@ -128,6 +140,7 @@ class TestPick(VerticalLiftCase):
         self.assertEqual(operation.quantity, ml.quantity)
         self.assertEqual(operation.lot_id, ml.lot_id)
 
+    @mute_logger(SHUTTLE_LOGGER, "odoo.models.unlink")
     def test_pick_count_move_lines(self):
         product1 = self.env.ref("stock_vertical_lift.product_running_socks")
         product2 = self.env.ref("stock_vertical_lift.product_recovery_socks")
@@ -202,6 +215,7 @@ class TestPick(VerticalLiftCase):
         self.assertEqual(operation1.number_of_ops_all, 6)
         self.assertEqual(operation2.number_of_ops_all, 6)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_on_barcode_scanned(self):
         operation = self._open_screen("pick")
         self.assertEqual(operation.state, "scan_destination")
@@ -228,10 +242,12 @@ class TestPick(VerticalLiftCase):
         self.assertEqual(move_line.move_id.location_dest_id, current_destination)
         self.assertEqual(move_line.picking_id.location_dest_id, current_destination)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_button_release(self):
         self._open_screen("pick")
         self._test_button_release(self.picking_out.move_line_ids, "noop")
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_process_current_pick(self):
         operation = self._open_screen("pick")
         operation.current_move_line_id = self.out_move_line
@@ -240,6 +256,7 @@ class TestPick(VerticalLiftCase):
         self.assertEqual(self.out_move_line.state, "done")
         self.assertEqual(self.out_move_line.quantity, qty_to_process)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_matrix(self):
         operation = self._open_screen("pick")
         operation.current_move_line_id = self.out_move_line
@@ -260,6 +277,7 @@ class TestPick(VerticalLiftCase):
             },
         )
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_tray_qty(self):
         cell = self.env.ref(
             "stock_vertical_lift.stock_location_vertical_lift_demo_tray_1a_x3y2"
@@ -273,6 +291,7 @@ class TestPick(VerticalLiftCase):
         self.assertEqual(operation.tray_qty, 30)
         self.assertTrue(operation.product_packagings)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_product_packagings(self):
         operation = self.shuttle._operation_for_mode()
         ml = operation.current_move_line_id

--- a/stock_vertical_lift/tests/test_put.py
+++ b/stock_vertical_lift/tests/test_put.py
@@ -191,8 +191,8 @@ class TestPut(VerticalLiftCase):
             }
         )
         # Split the move line to have 2
-        line2 = line1.copy({"product_uom_qty": 1, "picking_id": pick.id})
-        line1.with_context(bypass_reservation_update=True).product_uom_qty = 14
+        line2 = line1.copy({"quantity": 1, "picking_id": pick.id})
+        line1.with_context(bypass_reservation_update=True).quantity = 14
         line1.package_id = pack
         line2.package_id = pack
 
@@ -205,7 +205,8 @@ class TestPut(VerticalLiftCase):
         operation.button_save()
         self.assertEqual(line1.state, "done")
         # Check the lines quantity has been merged
-        self.assertEqual(line1.qty_done, 15)
+        self.assertEqual(line1.quantity, 15)
+        self.assertTrue(line1.picked)
         # Check there is no more move lines to do for the pack
         line_left = operation._find_move_line(pack.name)
         self.assertFalse(line_left)

--- a/stock_vertical_lift/tests/test_put.py
+++ b/stock_vertical_lift/tests/test_put.py
@@ -2,9 +2,12 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import logging
 
+from odoo.tools import mute_logger
+
 from .common import VerticalLiftCase
 
 _logger = logging.getLogger(__name__)
+SHUTTLE_LOGGER = "odoo.addons.stock_vertical_lift.models.vertical_lift_shuttle"
 
 
 class TestPut(VerticalLiftCase):
@@ -18,6 +21,7 @@ class TestPut(VerticalLiftCase):
         cls.in_move_line = cls.picking_in.move_line_ids
         cls.in_move_line.location_dest_id = cls.shuttle.location_id
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_put_action_open_screen(self):
         self.shuttle.switch_put()
         action = self.shuttle.action_open_screen()
@@ -26,6 +30,7 @@ class TestPut(VerticalLiftCase):
         self.assertEqual(action["res_model"], "vertical.lift.operation.put")
         self.assertEqual(action["res_id"], operation.id)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_switch_put(self):
         self.shuttle.switch_put()
         self.assertEqual(self.shuttle.mode, "put")
@@ -34,6 +39,7 @@ class TestPut(VerticalLiftCase):
             self.env["stock.move.line"].browse(),
         )
 
+    @mute_logger(SHUTTLE_LOGGER, "odoo.models.unlink")
     def test_put_count_move_lines(self):
         # If stock_picking_cancel_confirm is installed, we need to explicitly
         # confirm the cancellation.
@@ -71,12 +77,14 @@ class TestPut(VerticalLiftCase):
         self.assertEqual(operation2.number_of_ops, 0)
         self.assertEqual(operation2.number_of_ops_all, 3)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_transition_start(self):
         operation = self._open_screen("put")
         # we begin with an empty screen, user has to scan a package, product,
         # or lot
         self.assertEqual(operation.state, "scan_source")
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_transition_scan_source_to_scan_tray_type(self):
         operation = self._open_screen("put")
         self.assertEqual(operation.state, "scan_source")
@@ -88,6 +96,7 @@ class TestPut(VerticalLiftCase):
         self.assertEqual(operation.state, "scan_tray_type")
         self.assertEqual(operation.current_move_line_id, self.in_move_line)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_transition_scan_tray_type_to_save(self):
         operation = self._open_screen("put")
         # assume we already scanned the product
@@ -103,6 +112,7 @@ class TestPut(VerticalLiftCase):
             self.in_move_line.location_dest_id in self.location_1a.child_ids
         )
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_change_tray_type_on_save(self):
         operation = self._open_screen("put")
         move_line = self.in_move_line
@@ -123,6 +133,7 @@ class TestPut(VerticalLiftCase):
         # a cell has been set in the other tray
         self.assertTrue(move_line.location_dest_id in self.location_1b.child_ids)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_transition_scan_tray_type_no_empty_cell(self):
         operation = self._open_screen("put")
         # assume we already scanned the product
@@ -139,6 +150,7 @@ class TestPut(VerticalLiftCase):
         # destination not changed
         self.assertEqual(self.in_move_line.location_dest_id, self.shuttle.location_id)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_transition_save(self):
         operation = self._open_screen("put")
         # first steps of the workflow are done
@@ -150,6 +162,7 @@ class TestPut(VerticalLiftCase):
         self.assertEqual(self.in_move_line.state, "done")
         self.assertEqual(self.in_move_line.quantity, qty_to_process)
 
+    @mute_logger(SHUTTLE_LOGGER)
     def test_transition_button_release(self):
         operation = self._open_screen("put")
         move_line = self.in_move_line
@@ -164,6 +177,7 @@ class TestPut(VerticalLiftCase):
         self.assertEqual(operation.state, "scan_source")
         self.assertFalse(operation.current_move_line_id)
 
+    @mute_logger(SHUTTLE_LOGGER, "odoo.models.unlink")
     def test_put_package_with_multiple_move_lines(self):
         """Check moving a package linked to multiple move lines.
 

--- a/stock_vertical_lift/tests/test_put.py
+++ b/stock_vertical_lift/tests/test_put.py
@@ -163,3 +163,50 @@ class TestPut(VerticalLiftCase):
         operation.button_release()
         self.assertEqual(operation.state, "scan_source")
         self.assertFalse(operation.current_move_line_id)
+
+    def test_put_package_with_multiple_move_lines(self):
+        """Check moving a package linked to multiple move lines.
+
+        Even when scanning a package, the module moves one move line at a time
+        And not the whole package.
+        If the package is spread on multiple move lines an exception is raised.
+
+        The module will try to merge the move lines.
+
+        """
+        pick = self.picking_in
+        # split the move in 2 move lines
+        line1 = pick.move_line_ids
+        # Add two quants in a package
+        pack = self.env["stock.quant.package"].create({"name": "test"})
+        # Update the available stock necessary for the move
+        self._update_qty_in_location(pick.location_id, line1.product_id, 14, pack)
+        # The stock for the 2nd move line must be on a different quant
+        self.env["stock.quant"].create(
+            {
+                "product_id": line1.product_id.id,
+                "location_id": pick.location_id.id,
+                "quantity": 1,
+                "package_id": pack.id,
+            }
+        )
+        # Split the move line to have 2
+        line2 = line1.copy({"product_uom_qty": 1, "picking_id": pick.id})
+        line1.with_context(bypass_reservation_update=True).product_uom_qty = 14
+        line1.package_id = pack
+        line2.package_id = pack
+
+        # Do the full put workflow
+        operation = self._open_screen("put")
+        line = operation._find_move_line(pack.name)
+        operation.current_move_line_id = line
+        operation.current_move_line_id.location_dest_id = self.location_1a_x1y1
+        operation.state = "save"
+        operation.button_save()
+        self.assertEqual(line1.state, "done")
+        # Check the lines quantity has been merged
+        self.assertEqual(line1.qty_done, 15)
+        # Check there is no more move lines to do for the pack
+        line_left = operation._find_move_line(pack.name)
+        self.assertFalse(line_left)
+        self.assertEqual(pick.state, "done")


### PR DESCRIPTION
The workflow of this module moves one move line at at time even if the user scanned a package.

When the package is spread on multiple stock.move.line Odoo core will raise an error.

To avoid a refactor of the workflow, this fix tries to merge the move lines that are part of the same package


Port from 14.0 to 18.0:
- #2260