### PR TITLE
[FIX] stock_inventory_justification: _apply_inventory()

### DIFF
--- a/stock_inventory_discrepancy/hooks.py
+++ b/stock_inventory_discrepancy/hooks.py
@@ -48,7 +48,6 @@ def post_load_hook():
                             quant.company_id
                         ).property_stock_inventory,
                         quant.location_id,
-                        package_dest_id=quant.package_id,
                     )
                 )
             else:
@@ -59,7 +58,7 @@ def post_load_hook():
                         quant.product_id.with_company(
                             quant.company_id
                         ).property_stock_inventory,
-                        package_id=quant.package_id,
+                        out=True,
                     )
                 )
         moves = (


### PR DESCRIPTION
After the permission check upstream was copied but the signature of _get_inventory_move_values() has changed:
https://github.com/odoo/odoo/blob/17.0/addons/stock/models/stock_quant.py#L1056