### PR TITLE
[15.0][FIX] stock_move_location: reserved_quantity unfilled in _prepare_wizard_move_lines

### DIFF
--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -113,6 +113,7 @@ class StockMoveLocationWizard(models.TransientModel):
                         "product_id": quant.product_id.id,
                         "move_quantity": quant.quantity,
                         "max_quantity": quant.quantity,
+                        "reserved_quantity": quant.reserved_quantity,
                         "origin_location_id": quant.location_id.id,
                         "lot_id": quant.lot_id.id,
                         "package_id": quant.package_id.id,


### PR DESCRIPTION
In addition to the lack of information in the wizard, this results in detailed delivery note transactions disappearing and not being recreated.

https://github.com/OCA/stock-logistics-warehouse/blob/dd0bfe2c2f13e39e6fc9c9c59b65dd1fe358eb7f/stock_move_location/wizard/stock_move_location.py#L238-L244

TT56320