### PR TITLE
[IMP] stock_location_product_restriction: Allow to put products in location if being emptied

### DIFF
--- a/stock_location_product_restriction/__manifest__.py
+++ b/stock_location_product_restriction/__manifest__.py
@@ -10,7 +10,7 @@
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "maintainers": ["lmignon", "rousseldenis"],
     "website": "https://github.com/OCA/stock-logistics-warehouse",
-    "depends": ["stock"],
+    "depends": ["stock", "stock_location_fill_state"],
     "data": ["views/stock_location.xml"],
     "pre_init_hook": "pre_init_hook",
 }

--- a/stock_location_product_restriction/models/stock_location.py
+++ b/stock_location_product_restriction/models/stock_location.py
@@ -96,7 +96,7 @@ class StockLocation(models.Model):
                stock_quant.location_id in %s
                and stock_location.id = stock_quant.location_id
                and stock_location.product_restriction = 'same'
-               and stock_location.fill_state <> 'being_emptied'
+               and stock_location.fill_state NOT IN ('being_filled', 'being_emptied')
                /* Mimic the _unlink_zero_quant() query in Odoo */
                 AND (NOT (round(quantity::numeric, %s) = 0 OR quantity IS NULL)
                 OR NOT round(reserved_quantity::numeric, %s) = 0
@@ -120,7 +120,7 @@ class StockLocation(models.Model):
         for record in self:
             record_id = record.id
             has_restriction_violation = False
-            restriction_violation_message = False
+            restriction_violation_message = ""
             product_ids = product_ids_by_location_id.get(record_id)
             if product_ids:
                 products = ProductProduct.browse(product_ids)
@@ -163,7 +163,7 @@ class StockLocation(models.Model):
             WHERE
                stock_location.id = stock_quant.location_id
                and stock_location.product_restriction = 'same'
-               and stock_location.fill_state <> 'being_emptied'
+               and stock_location.fill_state NOT IN ('being_filled', 'being_emptied')
                /* Mimic the _unlink_zero_quant() query in Odoo */
                 AND (NOT (round(quantity::numeric, %s) = 0 OR quantity IS NULL)
                 OR NOT round(reserved_quantity::numeric, %s) = 0

--- a/stock_location_product_restriction/models/stock_location.py
+++ b/stock_location_product_restriction/models/stock_location.py
@@ -80,11 +80,7 @@ class StockLocation(models.Model):
                 "inventory_quantity",
             ]
         )
-        self.flush_model(
-            [
-                "product_restriction",
-            ]
-        )
+        self.flush_model(["product_restriction", "fill_state"])
         ProductProduct = self.env["product.product"]
         precision_digits = max(
             6, self.sudo().env.ref("product.decimal_product_uom").digits * 2
@@ -100,6 +96,7 @@ class StockLocation(models.Model):
                stock_quant.location_id in %s
                and stock_location.id = stock_quant.location_id
                and stock_location.product_restriction = 'same'
+               and stock_location.fill_state <> 'being_emptied'
                /* Mimic the _unlink_zero_quant() query in Odoo */
                 AND (NOT (round(quantity::numeric, %s) = 0 OR quantity IS NULL)
                 OR NOT round(reserved_quantity::numeric, %s) = 0
@@ -156,11 +153,7 @@ class StockLocation(models.Model):
                 "inventory_quantity",
             ]
         )
-        self.flush_model(
-            [
-                "product_restriction",
-            ]
-        )
+        self.flush_model(["product_restriction", "fill_state"])
         SQL = """
             SELECT
                 stock_quant.location_id
@@ -170,6 +163,7 @@ class StockLocation(models.Model):
             WHERE
                stock_location.id = stock_quant.location_id
                and stock_location.product_restriction = 'same'
+               and stock_location.fill_state <> 'being_emptied'
                /* Mimic the _unlink_zero_quant() query in Odoo */
                 AND (NOT (round(quantity::numeric, %s) = 0 OR quantity IS NULL)
                 OR NOT round(reserved_quantity::numeric, %s) = 0

--- a/stock_location_product_restriction/models/stock_location.py
+++ b/stock_location_product_restriction/models/stock_location.py
@@ -48,43 +48,7 @@ class StockLocation(models.Model):
     )
 
     @api.model
-    def _selection_product_restriction(self):
-        return [
-            ("any", "Items of any products are allowed into the location"),
-            (
-                "same",
-                "Only items of the same product allowed into the location",
-            ),
-        ]
-
-    @api.depends("specific_product_restriction", "parent_product_restriction")
-    def _compute_product_restriction(self):
-        default_value = "any"
-        for rec in self:
-            rec.product_restriction = (
-                rec.specific_product_restriction
-                or rec.parent_product_restriction
-                or default_value
-            )
-
-    @api.depends("product_restriction")
-    def _compute_restriction_violation(self):
-        records = self
-        self.env["stock.quant"].flush_model(
-            [
-                "product_id",
-                "location_id",
-                "quantity",
-                "reserved_quantity",
-                "available_quantity",
-                "inventory_quantity",
-            ]
-        )
-        self.flush_model(["product_restriction", "fill_state"])
-        ProductProduct = self.env["product.product"]
-        precision_digits = max(
-            6, self.sudo().env.ref("product.decimal_product_uom").digits * 2
-        )
+    def _get_product_restriction_query(self):
         SQL = """
            SELECT
                stock_quant.location_id,
@@ -104,8 +68,98 @@ class StockLocation(models.Model):
                         OR inventory_quantity IS NULL))
            GROUP BY
                stock_quant.location_id
+        """
+        return SQL
+
+    @api.model
+    def _get_product_restriction_query_having(self):
+        return """
             HAVING count(distinct(product_id)) > 1
-       """
+        """
+
+    @api.model
+    def _selection_product_restriction(self):
+        return [
+            ("any", "Items of any products are allowed into the location"),
+            (
+                "same",
+                "Only items of the same product allowed into the location",
+            ),
+        ]
+
+    @api.depends("specific_product_restriction", "parent_product_restriction")
+    def _compute_product_restriction(self):
+        default_value = "any"
+        for rec in self:
+            rec.product_restriction = (
+                rec.specific_product_restriction
+                or rec.parent_product_restriction
+                or default_value
+            )
+
+    def _check_has_location_product_restriction(self, product):
+        """
+        Call this if you want to check if product can
+        enter a location.
+        """
+        product_ids_by_location_id = self._get_product_ids_by_locations()
+        for location in self:
+            product_ids = product_ids_by_location_id.get(location.id)
+            if product_ids and product.id not in product_ids:
+                return True
+        return False
+
+    def _get_product_ids_by_locations(self):
+        self.env["stock.quant"].flush_model(
+            [
+                "product_id",
+                "location_id",
+                "quantity",
+                "reserved_quantity",
+                "available_quantity",
+                "inventory_quantity",
+            ]
+        )
+        self.flush_model(["product_restriction", "fill_state"])
+
+        precision_digits = max(
+            6, self.sudo().env.ref("product.decimal_product_uom").digits * 2
+        )
+        SQL = SQL = self._get_product_restriction_query()
+        # Browse only real record ids
+        ids = tuple(
+            [record.id for record in self if not isinstance(record.id, fields.NewId)]
+        )
+        if not ids:
+            product_ids_by_location_id = dict()
+        else:
+            self.env.cr.execute(
+                SQL, (ids, precision_digits, precision_digits, precision_digits)
+            )
+            product_ids_by_location_id = dict(self.env.cr.fetchall())
+        return product_ids_by_location_id
+
+    @api.depends("product_restriction")
+    def _compute_restriction_violation(self):
+        records = self
+        self.env["stock.quant"].flush_model(
+            [
+                "product_id",
+                "location_id",
+                "quantity",
+                "reserved_quantity",
+                "available_quantity",
+                "inventory_quantity",
+            ]
+        )
+        self.flush_model(["product_restriction", "fill_state"])
+        ProductProduct = self.env["product.product"]
+        precision_digits = max(
+            6, self.sudo().env.ref("product.decimal_product_uom").digits * 2
+        )
+
+        SQL = self._get_product_restriction_query()
+        SQL += self._get_product_restriction_query_having()
         # Browse only real record ids
         ids = tuple(
             [record.id for record in records if not isinstance(record.id, fields.NewId)]

--- a/stock_location_product_restriction/models/stock_quant.py
+++ b/stock_location_product_restriction/models/stock_quant.py
@@ -56,21 +56,29 @@ class StockQuant(models.Model):
                 "inventory_quantity",
             ]
         )
+        self.env["stock.location"].flush_model(
+            [
+                "fill_state",
+            ]
+        )
         SQL = """
             SELECT
-                location_id,
+                stock_quant.location_id,
                 array_agg(distinct(product_id))
             FROM
-                stock_quant
+                stock_quant,
+                stock_location
             WHERE
-                location_id in %s
+                stock_quant.location_id in %s
+                and stock_quant.location_id = stock_location.id
+                and stock_location.fill_state <> 'being_emptied'
             /* Mimic the _unlink_zero_quant() query in Odoo */
             AND (NOT (round(quantity::numeric, %s) = 0 OR quantity IS NULL)
             OR NOT round(reserved_quantity::numeric, %s) = 0
             OR NOT (round(inventory_quantity::numeric, %s) = 0
                     OR inventory_quantity IS NULL))
             GROUP BY
-                location_id
+                stock_quant.location_id
         """
         self.env.cr.execute(
             SQL,

--- a/stock_location_product_restriction/models/stock_quant.py
+++ b/stock_location_product_restriction/models/stock_quant.py
@@ -2,13 +2,53 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from collections import defaultdict
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
 class StockQuant(models.Model):
 
     _inherit = "stock.quant"
+
+    being_emptied_before_done_location_ids = fields.One2many(
+        comodel_name="stock.location",
+        compute="_compute_being_emptied_before_done_location_ids",
+        help="Technical field to compute locations with their fill state"
+        "at 'Being Emptied' before they'll be filled with an incoming move.",
+    )
+
+    @api.depends_context("being_emptied_locations_before_update")
+    @api.depends("location_id")
+    def _compute_being_emptied_before_done_location_ids(self):
+        self.being_emptied_before_done_location_ids = self.env["stock.location"].browse(
+            self.env.context.get("being_emptied_locations_before_update", [])
+        )
+
+    @api.model
+    def _update_available_quantity(
+        self,
+        product_id,
+        location_id,
+        quantity,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        in_date=None,
+    ):
+        new_self = self.with_context(
+            being_emptied_locations_before_update=location_id.filtered(
+                lambda location: location.fill_state == "being_emptied"
+            ).ids
+        )
+        return super(StockQuant, new_self)._update_available_quantity(
+            product_id=product_id,
+            location_id=location_id,
+            quantity=quantity,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            in_date=in_date,
+        )
 
     @api.constrains("location_id", "product_id")
     def _check_location_product_restriction(self):
@@ -30,6 +70,8 @@ class StockQuant(models.Model):
         for quant in quants_to_check:
             product_ids_location_id[quant.location_id.id].add(quant.product_id.id)
         for location_id, product_ids in product_ids_location_id.items():
+            if location_id in self.being_emptied_before_done_location_ids.ids:
+                continue
             if len(product_ids) > 1:
                 location = StockLocation.browse(location_id)
                 products = ProductProduct.browse(list(product_ids))
@@ -95,6 +137,8 @@ class StockQuant(models.Model):
             location_id,
             existing_product_ids,
         ) in existing_product_ids_by_location_id.items():
+            if location_id in self.being_emptied_before_done_location_ids.ids:
+                continue
             product_ids_to_add = product_ids_location_id[location_id]
             if set(existing_product_ids).symmetric_difference(product_ids_to_add):
                 location = StockLocation.browse(location_id)

--- a/stock_location_product_restriction/models/stock_quant.py
+++ b/stock_location_product_restriction/models/stock_quant.py
@@ -10,18 +10,18 @@ class StockQuant(models.Model):
 
     _inherit = "stock.quant"
 
-    being_emptied_before_done_location_ids = fields.One2many(
+    being_filled_before_done_location_ids = fields.One2many(
         comodel_name="stock.location",
-        compute="_compute_being_emptied_before_done_location_ids",
+        compute="_compute_being_filled_before_done_location_ids",
         help="Technical field to compute locations with their fill state"
-        "at 'Being Emptied' before they'll be filled with an incoming move.",
+        "at 'Being Filled' before they'll be filled with an incoming move.",
     )
 
-    @api.depends_context("being_emptied_locations_before_update")
+    @api.depends_context("being_filled_locations_before_update")
     @api.depends("location_id")
-    def _compute_being_emptied_before_done_location_ids(self):
-        self.being_emptied_before_done_location_ids = self.env["stock.location"].browse(
-            self.env.context.get("being_emptied_locations_before_update", [])
+    def _compute_being_filled_before_done_location_ids(self):
+        self.being_filled_before_done_location_ids = self.env["stock.location"].browse(
+            self.env.context.get("being_filled_locations_before_update", [])
         )
 
     @api.model
@@ -36,8 +36,8 @@ class StockQuant(models.Model):
         in_date=None,
     ):
         new_self = self.with_context(
-            being_emptied_locations_before_update=location_id.filtered(
-                lambda location: location.fill_state == "being_emptied"
+            being_filled_locations_before_update=location_id.filtered(
+                lambda location: location.fill_state == "being_filled"
             ).ids
         )
         return super(StockQuant, new_self)._update_available_quantity(
@@ -70,7 +70,7 @@ class StockQuant(models.Model):
         for quant in quants_to_check:
             product_ids_location_id[quant.location_id.id].add(quant.product_id.id)
         for location_id, product_ids in product_ids_location_id.items():
-            if location_id in self.being_emptied_before_done_location_ids.ids:
+            if location_id in self.being_filled_before_done_location_ids.ids:
                 continue
             if len(product_ids) > 1:
                 location = StockLocation.browse(location_id)
@@ -113,7 +113,7 @@ class StockQuant(models.Model):
             WHERE
                 stock_quant.location_id in %s
                 and stock_quant.location_id = stock_location.id
-                and stock_location.fill_state <> 'being_emptied'
+                and stock_location.fill_state NOT IN ('being_filled', 'being_emptied')
             /* Mimic the _unlink_zero_quant() query in Odoo */
             AND (NOT (round(quantity::numeric, %s) = 0 OR quantity IS NULL)
             OR NOT round(reserved_quantity::numeric, %s) = 0
@@ -137,7 +137,7 @@ class StockQuant(models.Model):
             location_id,
             existing_product_ids,
         ) in existing_product_ids_by_location_id.items():
-            if location_id in self.being_emptied_before_done_location_ids.ids:
+            if location_id in self.being_filled_before_done_location_ids.ids:
                 continue
             product_ids_to_add = product_ids_location_id[location_id]
             if set(existing_product_ids).symmetric_difference(product_ids_to_add):

--- a/stock_location_product_restriction/tests/test_stock_location.py
+++ b/stock_location_product_restriction/tests/test_stock_location.py
@@ -283,3 +283,33 @@ class TestStockLocation(TransactionCase):
         self.loc_lvl_1_1_1.product_restriction = "same"
         self.assertFalse(self.loc_lvl_1_1_1.has_restriction_violation)
         self.assertFalse(self.loc_lvl_1_1_1.restriction_violation_message)
+
+    def test_check_product(self):
+        """
+          Data:
+            * Location level_1_1_1 with 2 different products no restriction
+        Test Case:
+            1. Check restriction message
+            2. Change product 1 quant to 0.0
+            3. Set restriction 'same' on location level_1_1_1
+            4. Check restriction message
+        Expected result:
+            1. No restriction message
+        """
+        self.loc_lvl_1_1_1.product_restriction = "any"
+        self.assertFalse(self.loc_lvl_1_1_1.has_restriction_violation)
+        self.assertFalse(self.loc_lvl_1_1_1.restriction_violation_message)
+        self.quant_1_lvl_1_1_1.inventory_quantity = 0.0
+        self.quant_1_lvl_1_1_1._apply_inventory()
+        self.loc_lvl_1_1_1.product_restriction = "same"
+        self.assertFalse(self.loc_lvl_1_1_1.has_restriction_violation)
+        self.assertFalse(self.loc_lvl_1_1_1.restriction_violation_message)
+
+        # Check for product_2
+        self.assertFalse(
+            self.loc_lvl_1_1_1._check_has_location_product_restriction(self.product_2)
+        )
+        # Check for product_1
+        self.assertTrue(
+            self.loc_lvl_1_1_1._check_has_location_product_restriction(self.product_1)
+        )

--- a/stock_location_product_restriction/tests/test_stock_move.py
+++ b/stock_location_product_restriction/tests/test_stock_move.py
@@ -398,6 +398,42 @@ class TestStockMove(TransactionCase):
 
         self._change_product_qty(self.product_2, self.location_1, 10)
 
+    def test_filling_move_with_outgoing_move(self):
+        """
+        Data:
+            location_1 with same product restriction
+            location_1 with 50 product_1
+        Test case:
+            Create a move that empty the location
+            Add qty of product_2 into location_1
+        Expected result:
+            ValidationError
+        """
+        self.assertEqual(
+            self.product_1, self._get_products_in_location(self.location_1)
+        )
+        self.location_1.specific_product_restriction = "same"
+        move = self._create_outgoing_move()
+        move.move_line_ids.qty_done = 50.0
+        self.location_1.flush_recordset()
+
+        in_move = self.env["stock.move"].create(
+            {
+                "name": "Filling in move Product 2",
+                "location_id": self.env.ref("stock.stock_location_customers").id,
+                "location_dest_id": self.location_1.id,
+                "product_id": self.product_2.id,
+                "product_uom": self.product_2.uom_id.id,
+                "product_uom_qty": 10.0,
+            }
+        )
+        in_move._action_confirm()
+        in_move.quantity_done = 10.0
+        self.env["stock.quant"].invalidate_recordset(
+            ["being_emptied_before_done_location_ids"]
+        )
+        in_move._action_done()
+
     def test_change_quants_location(self):
         """
         Data:

--- a/stock_location_product_restriction/tests/test_stock_move.py
+++ b/stock_location_product_restriction/tests/test_stock_move.py
@@ -62,6 +62,7 @@ class TestStockMove(TransactionCase):
         )
 
         cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
 
         # partner
         cls.partner_1 = cls.env["res.partner"].create(
@@ -120,6 +121,22 @@ class TestStockMove(TransactionCase):
             )
         picking_in.action_confirm()
         return picking_in
+
+    def _create_outgoing_move(self, product=False):
+        if not product:
+            product = self.product_1
+        values = {
+            "name": product.name,
+            "location_id": self.location_1.id,
+            "location_dest_id": self.customer_location.id,
+            "product_id": product.id,
+            "product_uom_qty": 50.0,
+            "product_uom": product.uom_id.id,
+        }
+        move = self.StockMove.create(values)
+        move._action_confirm()
+        move._action_assign()
+        return move
 
     def _process_picking(self, picking):
         picking.action_assign()
@@ -359,3 +376,57 @@ class TestStockMove(TransactionCase):
         )
         picking.move_line_ids.location_dest_id = self.location_1
         self._process_picking(picking)
+
+    def test_filling_with_outgoing_move(self):
+        """
+        Data:
+            location_1 with same product restriction
+            location_1 with 50 product_1
+        Test case:
+            Create a move that empty the location
+            Add qty of product_2 into location_1
+        Expected result:
+            ValidationError
+        """
+        self.assertEqual(
+            self.product_1, self._get_products_in_location(self.location_1)
+        )
+        self.location_1.specific_product_restriction = "same"
+        move = self._create_outgoing_move()
+        move.move_line_ids.qty_done = 50.0
+        self.location_1.flush_recordset()
+
+        self._change_product_qty(self.product_2, self.location_1, 10)
+
+    def test_change_quants_location(self):
+        """
+        Data:
+            location_1 with same product restriction
+            location_1 with 50 product_1
+        Test case:
+            Create a quant for product 1 and 2 in supplier location
+            Change their location to location_1
+        Expected result:
+            ValidationError
+        """
+        self.assertEqual(
+            self.product_1, self._get_products_in_location(self.location_1)
+        )
+        self.location_1.specific_product_restriction = "same"
+
+        quants = self.env["stock.quant"].create(
+            [
+                {
+                    "product_id": self.product_2.id,
+                    "location_id": self.supplier_location.id,
+                    "quantity": 10.0,
+                },
+                {
+                    "product_id": self.product_1.id,
+                    "location_id": self.supplier_location.id,
+                    "quantity": 10.0,
+                },
+            ]
+        )
+        with self.assertRaises(ValidationError):
+            quants.location_id = self.location_1

--- a/stock_location_product_restriction/tests/test_stock_move.py
+++ b/stock_location_product_restriction/tests/test_stock_move.py
@@ -430,7 +430,7 @@ class TestStockMove(TransactionCase):
         in_move._action_confirm()
         in_move.quantity_done = 10.0
         self.env["stock.quant"].invalidate_recordset(
-            ["being_emptied_before_done_location_ids"]
+            ["being_filled_before_done_location_ids"]
         )
         in_move._action_done()
 


### PR DESCRIPTION
Depends on :

- https://github.com/OCA/stock-logistics-warehouse/pull/2188

In day-to-day stock operations, operators will take products from a location and often empty that location.

But, if the movement quantity is already changed ('qty_done'), the picking is not yet validated.

In parallel, some operators want to fill in the location with another product as it is already physically void.


NOTE: This is a major change as a dependency is added

- Adds also an helper function to check if a product can enter a location