### PR TITLE
[15.0][FIX] stock_inventory: string attribute duplicated in field count_stock_quants_string

### DIFF
--- a/stock_inventory/models/stock_inventory.py
+++ b/stock_inventory/models/stock_inventory.py
@@ -124,7 +124,7 @@ class InventoryAdjustmentsGroup(models.Model):
     )
 
     count_stock_quants_string = fields.Char(
-        compute="_compute_count_stock_quants", string="Adjustments"
+        compute="_compute_count_stock_quants", string="Adjustments Count"
     )
 
     count_stock_moves = fields.Integer(


### PR DESCRIPTION
Avoid these logs

`2025-05-20 07:57:57,954 1 WARNING devel odoo.addons.base.models.ir_model: Two fields (count_stock_quants_string, count_stock_quants) of stock.inventory() have the same label: Adjustments. `