### PR TITLE
!DONT MERGE just proving OCA/15.0 branch is red

### DIFF
--- a/stock_cycle_count/tests/test_stock_cycle_count.py
+++ b/stock_cycle_count/tests/test_stock_cycle_count.py
@@ -483,7 +483,7 @@ class TestStockCycleCount(common.TransactionCase):
         sml = self.env["stock.move.line"].search(
             [("location_id", "=", loc.id), ("product_id", "=", self.product1.id)]
         )
-        # Check that line_accuracy is still 0
+        # Check that line_accuracy is still 0.
         self.assertEqual(sml.line_accuracy, 0)
 
     def test_auto_start_inventory_from_cycle_count(self):


### PR DESCRIPTION
Can't reproduce in local, but there must be some incompatibility in stock_cycle_count and other module.

Only test with Odoo fail, not wit OCB.

Example: https://github.com/OCA/stock-logistics-warehouse/actions/runs/15157529327/job/42615744592#step:8:631