### PR TITLE
[18.0][FIX] stock_move_location: fill with stock

### DIFF
--- a/stock_move_location/models/stock_picking.py
+++ b/stock_move_location/models/stock_picking.py
@@ -1,4 +1,4 @@
-# Copyright Jacques-Etienne Baudoux 2016 Camptocamp
+# Copyright 2016 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright Iryna Vyshnevska 2020 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
@@ -19,6 +19,7 @@ class StockPicking(models.Model):
             "active_model": "stock.quant",
             "planned": True,
         }
+        # FIXME: this action should not bypass the call to action_assign !!!
         move_wizard = (
             self.env["wiz.stock.move.location"]
             .with_context(**context)
@@ -28,6 +29,7 @@ class StockPicking(models.Model):
                     "origin_location_id": self.location_id.id,
                     "picking_type_id": self.picking_type_id.id,
                     "picking_id": self.id,
+                    "apply_putaway_strategy": True,
                 }
             )
         )

--- a/stock_move_location/readme/ROADMAP.md
+++ b/stock_move_location/readme/ROADMAP.md
@@ -9,3 +9,8 @@ ACSONE):
 - Nice to have: add a magic button on locations that with context
   creates a new picking of that type with the origin location already
   filled in.
+
+Note from Jacques-Etienne Baudoux (BCIM)
+- The fill with stock action on stock.picking should not create manually the
+  move lines but instead call `action_assign()`. There are many modules hooking
+  `action_assign` that are not called due to this.


### PR DESCRIPTION
Always compute put-aways when using the fill with stock action on a transfer

The initial implementation https://github.com/OCA/stock-logistics-warehouse/pull/882 was calling action_assign to create move lines and have the put-aways computed. In the merge of the feature in this module https://github.com/OCA/stock-logistics-warehouse/pull/885, that behavior has been changed to manually create move lines and mark them as "assigned". This is not a good approach. I added a FIXME and a note in the ROADMAP.

cc @rousseldenis @leemannd @sebalix 