### PR TITLE
[18.0][FIX] procurement_auto_create_group:Fixed the view of stock rule

### DIFF
--- a/procurement_auto_create_group/views/procurement_view.xml
+++ b/procurement_auto_create_group/views/procurement_view.xml
@@ -11,9 +11,6 @@
                     invisible="group_propagation_option != 'propagate'"
                 />
             </field>
-            <field name="auto" position="after">
-                <field name="auto_create_group" invisible="action != 'push'" />
-            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
In Odoo v18, the 'Auto-create Procurement Group' field is included by default. 
However, in v17, it was not present, so this module added it to the view. It is no longer needed as it is available by default.

![stock-rule-view](https://github.com/user-attachments/assets/280d19d6-1c82-4656-818e-f98005fec699)
