### PR TITLE
[18.0][FIX] stock_location_bin_name: remove constraint on `location_name_format`

### DIFF
--- a/stock_location_bin_name/models/stock_location.py
+++ b/stock_location_bin_name/models/stock_location.py
@@ -5,7 +5,6 @@
 import string
 
 from odoo import api, fields, models
-from odoo.exceptions import ValidationError
 
 
 class PartialFormatter(string.Formatter):
@@ -44,16 +43,6 @@ class StockLocation(models.Model):
         ".{level:0>2}'\n"
         "Missing fields are replaced by '~' and formatting errors by '!'.",
     )
-
-    @api.constrains("location_name_format")
-    def _check_location_name_format(self):
-        for loc in self:
-            if loc.location_kind == "bin" and loc.location_name_format:
-                raise ValidationError(
-                    self.env._(
-                        "Location Name Format cannot be set on 'bin' type locations."
-                    )
-                )
 
     @api.onchange("corridor", "row", "rack", "level", "posx", "posy", "posz")
     def _onchange_attribute_compute_name(self):

--- a/stock_location_bin_name/tests/test_stock_location_bin_name.py
+++ b/stock_location_bin_name/tests/test_stock_location_bin_name.py
@@ -1,4 +1,3 @@
-from odoo.exceptions import ValidationError
 from odoo.tests import Form
 
 from odoo.addons.base.tests.common import BaseCommon
@@ -67,23 +66,6 @@ class TestStockLocationBinName(BaseCommon):
             location_form.level = "2"
 
         self.assertEqual(self.location_bin.name, "Zone Location-Z-02-123.005")
-
-    def test_location_bin_with_name_format(self):
-        """Test location constraint with location name format in a bin location"""
-
-        regex = "Location Name Format cannot be set on 'bin' type locations."
-        with self.assertRaisesRegex(ValidationError, regex):
-            self.location_obj.create(
-                {
-                    "name": "Local",
-                    "location_id": self.location_area.id,
-                    "location_name_format": "{area}-{corridor}{level:0>2}",
-                    "usage": "internal",
-                    "location_kind": "bin",
-                    "zone_location_id": self.location_zone.id,
-                    "area_location_id": self.location_area.id,
-                }
-            )
 
     def test_onchange_non_bin_location(self):
         """Test onchange does nothing for non-bin locations"""


### PR DESCRIPTION
This constraint was added during the migration to 18.0 and is blocking the creation of `stock.location` records with `location_name_format`, while the children are not yet created, so the location is at first considered as a bin.

This is blocking the loading of XML data for instance where we create parent locations used by some configurations, and children are then created later.