### PR TITLE
[14.0][IMP] sale_stock_on_hand_popup: use o2m instead m2m for better view control

### DIFF
--- a/sale_stock_on_hand_popup/wizards/product_quant_wizard.py
+++ b/sale_stock_on_hand_popup/wizards/product_quant_wizard.py
@@ -6,9 +6,7 @@ class ProductQuantWizard(models.TransientModel):
     _description = "Product Quant Wizard"
 
     product_id = fields.Many2one("product.product")
-    stock_quant_ids = fields.Many2many(
-        "stock.quant", compute="_compute_stock_quant_ids"
-    )
+    stock_quant_ids = fields.One2many("stock.quant", compute="_compute_stock_quant_ids")
 
     @api.depends("product_id")
     def _compute_stock_quant_ids(self):


### PR DESCRIPTION
Switching to a o2m for `stock_quant_ids` allows the use of the o2m options in the view