### PR TITLE
[16.0][FIX] stock_location_release_channel_restriction: it.po translation error

### DIFF
--- a/stock_location_release_channel_restriction/i18n/it.po
+++ b/stock_location_release_channel_restriction/i18n/it.po
@@ -150,7 +150,7 @@ msgstr ""
 "Non è possibile spostare i prodotti in fase di prelievo (%(picking_name)s) "
 "in %(location_name)s. Quella ubicazione ha già movimenti in uscita in "
 "sospeso per il canale di rilascio di %(release_channel_name)s e/o movimenti "
-"in entrata in sospeso per %(incoming_channel_name)s"
+"in entrata in sospeso per %(incoming_channel_names)s"
 
 #, python-format
 #~ msgid ""


### PR DESCRIPTION
```
 ****po-python-parse-printf****
stock_location_release_channel_restriction/i18n/it.po:144 Translation string couldn't be parsed correctly using str%variables KeyError('incoming_channel_name') - [po-python-parse-printf]
```

@Tecnativa