### PR TITLE
[18.0][FIX] stock_warehouse_out_pull: Added tagged in test case

### DIFF
--- a/stock_warehouse_out_pull/tests/test_delivery_steps.py
+++ b/stock_warehouse_out_pull/tests/test_delivery_steps.py
@@ -2,10 +2,12 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
 
 from odoo import fields
+from odoo.tests import tagged
 
 from odoo.addons.base.tests.common import BaseCommon
 
 
+@tagged("post_install", "-at_install")
 class TestDeliverySteps(BaseCommon):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Add `@tagged` to test class to fix pipeline failure in `stock_move_auto_assign_auto_release`.  
Ref: [https://github.com/OCA/stock-logistics-warehouse/actions/runs/15974088543/job/45051892955?pr=2377#step:8:42](https://github.com/OCA/stock-logistics-warehouse/actions/runs/15974088543/job/45051892955?pr=2377#step:8:42)