### PR TITLE
[FIX] stock_picking_supplier_ref: clarify label and help text for supplier_reference field

### DIFF
--- a/stock_picking_supplier_ref/i18n/es.po
+++ b/stock_picking_supplier_ref/i18n/es.po
@@ -4,41 +4,34 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-11 07:27+0000\n"
-"PO-Revision-Date: 2025-03-10 19:26+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
+"POT-Creation-Date: 2025-07-08 11:42+0000\n"
+"PO-Revision-Date: 2025-07-08 11:42+0000\n"
+"Last-Translator: \n"
 "Language-Team: \n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.10.2\n"
-
-#. module: stock_picking_supplier_ref
-#: model:ir.model.fields,field_description:stock_picking_supplier_ref.field_stock_picking__supplier_reference
-msgid "Supplier Reference Available in PO"
-msgstr "Referencia proveedor disponible en el PO"
+"Plural-Forms: \n"
 
 #. module: stock_picking_supplier_ref
 #: model:ir.model.fields,help:stock_picking_supplier_ref.field_stock_picking__supplier_reference
-msgid "This field adds the supplier reference added in related purchase order"
+msgid ""
+"Enter the supplier's delivery note or shipment reference related to this "
+"receipt. This does not sync automatically with the supplier reference in the"
+" purchase order."
 msgstr ""
-"Este campo añade la referencia del proveedor añadida en el pedido de compra "
-"relacionada"
+"Introduce el albarán o la referencia de envío del proveedor relacionada con "
+"esta recepción. Esto no se sincroniza automáticamente con la referencia del "
+"proveedor en el pedido de compra."
+
+#. module: stock_picking_supplier_ref
+#: model:ir.model.fields,field_description:stock_picking_supplier_ref.field_stock_picking__supplier_reference
+msgid "Supplier Delivery Reference"
+msgstr "Referencia del albarán del proveedor"
 
 #. module: stock_picking_supplier_ref
 #: model:ir.model,name:stock_picking_supplier_ref.model_stock_picking
 msgid "Transfer"
-msgstr "Albarán"
-
-#~ msgid "Display Name"
-#~ msgstr "Nombre mostrado"
-
-#~ msgid "ID"
-#~ msgstr "ID (Identificación)"
-
-#~ msgid "Last Modified on"
-#~ msgstr "Última modificación el"
+msgstr "Traslado"

--- a/stock_picking_supplier_ref/i18n/stock_picking_supplier_ref.pot
+++ b/stock_picking_supplier_ref/i18n/stock_picking_supplier_ref.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-08 11:43+0000\n"
+"PO-Revision-Date: 2025-07-08 11:43+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,13 +16,16 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_picking_supplier_ref
-#: model:ir.model.fields,field_description:stock_picking_supplier_ref.field_stock_picking__supplier_reference
-msgid "Supplier Reference Available in PO"
+#: model:ir.model.fields,help:stock_picking_supplier_ref.field_stock_picking__supplier_reference
+msgid ""
+"Enter the supplier's delivery note or shipment reference related to this "
+"receipt. This does not sync automatically with the supplier reference in the"
+" purchase order."
 msgstr ""
 
 #. module: stock_picking_supplier_ref
-#: model:ir.model.fields,help:stock_picking_supplier_ref.field_stock_picking__supplier_reference
-msgid "This field adds the supplier reference added in related purchase order"
+#: model:ir.model.fields,field_description:stock_picking_supplier_ref.field_stock_picking__supplier_reference
+msgid "Supplier Delivery Reference"
 msgstr ""
 
 #. module: stock_picking_supplier_ref

--- a/stock_picking_supplier_ref/models/stock_picking.py
+++ b/stock_picking_supplier_ref/models/stock_picking.py
@@ -8,6 +8,8 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     supplier_reference = fields.Char(
-        string="Supplier Reference Available in PO",
-        help="This field adds the supplier reference added in related purchase order",
+        string="Supplier Delivery Reference",
+        help="Enter the supplier's delivery note or shipment reference related "
+        "to this receipt. This does not sync automatically with the supplier "
+        "reference in the purchase order.",
     )


### PR DESCRIPTION
This change updates the label and help text of the supplier_reference field on the stock picking model to better reflect its actual use. Previously, the field’s description implied that the supplier reference from the related purchase order would be automatically copied to the picking, which is not the case. This improves user understanding and reduces confusion about the purpose and behavior of this field.

cc https://github.com/APSL 16755

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review