### PR TITLE
[DOC] Improve README for stock_route_location_source

### DIFF
--- a/stock_route_location_source/readme/CONTRIBUTORS.md
+++ b/stock_route_location_source/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 * Michael Tietz (MT Software) <mtietz@mt-software.de>
+* Azar Nazri <azar.nazari@gmail.com>

--- a/stock_route_location_source/readme/DESCRIPTION.md
+++ b/stock_route_location_source/readme/DESCRIPTION.md
@@ -1,1 +1,19 @@
 Add method to get source location of Inventory Routes
+--
+This technical module extends the `stock.route` model to add the method
+`_get_source_location(dest_location)`. It recursively traces upstream
+rules (`pull` or `pull_push`) from a destination location, and returns
+the ultimate source location — stopping at a rule with `procure_method='make_to_stock'`
+or when no applicable pull rules remain.
+
+Useful for multi-hop route setups (e.g., warehouse → packing → output),
+to programmatically determine the actual stock source. No UI changes are made —
+it's purely for custom logic or other technical modules.
+
+**Example usage:**
+
+```python
+route = env.ref("stock.route_warehouse0_mto")
+dest = env.ref("stock.stock_location_customers")
+src = route._get_source_location(dest)
+print(src.display_name)


### PR DESCRIPTION
This PR improves the documentation of the `stock_route_location_source` module by:

- Rewriting the description to clarify the purpose of the `_get_source_location(dest_location)` method.
- Adding a short usage example.
- Mentioning that the module does not modify UI or create menus.

These changes aim to make it easier for new contributors and developers to understand the module's technical use case.

No functional or code changes are included.
