### PR TITLE
[18.0] stock_warehouse_out_pull: fix delivery_route_id missing

### DIFF
--- a/stock_warehouse_out_pull/models/stock_warehouse.py
+++ b/stock_warehouse_out_pull/models/stock_warehouse.py
@@ -61,5 +61,6 @@ class StockWarehouse(models.Model):
         # Override to trigger the delivery route config update when
         # `delivery_pull` field is updated
         res = super()._get_routes_values()
-        res["delivery_route_id"]["depends"].append("delivery_pull")
+        if "delivery_route_id" in res:
+            res["delivery_route_id"]["depends"].append("delivery_pull")
         return res


### PR DESCRIPTION
This key might not be there yet in the dict.
Avoid KeyError when that happens.