### PR TITLE
[16.0][FIX] stock_cycle_count: filter stock.inventory is not inherited yet

### DIFF
--- a/stock_cycle_count/views/stock_inventory_view.xml
+++ b/stock_cycle_count/views/stock_inventory_view.xml
@@ -30,16 +30,19 @@
     <record id="view_inventory_filter" model="ir.ui.view">
         <field name="name">stock.inventory.filter - stock_cycle_count</field>
         <field name="model">stock.inventory</field>
+        <field name="inherit_id" ref="stock_inventory.stock_inventory_search_view" />
         <field name="arch" type="xml">
-            <search>
-                <field name="location_ids" />
+            <xpath
+                expr="//search/field[@name='products_under_review_ids']"
+                position="after"
+            >
                 <field name="responsible_id" />
                 <filter
                     string="My Adjustments"
                     name="my_adjustments"
                     domain="[('responsible_id', '=', uid)]"
                 />
-            </search>
+            </xpath>
         </field>
     </record>
     <record id="view_inventory_graph" model="ir.ui.view">


### PR DESCRIPTION
fix `My Adjustments` filter is now missing because the view has inherited it incorrectly

result: 
<img width="1847" height="422" alt="image" src="https://github.com/user-attachments/assets/fe75a2c3-caa2-4e43-8476-a97104319311" />
