### PR TITLE
[18.0][IMP] stock_picking_volume: Add volume digits to the volume fields

### DIFF
--- a/stock_picking_volume/hooks.py
+++ b/stock_picking_volume/hooks.py
@@ -11,7 +11,7 @@ _logger = logging.getLogger(__name__)
 def pre_init_hook(env):
     """Pre init create volume column on stock.picking and stock.move"""
     if not column_exists(env.cr, "stock_move", "volume"):
-        create_column(env.cr, "stock_move", "volume", "double precision")
+        create_column(env.cr, "stock_move", "volume", "numeric")
         # First we compute the reserved qty by move_id
         # the reserved qty is the sum of the reserved qty of the move lines
         # linked to the move
@@ -38,7 +38,7 @@ def pre_init_hook(env):
         _logger.info(f"{env.cr.rowcount} rows updated in stock_move")
 
     if not column_exists(env.cr, "stock_picking", "volume"):
-        create_column(env.cr, "stock_picking", "volume", "double precision")
+        create_column(env.cr, "stock_picking", "volume", "numeric")
         # we recompute the volume of the pickings not in state done or cancel
         # the volume is the sum of the volume of the moves linked to the picking
         # that are not in state done or cancel

--- a/stock_picking_volume/models/stock_move.py
+++ b/stock_picking_volume/models/stock_move.py
@@ -11,6 +11,7 @@ class StockMove(models.Model):
         compute="_compute_volume",
         store=True,
         compute_sudo=True,
+        digits="Volume",
     )
 
     volume_uom_name = fields.Char(

--- a/stock_picking_volume/models/stock_picking.py
+++ b/stock_picking_volume/models/stock_picking.py
@@ -11,6 +11,7 @@ class StockPicking(models.Model):
         compute="_compute_volume",
         store=True,
         compute_sudo=True,
+        digits="Volume",
     )
     volume_uom_name = fields.Char(
         string="Volume unit of measure label", compute="_compute_volume_uom_name"


### PR DESCRIPTION
I think that this improves flexibility in the module as it allows the user to set custom digits number via the decimal precision. It also adds more consistency with the digits throughout all volume fields in the database.

If this change is approved I'll gladly backport it to previous versions.