### PR TITLE
[18.0][FIX] stock_vertical_lift: Ensure that button_save keep the destination

### DIFF
--- a/stock_vertical_lift/models/vertical_lift_operation_base.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_base.py
@@ -48,20 +48,19 @@ def extract_and_action_done(move):
     to first extract some move lines in a separate move, then validate it
     with this method.
     """
-    # Put remaining qty to process from partially available moves
-    # in their own move (which will be then 'confirmed')
-    partial_moves = move.filtered(lambda m: m.state == "partially_available")
-    for partial_move in partial_moves:
-        split_other_move_lines(partial_move, partial_move.move_line_ids)
     # Process assigned moves
     moves = move.filtered(lambda m: m.state == "assigned")
     if not moves:
         return False
     for picking in moves.picking_id:
         moves_todo = picking.move_ids & moves
+        # No need to create a new transfer if we are processing all moves
         if moves_todo == picking.move_ids:
-            # No need to create a new transfer if we are processing all moves
             new_picking = picking
+        # We process some available moves of the picking, but there are still
+        # some other moves to process, then we put the moves to process in
+        # a new transfer to validate. All remaining moves stay in the
+        # current transfer.
         else:
             new_picking = picking.copy(
                 {
@@ -71,13 +70,12 @@ def extract_and_action_done(move):
                     "backorder_id": picking.id,
                 }
             )
-            moves_todo.write({"picking_id": new_picking.id})
-            moves_todo.package_level_id.write({"picking_id": new_picking.id})
-            moves_todo.move_line_ids.write({"picking_id": new_picking.id})
-            moves_todo.move_line_ids.package_level_id.write(
-                {"picking_id": new_picking.id}
-            )
-            new_picking.action_assign()
+            moves_todo.picking_id = new_picking.id
+            moves_todo.package_level_id.picking_id = new_picking.id
+            moves_todo.move_line_ids.picking_id = new_picking.id
+            moves_todo.move_line_ids.package_level_id.picking_id = new_picking.id
+            if moves_todo.state != "assigned":
+                moves_todo._action_assign()
             assert new_picking.state == "assigned"
         new_picking.button_validate()
     return True

--- a/stock_vertical_lift/models/vertical_lift_shuttle.py
+++ b/stock_vertical_lift/models/vertical_lift_shuttle.py
@@ -63,10 +63,10 @@ class VerticalLiftShuttle(models.Model):
     @property
     def _screen_view_for_mode(self):
         return {
-            "pick": ("stock_vertical_lift." "vertical_lift_operation_pick_screen_view"),
-            "put": ("stock_vertical_lift." "vertical_lift_operation_put_screen_view"),
+            "pick": ("stock_vertical_lift.vertical_lift_operation_pick_screen_view"),
+            "put": ("stock_vertical_lift.vertical_lift_operation_put_screen_view"),
             "inventory": (
-                "stock_vertical_lift." "vertical_lift_operation_inventory_screen_view"
+                "stock_vertical_lift.vertical_lift_operation_inventory_screen_view"
             ),
         }
 
@@ -81,8 +81,8 @@ class VerticalLiftShuttle(models.Model):
 
         """
         self.ensure_one()
-        _logger.info("send %r", payload)
         command_values = {"shuttle_id": self.id, "command": payload.decode()}
+        _logger.info("send %(command)r", command_values)
 
         self.env["vertical.lift.command"].sudo().create(command_values)
         if self.hardware == "simulation":

--- a/stock_vertical_lift/tests/test_pick.py
+++ b/stock_vertical_lift/tests/test_pick.py
@@ -213,12 +213,20 @@ class TestPick(VerticalLiftCase):
         self.assertEqual(
             current_destination, self.env.ref("stock.stock_location_customers")
         )
+        self.assertEqual(move_line.state, "assigned")
         operation.on_barcode_scanned(stock_location.barcode)
         self.assertEqual(move_line.location_dest_id, stock_location)
+        self.assertEqual(move_line.move_id.location_dest_id, current_destination)
+        self.assertEqual(move_line.picking_id.location_dest_id, current_destination)
         self.assertEqual(operation.state, "save")
         # Done for test coverage
         operation.button_save()
+        self.assertEqual(move_line.state, "done")
         operation.on_barcode_scanned("test")
+        self.assertEqual(move_line.state, "done")
+        # These destination were NOT updated
+        self.assertEqual(move_line.move_id.location_dest_id, current_destination)
+        self.assertEqual(move_line.picking_id.location_dest_id, current_destination)
 
     def test_button_release(self):
         self._open_screen("pick")

--- a/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
+++ b/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
@@ -141,7 +141,7 @@
                             <div>
                                 <field
                                     name="location_dest_id"
-                                    class="bg-primary o_shuttle_highlight"
+                                    class="bg-primary o_shuttle_highlight text-white"
                                     readonly="1"
                                     options="{'no_open': True}"
                                 />


### PR DESCRIPTION
The destination location was not saved correctly when the stock move was split.

This change fixes the issue.

Also the readability of field was not optimal: black on purple.  Now it is white on purple like similar fields.