### PR TITLE
[14.0][FIX] stock_mts_mto_mrp_rule: Fix updating procure method

### DIFF
--- a/stock_mts_mto_mrp_rule/models/stock_move.py
+++ b/stock_mts_mto_mrp_rule/models/stock_move.py
@@ -23,6 +23,7 @@ class StockMove(models.Model):
         precision = self.env["decimal.precision"].precision_get(
             "Product Unit of Measure"
         )
+        no_split_procurement_moves = self.browse([])
         for move in self:
             product_id = move.product_id
             domain = [
@@ -34,7 +35,7 @@ class StockMove(models.Model):
                 False, product_id, move.warehouse_id, domain
             )
             if not rules or rules and rules.action != "split_procurement":
-                super(StockMove, move)._adjust_procure_method()
+                no_split_procurement_moves |= move
             else:
                 needed_qty = rules.get_mto_qty_to_order(
                     product_id, move.product_qty, move.product_uom, {}
@@ -55,3 +56,6 @@ class StockMove(models.Model):
                         )
                     )
                     move._action_assign()
+
+        if no_split_procurement_moves:
+            super(StockMove, no_split_procurement_moves)._adjust_procure_method()


### PR DESCRIPTION
After installing **stock_mts_mto_mrp_rule** (no extra config), SO confirmation stopped creating Purchase Orders for buyable MRP components. This PR restores the expected behavior.

Before this changes:

No purchase order and transfer from Input location
<img width="889" height="142" alt="image" src="https://github.com/user-attachments/assets/520bf2ad-62ca-4221-9f24-57dfac81b419" />

After this changes:
purchase order and transfers were created
<img width="848" height="144" alt="image" src="https://github.com/user-attachments/assets/eabb2565-7cae-469d-bb87-6fbb8293e317" />

