### PR TITLE
[17.0][FIX] stock_secondary_unit

### DIFF
--- a/stock_secondary_unit/models/stock_move.py
+++ b/stock_secondary_unit/models/stock_move.py
@@ -44,10 +44,10 @@ class StockMove(models.Model):
 class StockMoveLine(models.Model):
     _inherit = ["stock.move.line", "product.secondary.unit.mixin"]
     _name = "stock.move.line"
-    _secondary_unit_fields = {"qty_field": "qty_done", "uom_field": "product_uom_id"}
+    _secondary_unit_fields = {"qty_field": "quantity", "uom_field": "product_uom_id"}
 
-    qty_done = fields.Float(
-        store=True, readonly=False, compute="_compute_qty_done", precompute=True
+    quantity = fields.Float(
+        store=True, readonly=False, compute="_compute_quantity", precompute=True
     )
 
     @api.model_create_multi
@@ -59,5 +59,7 @@ class StockMoveLine(models.Model):
         return super().create(vals_list)
 
     @api.depends("secondary_uom_id", "secondary_uom_qty")
-    def _compute_qty_done(self):
+    def _compute_quantity(self):
+        res = super()._compute_quantity()
         self._compute_helper_target_field_qty()
+        return res

--- a/stock_secondary_unit/tests/test_stock_secondary_unit.py
+++ b/stock_secondary_unit/tests/test_stock_secondary_unit.py
@@ -149,7 +149,7 @@ class TestProductSecondaryUnit(TransactionCase):
             delivery_order.move_line_ids.mapped("secondary_uom_qty")
         )
         self.assertEqual(uom_qty, 20.0)
-        self.assertEqual(secondary_uom_qty, 0.0)
+        self.assertEqual(secondary_uom_qty, 40.0)
 
     def test_picking_secondary_unit(self):
         product = self.product_template.product_variant_ids[0]
@@ -184,12 +184,12 @@ class TestProductSecondaryUnit(TransactionCase):
         stock_move_line.product_uom_id = stock_move_line.product_id.uom_id.id
         stock_move_line.secondary_uom_qty = 1
         stock_move_line.secondary_uom_id = product.product_tmpl_id.secondary_uom_ids[0]
-        self.assertEqual(stock_move_line.qty_done, 0.5)
+        self.assertEqual(stock_move_line.quantity, 0.5)
         stock_move_line.secondary_uom_qty = 2
-        self.assertEqual(stock_move_line.qty_done, 1)
+        self.assertEqual(stock_move_line.quantity, 1)
         stock_move_line.secondary_uom_id = product.product_tmpl_id.secondary_uom_ids[1]
-        self.assertEqual(stock_move_line.qty_done, 1.8)
-        stock_move_line.qty_done = 5
+        self.assertEqual(stock_move_line.quantity, 1.8)
+        stock_move_line.quantity = 5
         self.assertAlmostEqual(stock_move_line.secondary_uom_qty, 5.56, 2)
 
     def test_secondary_unit_merge_move_diff_uom(self):


### PR DESCRIPTION
@BinhexTeam

Roadmap:

1. Calculating the `secondary_uom_qty` field using the `quantity` field instead of the `qty_done` field.
2. Tests

ping @sergio-teruel @CarlosRoca13 @pedrobaeza 