### PR TITLE
[18.0][FIX] stock_vertical_lift: mig readonly

### DIFF
--- a/stock_vertical_lift/readme/CONTRIBUTORS.md
+++ b/stock_vertical_lift/readme/CONTRIBUTORS.md
@@ -4,3 +4,5 @@ Trobz
 
 - Dung Tran \<<dungtd@trobz.com>\>
 - Nhan Tran \<<nhant@trobz.com>\>
+
+- Jacques-Etienne Baudoux (BCIM) \<<je@bcim.be>\>

--- a/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
+++ b/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
@@ -92,7 +92,12 @@
                         class="o_shuttle_operation bg-primary jumbotron jumbotron-fluid"
                     >
                         <div class="container">
-                            <field name="state" invisible="0" readonly="True" />
+                            <field
+                                name="state"
+                                invisible="0"
+                                readonly="True"
+                                force_save="1"
+                            />
                         </div>
                     </div>
                     <div class="o_shuttle_data" />
@@ -143,6 +148,7 @@
                                     name="location_dest_id"
                                     class="bg-primary o_shuttle_highlight"
                                     readonly="1"
+                                    force_save="1"
                                     options="{'no_open': True}"
                                 />
                             </div>


### PR DESCRIPTION
The readonly fields updated by onchange (on barcode scanned) now requires force_save to be saved on action button

cc @sebalix @florentx 