### PR TITLE
[18.0][FIX] stock_vertical_lift: fix migration v18.0 - fix inventory

### DIFF
--- a/stock_vertical_lift/models/vertical_lift_operation_inventory.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_inventory.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Camptocamp SA
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -224,19 +225,19 @@ class VerticalLiftOperationInventory(models.Model):
         return bool(next_quant_id)
 
     def process_current(self):
-        stock_quant = self.quant_id
-        if not stock_quant.vertical_lift_done:
-            stock_quant.vertical_lift_done = True
+        quant = self.quant_id
+        if quant and not quant.vertical_lift_done:
+            quant.vertical_lift_done = True
             if (
                 float_compare(
                     self.quantity_input,
-                    stock_quant.inventory_quantity,
-                    precision_digits=2,
+                    quant.quantity,
+                    precision_rounding=quant.product_uom_id.rounding,
                 )
                 != 0
             ):
-                stock_quant.inventory_quantity = self.quantity_input
-                stock_quant.action_apply_inventory()
+                quant.inventory_quantity = self.quantity_input
+                quant._apply_inventory()
             self.quantity_input = self.last_quantity_input = 0.0
         return True
 

--- a/stock_vertical_lift/tests/test_inventory.py
+++ b/stock_vertical_lift/tests/test_inventory.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Camptocamp SA
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests import Form
@@ -128,7 +129,7 @@ class TestInventory(VerticalLiftCase):
         operation.button_save()
         self.assertFalse(operation.quant_id)
         self.assertTrue(quant.vertical_lift_done)
-        self.assertEqual(quant.inventory_quantity, 12.0)
+        self.assertEqual(quant.quantity, 12.0)
         self.assertFalse(operation.quant_id)
 
     def test_confirm_wrong_quantity(self):


### PR DESCRIPTION
Once the inventory is posted the quantity is updated and inventory_quantity reset to 0

cc @sebalix