### PR TITLE
[18.0][FIX] stock_vertical_lift put

### DIFF
--- a/stock_vertical_lift/models/vertical_lift_operation_base.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_base.py
@@ -486,6 +486,7 @@ class VerticalLiftOperationTransfer(models.AbstractModel):
 
     def process_current(self):
         line = self.current_move_line_id
+        line.ensure_one()
         if line.state in ("assigned", "partially_available"):
             # if the move has other move lines, it is split to have only this move line
             split_other_move_lines(line.move_id, line)

--- a/stock_vertical_lift/models/vertical_lift_operation_base.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_base.py
@@ -77,7 +77,9 @@ def extract_and_action_done(move):
             if moves_todo.state != "assigned":
                 moves_todo._action_assign()
             assert new_picking.state == "assigned"
-        new_picking.button_validate()
+        new_picking.with_context(
+            skip_backorder=True, skip_expired=True, skip_sms=True
+        ).button_validate()
     return True
 
 

--- a/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
+++ b/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
@@ -116,6 +116,7 @@
                 <attribute name="invisible">not current_move_line_id</attribute>
             </xpath>
             <xpath expr="//div[hasclass('o_shuttle_data')]" position="inside">
+                <field name="current_move_line_id" invisible="True" force_save="1" />
                 <!-- on the left of the screen -->
                 <div class="o_shuttle_data_content o_shuttle_move">
                     <div>


### PR DESCRIPTION
* Add missing current_move_line_id to the view and force save as it is readonly
   The missing line was automatically added by odoo in the view but as it is marked as readonly in the model, it was not transmitted on save
* Validate the picking even if the lot is expired

cc @simahawk @sebalix 