### PR TITLE
[18.0][FIX] stock_demand_estimate: make active in list view invisible

### DIFF
--- a/stock_demand_estimate/views/stock_demand_estimate_view.xml
+++ b/stock_demand_estimate/views/stock_demand_estimate_view.xml
@@ -13,7 +13,7 @@
                 <field name="product_uom" />
                 <field name="product_qty" />
                 <field name="daily_qty" />
-                <field name="active" invisible="1" />
+                <field name="active" column_invisible="True" />
             </list>
         </field>
     </record>


### PR DESCRIPTION
This was not making the column invisible.
<img width="542" height="200" alt="image" src="https://github.com/user-attachments/assets/ed10aff8-a7e8-4540-86a3-06579e7ad38e" />
