### PR TITLE
[IMP][18.0]stock_move_packaging_qty: move columnt packaging

### DIFF
--- a/stock_lot_image/i18n/it.po
+++ b/stock_lot_image/i18n/it.po
@@ -6,129 +6,131 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"Last-Translator: Automatically generated\n"
+"PO-Revision-Date: 2025-11-10 10:04+0000\n"
+"Last-Translator: mymage <stefano.consolaro@mymage.it>\n"
 "Language-Team: none\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.10.4\n"
 
 #. module: stock_lot_image
 #: model_terms:ir.ui.view,arch_db:stock_lot_image.stock_lot_image_view_kanban
 msgid "#{record.name.value}"
-msgstr ""
+msgstr "#{record.name.value}"
 
 #. module: stock_lot_image
 #: model_terms:ir.ui.view,arch_db:stock_lot_image.stock_lot_image_view_form
 msgid "<span>Video Preview</span>"
-msgstr ""
+msgstr "<span>Anteprima video</span>"
 
 #. module: stock_lot_image
 #: model_terms:ir.ui.view,arch_db:stock_lot_image.stock_lot_image_view_kanban
 msgid "Acceptable file size"
-msgstr ""
+msgstr "Dimensione file accettabile"
 
 #. module: stock_lot_image
 #: model_terms:ir.ui.view,arch_db:stock_lot_image.view_production_lot_form
 msgid "Add Media"
-msgstr ""
+msgstr "Aggiungi media"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__can_image_1024_be_zoomed
 msgid "Can Image 1024 be zoomed"
-msgstr ""
+msgstr "L'immagine 1024 può essere zoomata"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__create_uid
 msgid "Created by"
-msgstr ""
+msgstr "Creato da"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__create_date
 msgid "Created on"
-msgstr ""
+msgstr "Creato il"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Nome visualizzato"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__embed_code
 msgid "Embed Code"
-msgstr ""
+msgstr "Codice incluso"
 
 #. module: stock_lot_image
 #: model_terms:ir.ui.view,arch_db:stock_lot_image.stock_lot_image_view_kanban
 msgid "Huge file size. The image should be optimized/reduced."
-msgstr ""
+msgstr "Dimensione file eccessiva. L'immagine deve essere ottimizzata/ridotta."
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__image_1920
 msgid "Image"
-msgstr ""
+msgstr "Immagine"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__image_1024
 msgid "Image 1024"
-msgstr ""
+msgstr "Immagine 1024"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__image_128
 msgid "Image 128"
-msgstr ""
+msgstr "Immagine 128"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__image_256
 msgid "Image 256"
-msgstr ""
+msgstr "Immagine 256"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__image_512
 msgid "Image 512"
-msgstr ""
+msgstr "Immagine 512"
 
 #. module: stock_lot_image
 #: model_terms:ir.ui.view,arch_db:stock_lot_image.stock_lot_image_view_form
 msgid "Image Name"
-msgstr ""
+msgstr "Nome immagine"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot__image_ids
 #: model_terms:ir.ui.view,arch_db:stock_lot_image.view_production_lot_form
 msgid "Images"
-msgstr ""
+msgstr "Immagini"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__write_uid
 msgid "Last Updated by"
-msgstr ""
+msgstr "Ultimo aggiornamento di"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__write_date
 msgid "Last Updated on"
-msgstr ""
+msgstr "Ultimo aggiornamento il"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__lot_id
 msgid "Lot"
-msgstr ""
+msgstr "Lotto"
 
 #. module: stock_lot_image
 #: model:ir.model,name:stock_lot_image.model_stock_lot
 msgid "Lot/Serial"
-msgstr ""
+msgstr "Lotto/seriale"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__name
 msgid "Name"
-msgstr ""
+msgstr "Nome"
 
 #. module: stock_lot_image
 #: model_terms:ir.ui.view,arch_db:stock_lot_image.stock_lot_image_view_kanban
@@ -136,11 +138,13 @@ msgid ""
 "Optimization required! Reduce the image size or increase your compression "
 "settings."
 msgstr ""
+"Richiesta ottimizzazione! Ridurre la dimensione dell'immagine o aumentare le "
+"impostazioni di compressione."
 
 #. module: stock_lot_image
 #: model_terms:ir.ui.view,arch_db:stock_lot_image.stock_lot_image_view_form
 msgid "Please enter a valid Video URL."
-msgstr ""
+msgstr "Inserire un URL video valido."
 
 #. module: stock_lot_image
 #. odoo-python
@@ -148,24 +152,25 @@ msgstr ""
 msgid ""
 "Provided video URL for '%s' is not valid. Please enter a valid video URL."
 msgstr ""
+"L'URL video fornito per '%s' non è valido. Inserire un URL video valido."
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__sequence
 msgid "Sequence"
-msgstr ""
+msgstr "Sequenza"
 
 #. module: stock_lot_image
 #: model:ir.model,name:stock_lot_image.model_stock_lot_image
 msgid "Stock Lot Image"
-msgstr ""
+msgstr "Immagine lotto magazzino"
 
 #. module: stock_lot_image
 #: model:ir.model.fields,help:stock_lot_image.field_stock_lot_image__video_url
 msgid "URL of a video for showcasing your lot."
-msgstr ""
+msgstr "URL di un video di presentazione del lotto."
 
 #. module: stock_lot_image
 #: model:ir.model.fields,field_description:stock_lot_image.field_stock_lot_image__video_url
 #: model_terms:ir.ui.view,arch_db:stock_lot_image.stock_lot_image_view_form
 msgid "Video URL"
-msgstr ""
+msgstr "URL video"

--- a/stock_move_packaging_qty/views/stock_picking_view.xml
+++ b/stock_move_packaging_qty/views/stock_picking_view.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <!-- Packaging quantity -->
             <xpath
-                expr="//field[@name='move_ids_without_package']/list/field[@name='product_uom' and @column_invisible='True']"
+                expr="//field[@name='move_ids_without_package']/list/field[@name='product_packaging_id']"
                 position="after"
             >
                 <field
@@ -20,7 +20,6 @@
                     readonly="not product_id or not is_quantity_done_editable or move_lines_count != 1"
                     invisible="not product_packaging_id"
                 />
-                <xpath expr="//field[@name='product_packaging_id']" position="move" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
In version 16, the packaging column is in a different position.
In Odoo 18, it also appears as it did in v16, so to improve the
adaptation of the migration to v18 and make it less confusing,
the column is placed in the same location.

Before > 

<img width="1251" height="634" alt="image" src="https://github.com/user-attachments/assets/9534537e-3583-46c5-9153-0ff463c68999" />

After > 

<img width="1251" height="634" alt="image" src="https://github.com/user-attachments/assets/4bddbc8e-0728-492c-9060-5dfd299e7446" />

@moduon MT-11845