### PR TITLE
[18.0][FIX] stock_cycle_count: prevent select location from other company

### DIFF
--- a/stock_cycle_count/models/stock_cycle_count.py
+++ b/stock_cycle_count/models/stock_cycle_count.py
@@ -20,6 +20,7 @@ class StockCycleCount(models.Model):
         comodel_name="stock.location",
         string="Location",
         required=True,
+        domain="[('company_id', '=', company_id)]",
     )
     responsible_id = fields.Many2one(
         comodel_name="res.users",

--- a/stock_cycle_count/models/stock_inventory.py
+++ b/stock_cycle_count/models/stock_inventory.py
@@ -127,13 +127,11 @@ class StockInventory(models.Model):
 
     def action_state_to_done(self):
         res = super().action_state_to_done()
-        self._calculate_inventory_accuracy()
         self._update_cycle_state()
         return res
 
     def action_force_done(self):
         res = super().action_force_done()
-        self._calculate_inventory_accuracy()
         self._update_cycle_state()
         return res
 

--- a/stock_cycle_count/models/stock_quant.py
+++ b/stock_cycle_count/models/stock_quant.py
@@ -13,6 +13,7 @@ class StockQuant(models.Model):
         theoretical_dict = {}
         counted_dict = {}
         StockMoveLine = self.env["stock.move.line"]
+        inv_adjustments_ids = set()
         for quant in self:
             if quant.discrepancy_percent > 100:
                 line_accuracy = 0
@@ -42,3 +43,11 @@ class StockQuant(models.Model):
                         "counted_qty": counted_dict[quant.id],
                     }
                 )
+                adjustment_id = last_move_line.inventory_adjustment_id.id
+                inv_adjustments_ids.add(adjustment_id)
+
+        if inv_adjustments_ids:
+            inv_adjustments = self.env["stock.inventory"].browse(
+                list(inv_adjustments_ids)
+            )
+            inv_adjustments._calculate_inventory_accuracy()

--- a/stock_cycle_count/tests/test_stock_cycle_count.py
+++ b/stock_cycle_count/tests/test_stock_cycle_count.py
@@ -630,3 +630,63 @@ class TestStockCycleCount(common.TransactionCase):
                 additional_user_2.id,
                 "Quant user not updated after inventory responsible change.",
             )
+
+    def test_inventory_adjustment_auto_complete_accuracy(self):
+        self.env.company.stock_inventory_auto_complete = True
+        date = datetime.today() - timedelta(days=1)
+        # Create location
+        loc = self.stock_location_model.create(
+            {"name": "Test Location", "usage": "internal"}
+        )
+        # Create stock quants for specific location
+        quant1 = self.quant_model.create(
+            {
+                "product_id": self.product1.id,
+                "location_id": loc.id,
+                "quantity": 10.0,
+            }
+        )
+        quant2 = self.quant_model.create(
+            {
+                "product_id": self.product2.id,
+                "location_id": loc.id,
+                "quantity": 15.0,
+            }
+        )
+        # Create adjustments for specific location
+        adjustment = self.inventory_model.create(
+            {
+                "name": "Pre-existing inventory",
+                "location_ids": [Command.link(loc.id)],
+                "date": date,
+            }
+        )
+        # Start the adjustment
+        adjustment.action_state_to_in_progress()
+        # Check that there are stock quants for the specific location
+        self.assertTrue(self.env["stock.quant"].search([("location_id", "=", loc.id)]))
+        # Make the count of the stock
+        quant1.update(
+            {
+                "inventory_quantity": 5,
+            }
+        )
+        quant2.update(
+            {
+                "inventory_quantity": 10,
+            }
+        )
+        # Apply the changes
+        quant1._apply_inventory()
+        quant2._apply_inventory()
+        # Check that line_accuracy is calculated properly
+        sml = self.env["stock.move.line"].search(
+            [("location_id", "=", loc.id), ("product_id", "=", self.product1.id)]
+        )
+        self.assertEqual(sml.line_accuracy, 0.5)
+        sml = self.env["stock.move.line"].search(
+            [("location_id", "=", loc.id), ("product_id", "=", self.product2.id)]
+        )
+        self.assertEqual(sml.line_accuracy, 0.6667000000000001)
+        # Check that accuracy is correctly calculated
+        self.assertEqual(adjustment.inventory_accuracy, 60)


### PR DESCRIPTION
This pr include several fixes:
- Added a domain to the location_id field so the cycle count form only displays locations belonging to the selected company.
- Fixed a bug in accuracy calculation for auto-completed inventory adjustments