### PR TITLE
[18.0][ADD] stock_restrict_immediate_adjustment: Prevent accidental stock changes

### DIFF
--- a/stock_restrict_immediate_adjustment/README.rst
+++ b/stock_restrict_immediate_adjustment/README.rst
@@ -1,0 +1,88 @@
+===================================
+Stock Restrict Immediate Adjustment
+===================================
+
+.. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
+    :target: https://odoo-community.org/page/development-status
+    :alt: Beta
+.. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+.. |badge3| image:: https://img.shields.io/badge/github-OCA%2Fstock--logistics--warehouse-lightgray.png?logo=github
+    :target: https://github.com/OCA/stock-logistics-warehouse/tree/18.0/stock_restrict_immediate_adjustment
+    :alt: OCA/stock-logistics-warehouse
+
+|badge1| |badge2| |badge3|
+
+This module prevents accidental immediate stock adjustments from the "Stock On Hand" 
+view that is accessible from product cards and inventory reports.
+
+**Problem**
+
+In standard Odoo, when users click on the "On Hand" quantity button from a product 
+or access the inventory report, they can immediately change stock quantities just by 
+typing a new value. The change is applied instantly without any confirmation step, 
+making it very easy to accidentally modify inventory.
+
+**Solution**
+
+This module disables inline editing in the stock quant tree view, forcing users to:
+
+1. Use the "Inventory Adjustments" menu where they must explicitly click "Apply" to 
+   confirm changes
+2. Prevents accidental stock modifications from quick views
+3. Ensures proper traceability of all inventory adjustments
+
+**Table of contents**
+
+.. contents::
+   :local:
+
+Usage
+=====
+
+After installing this module:
+
+* When you click on "On Hand" quantity from a product card, the quant list view 
+  will be read-only
+* When you access the inventory report, direct editing is disabled
+* Users must go to Inventory > Operations > Inventory Adjustments to make stock 
+  changes with proper confirmation
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/stock-logistics-warehouse/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+
+Credits
+=======
+
+Authors
+-------
+
+* ForgeFlow
+
+Contributors
+------------
+
+- `ForgeFlow <https://www.forgeflow.com>`__:
+
+  - Joan Sisquella <joan.sisquella@forgeflow.com>
+
+Maintainers
+-----------
+
+This module is maintained by the OCA.
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+This module is part of the `OCA/stock-logistics-warehouse <https://github.com/OCA/stock-logistics-warehouse/tree/18.0/stock_restrict_immediate_adjustment>`_ project on GitHub.
+
+You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/stock_restrict_immediate_adjustment/__init__.py
+++ b/stock_restrict_immediate_adjustment/__init__.py
@@ -1,0 +1,1 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/stock_restrict_immediate_adjustment/__manifest__.py
+++ b/stock_restrict_immediate_adjustment/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2025 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Stock Restrict Immediate Adjustment",
+    "version": "18.0.1.0.0",
+    "category": "Inventory/Inventory",
+    "summary": "Restrict immediate stock adjustments from Stock On Hand view",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "license": "AGPL-3",
+    "depends": ["stock"],
+    "data": [
+        "views/stock_quant_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/stock_restrict_immediate_adjustment/pyproject.toml
+++ b/stock_restrict_immediate_adjustment/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/stock_restrict_immediate_adjustment/views/stock_quant_views.xml
+++ b/stock_restrict_immediate_adjustment/views/stock_quant_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 ForgeFlow S.L.
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+    <record id="view_stock_quant_tree_editable_inherit" model="ir.ui.view">
+        <field name="name">stock.quant.tree.editable.inherit</field>
+        <field name="model">stock.quant</field>
+        <field name="inherit_id" ref="stock.view_stock_quant_tree_editable" />
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="attributes">
+                <attribute name="create">0</attribute>
+                <attribute name="edit">0</attribute>
+                <attribute name="editable" />
+            </xpath>
+            <field name="inventory_quantity_auto_apply" position="attributes">
+                <attribute name="column_invisible">1</attribute>
+            </field>
+            <field name="inventory_quantity_auto_apply" position="after">
+                <field name="quantity" string="On Hand Quantity" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module disables inline editing in the stock quant tree view, forcing users to:

1. Use the "Inventory Adjustments" menu where they must explicitly click "Apply" to 
   confirm changes
2. Prevents accidental stock modifications from quick views
3. Ensures proper traceability of all inventory adjustments