### PR TITLE
[18.0][FIX] stock_inventory: auto done not work with more than 1 adjustment

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -21,7 +21,7 @@ class StockQuant(models.Model):
     def _apply_inventory(self):
         res = super()._apply_inventory()
         record_moves = self.env["stock.move.line"]
-        adjustment = self.env["stock.inventory"].browse()
+        adjustments = []
         for rec in self:
             adjustment = rec.current_inventory_id
             moves = record_moves.search(
@@ -55,8 +55,11 @@ class StockQuant(models.Model):
             )
             rec.to_do = False
             rec.current_inventory_id = False
-        if adjustment and self.env.company.stock_inventory_auto_complete:
-            adjustment.action_auto_state_to_done()
+            if adjustment not in adjustments:
+                adjustments.append(adjustment)
+        if adjustments and self.env.company.stock_inventory_auto_complete:
+            for adjustment in adjustments:
+                adjustment.action_auto_state_to_done()
         return res
 
     def _get_inventory_fields_write(self):


### PR DESCRIPTION
When using barcode to do more than 1 adjustment at the same time, the auto completion to done is not working properly, and only sets to done the last adjustment:

As you can see we have 2 adjustments:
<img width="1847" height="363" alt="2025-11-28_17-26" src="https://github.com/user-attachments/assets/870d9919-6876-48de-8045-f41ce74f243d" />

We complete the 2 adjustments using the barcode app:
<img width="1854" height="907" alt="2025-11-28_17-27" src="https://github.com/user-attachments/assets/25ac9049-ba07-48c0-be31-763eb2689726" />

Whenever we apply, only 1 is marked as done, when both should be done:
<img width="1833" height="523" alt="2025-11-28_17-29" src="https://github.com/user-attachments/assets/8d043526-5fb4-460c-8508-4a26f55f6f5f" />

As you can see the adjustment that is in progress, is done:
<img width="1829" height="577" alt="2025-11-28_17-29_1" src="https://github.com/user-attachments/assets/77d51fd3-9fef-458b-91f1-4c0cbed8087c" />


