### PR TITLE
[18.0][FIX] stock_inventory: prevent auto_state_to_done to empty recordsets

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -21,8 +21,9 @@ class StockQuant(models.Model):
     def _apply_inventory(self):
         res = super()._apply_inventory()
         record_moves = self.env["stock.move.line"]
-        adjustments = []
-        for rec in self:
+        adjustments_to_process = self.env["stock.inventory"]
+
+        for rec in self.filtered("current_inventory_id"):
             adjustment = rec.current_inventory_id
             moves = record_moves.search(
                 [
@@ -55,11 +56,11 @@ class StockQuant(models.Model):
             )
             rec.to_do = False
             rec.current_inventory_id = False
-            if adjustment not in adjustments:
-                adjustments.append(adjustment)
-        if adjustments and self.env.company.stock_inventory_auto_complete:
-            for adjustment in adjustments:
-                adjustment.action_auto_state_to_done()
+            adjustments_to_process |= adjustment
+
+        if adjustments_to_process and self.env.company.stock_inventory_auto_complete:
+            for inventory in adjustments_to_process:
+                inventory.action_auto_state_to_done()
         return res
 
     def _get_inventory_fields_write(self):


### PR DESCRIPTION
Fixed an issue where action_auto_state_to_done() was being executed on an empty stock.inventory() recordset, caused by adding undefined adjustments to the `adjustments` list. Now only valid inventory records are added, preventing errors during auto-complete.