### PR TITLE
[18.0][IMP] stock_vertical_lift: improve screen rendering

### DIFF
--- a/stock_vertical_lift/static/src/scss/vertical_lift.scss
+++ b/stock_vertical_lift/static/src/scss/vertical_lift.scss
@@ -21,7 +21,7 @@
         .o_shuttle_header {
             display: flex;
             flex-flow: row wrap;
-            padding: $o-shuttle-padding;
+            padding: 0 0.5em;
         }
 
         .o_shuttle_header_content {
@@ -47,7 +47,7 @@
         .o_shuttle_operation {
             text-align: center;
             font-size: 2.5em;
-            padding: 0.5em;
+            padding: 0 0.5em;
             color: #ffffff;
         }
 

--- a/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
+++ b/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
@@ -126,7 +126,7 @@
                                     <field
                                         name="picking_id"
                                         options="{'no_open': True}"
-                                        class="mr8"
+                                        class="oe_inline mr8"
                                     />
                                     <span>/</span>
                                     <field
@@ -153,13 +153,12 @@
                                 />
                             </div>
                             <label for="product_id" />
-                            <div colspan="2" class="oe_title">
-                                <h1>
-                                    <field
-                                        name="product_id"
-                                        options="{'no_open': True}"
-                                    />
-                                </h1>
+                            <div>
+                                <field
+                                    name="product_id"
+                                    options="{'no_open': True}"
+                                    class="fw-bold fs-1"
+                                />
                             </div>
                             <div colspan="2">
                                 <field name="product_packagings" />


### PR DESCRIPTION
Depending on the number of product packagings displayed, user would need to scroll down to see the last elements of the screen (here quantity). Tune the rendering here and there to get everything displayed.

PS: vendor code on the screenshots is a specific development not included here.

## Before:
<img width="1920" height="944" alt="image" src="https://github.com/user-attachments/assets/c361cd13-a9b2-44dd-9811-786b0b7daebd" />

## After:
<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/c25c34c7-3b4b-499b-8250-c6ff1891504e" />