### PR TITLE
[IMP][16.0] Action to create Inventory Group from products tree views

### DIFF
--- a/stock_inventory/__manifest__.py
+++ b/stock_inventory/__manifest__.py
@@ -15,6 +15,7 @@
         "views/stock_inventory.xml",
         "views/stock_quant.xml",
         "views/stock_move_line.xml",
+        "views/product.xml",
         "views/res_config_settings_view.xml",
     ],
     "installable": True,

--- a/stock_inventory/models/__init__.py
+++ b/stock_inventory/models/__init__.py
@@ -1,5 +1,6 @@
 from . import stock_inventory
 from . import stock_quant
 from . import stock_move_line
+from . import product
 from . import res_company
 from . import res_config_settings

--- a/stock_inventory/models/product.py
+++ b/stock_inventory/models/product.py
@@ -1,0 +1,35 @@
+from odoo import _, api, fields, models
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    def action_inventory(self):
+        """ Retrieve template's product.product
+            and call `product.product.action_inventory`
+        """
+        products = self.env['product.product'].search(
+            [('product_tmpl_id', 'in', self._context.get('active_ids'))]
+        )
+        return self.env['product.product'].action_inventory(products.ids)
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def action_inventory(self, product_ids=None):
+        """ Create an inventory group from a selection of records
+            and redirect the user to the created inventory's form
+        """
+        product_ids = product_ids or self._context.get('active_ids')
+
+        # create inventory
+        inventory = self.env['stock.inventory'].create({
+            'product_selection': 'manual',
+            'product_ids': product_ids,
+        })
+
+        # redirect the user
+        action_id = 'stock_inventory.action_view_inventory_group_form'
+        return self.env['ir.actions.act_window']._for_xml_id(action_id) | {
+            'res_id': inventory.id,
+            'views': [(False, 'form')],
+        }

--- a/stock_inventory/tests/test_stock_inventory.py
+++ b/stock_inventory/tests/test_stock_inventory.py
@@ -589,3 +589,14 @@ class TestStockInventory(TransactionCase):
             ).current_inventory_id,
             inventory2,
         )
+
+    def test_14_action_inventory(self):
+        """ Ensure Inventory Group creation from Action,
+            and user redirection to Inventory Group's form
+        """
+        product_tmpl = self.product.product_tmpl_id
+        action = product_tmpl.with_context(active_ids=product_tmpl.ids).action_inventory()
+        inventory_id = action.get('res_id')
+        inventory = self.env['stock.inventory'].browse(inventory_id)
+
+        self.assertEqual(inventory.product_ids.ids, self.product.ids)

--- a/stock_inventory/views/product.xml
+++ b/stock_inventory/views/product.xml
@@ -1,0 +1,19 @@
+<odoo>
+    <record id="action_product_template_inventory" model="ir.actions.server">
+        <field name="name">Inventory</field>
+        <field name="model_id" ref="product.model_product_template" />
+        <field name="state">code</field>
+        <field name="code">action = model.action_inventory()</field>
+        <field name="binding_model_id" ref="product.model_product_template"/>
+        <field name="binding_view_types">list</field>
+    </record>
+
+    <record id="action_product_product_inventory" model="ir.actions.server">
+        <field name="name">Inventory</field>
+        <field name="model_id" ref="product.model_product_product" />
+        <field name="state">code</field>
+        <field name="code">action = model.action_inventory()</field>
+        <field name="binding_model_id" ref="product.model_product_product"/>
+        <field name="binding_view_types">list</field>
+    </record>
+</odoo>

--- a/stock_inventory/views/stock_quant.xml
+++ b/stock_inventory/views/stock_quant.xml
@@ -1,16 +1,16 @@
 <odoo>
     <record id="view_stock_quant_search_not_done" model="ir.ui.view">
-            <field name="name">stock.quant.search.not.done</field>
-            <field name="model">stock.quant</field>
-            <field name="inherit_id" ref="stock.quant_search_view" />
-            <field name="arch" type="xml">
-                <filter name="to_apply" position="after">
-                    <filter
-                    name='to_do'
-                    string="To Do"
-                    domain="[('to_do', '=', 'True')]"
-                />
-                </filter>
-            </field>
-        </record>
+        <field name="name">stock.quant.search.not.done</field>
+        <field name="model">stock.quant</field>
+        <field name="inherit_id" ref="stock.quant_search_view" />
+        <field name="arch" type="xml">
+            <filter name="to_apply" position="after">
+                <filter
+                name='to_do'
+                string="To Do"
+                domain="[('to_do', '=', 'True')]"
+            />
+            </filter>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Just allow the creation of "inventory group" from the tree view of `product.template` and `product.product`.
This allow quite simple and dynamic way of filtering products from their original views, and then add them into new Inventory Groups, instead of adding complex filtering logic in Inventory Groups form.

1 test was added.
I'll port it to 18.0 right after validation of this PR.