### PR TITLE
[17.0][FIX] stock_secondary_unit: add missing second qty data to done delivery slip

### DIFF
--- a/stock_secondary_unit/report/report_deliveryslip.xml
+++ b/stock_secondary_unit/report/report_deliveryslip.xml
@@ -41,4 +41,15 @@
             </td>
         </xpath>
     </template>
+    <template
+        id="stock_report_delivery_aggregated_move_lines"
+        inherit_id="stock.stock_report_delivery_aggregated_move_lines"
+    >
+        <xpath expr="//tr[@t-foreach='aggregated_lines']/td[1]" position="after">
+            <td>
+                <span t-field="aggregated_lines[line]['move'].secondary_uom_qty" />
+                <span t-field="aggregated_lines[line]['move'].secondary_uom_id" />
+            </td>
+        </xpath>
+    </template>
 </odoo>


### PR DESCRIPTION
Delivery slip detail for a done picking is placed in a separate template aggregated section. This commit adds missing column values for secondary quantity and secondary unit for such situation.

This was initially added during unfinished migration of this addon at closed PR #2086 , and that was not finally added at superseded one.

Before this fix:

<img width="950" height="247" alt="imagen" src="https://github.com/user-attachments/assets/2f332015-fb75-4265-806c-0ca5ca43dc0e" />


After:

<img width="945" height="330" alt="imagen" src="https://github.com/user-attachments/assets/c89b7049-5966-4751-b241-39d1720518bb" />





I've preserved original authorship

@mmrondon @rov-adhoc @juancarlosonate-tecnativa could you review? Thanks!