### PR TITLE
[18.0][IMP] stock_move_packaging_qty: move columnt packaging

### DIFF
--- a/stock_move_packaging_qty/views/stock_picking_view.xml
+++ b/stock_move_packaging_qty/views/stock_picking_view.xml
@@ -7,13 +7,9 @@
         <field name="arch" type="xml">
             <!-- Packaging quantity -->
             <xpath
-                expr="//field[@name='move_ids_without_package']/list/field[@name='product_uom' and @column_invisible='True']"
+                expr="//field[@name='move_ids_without_package']/list/field[@name='product_uom_qty']"
                 position="after"
             >
-                <field
-                    name="product_packaging_qty"
-                    groups="product.group_stock_packaging"
-                />
                 <field
                     name="product_packaging_quantity"
                     groups="product.group_stock_packaging"
@@ -21,6 +17,15 @@
                     invisible="not product_packaging_id"
                 />
                 <xpath expr="//field[@name='product_packaging_id']" position="move" />
+            </xpath>
+            <xpath
+                expr="//field[@name='move_ids_without_package']/list/field[@name='product_uom_qty']"
+                position="before"
+            >
+                <field
+                    name="product_packaging_qty"
+                    groups="product.group_stock_packaging"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
In version 16, the packaging column is in a different position. In Odoo 18, it also appears as it did in v16, so to improve the adaptation of the migration to v18 and make it less confusing, the column is placed in the same location.
v16
<img width="1689" height="821" alt="image" src="https://github.com/user-attachments/assets/4fb06bad-de91-4753-a68a-843db23c8944" />
v18 now
<img width="1693" height="860" alt="image" src="https://github.com/user-attachments/assets/85464cdf-2325-4e29-a8ca-decfeceaa0f3" />


MT-11845
@moduon