### PR TITLE
[14.0][UPD] stock_warehouse_calendar_orderpoint: method belongs to the Warehouse

### DIFF
--- a/stock_warehouse_calendar/models/stock_rule.py
+++ b/stock_warehouse_calendar/models/stock_rule.py
@@ -20,7 +20,7 @@ class StockRule(models.Model):
         company_id,
         values,
     ):
-        res = super(StockRule, self)._get_stock_move_values(
+        res = super()._get_stock_move_values(
             product_id,
             product_qty,
             product_uom,

--- a/stock_warehouse_calendar/tests/test_stock_warehouse_calendar.py
+++ b/stock_warehouse_calendar/tests/test_stock_warehouse_calendar.py
@@ -7,7 +7,7 @@ from odoo.tests.common import TransactionCase
 
 class TestStockWarehouseCalendar(TransactionCase):
     def setUp(self):
-        super(TestStockWarehouseCalendar, self).setUp()
+        super().setUp()
         self.wh_obj = self.env["stock.warehouse"]
         self.move_obj = self.env["stock.move"]
         self.pg_obj = self.env["procurement.group"]

--- a/stock_warehouse_calendar_orderpoint/README.rst
+++ b/stock_warehouse_calendar_orderpoint/README.rst
@@ -58,6 +58,12 @@ For example, if we plan to execute the reordering rules on a given weekday
 (configuration of the Reordering Calendar), it will take this day as a
 starting date instead of the current day (standard behavior).
 
+Known issues / Roadmap
+======================
+
+Method `_get_next_reordering_date()` is moved to `stock.warehouse` where it belongs. Method
+on the `stock.warehouse.orderpoint` is deprecated and will be removed.
+
 Bug Tracker
 ===========
 

--- a/stock_warehouse_calendar_orderpoint/models/stock_rule.py
+++ b/stock_warehouse_calendar_orderpoint/models/stock_rule.py
@@ -13,7 +13,7 @@ class StockRule(models.Model):
         if self.env.context.get("orderpoint_id"):
             op_id = self.env.context["orderpoint_id"]
             op = self.env["stock.warehouse.orderpoint"].browse(op_id)
-            reordering_date = op._get_next_reordering_date()
+            reordering_date = op.warehouse_id._get_next_reordering_date()
             # Display the reordering date first so the user will know from which
             # date the computation is done.
             if reordering_date:

--- a/stock_warehouse_calendar_orderpoint/models/stock_warehouse.py
+++ b/stock_warehouse_calendar_orderpoint/models/stock_warehouse.py
@@ -57,6 +57,14 @@ class StockWarehouse(models.Model):
             self = self.with_context(force_wh_company=vals["company_id"])
         return super().create(vals)
 
+    def _get_next_reordering_date(self):
+        self.ensure_one()
+        now = fields.Datetime.now()
+        calendar = self.orderpoint_calendar_id
+        # TODO: should we take into account days off of the reordering calendar with
+        #  'compute_leaves=True' here?
+        return calendar and calendar.plan_hours(0, now) or now
+
     def _get_lead_date(self, date_order, lead_days):
         self.ensure_one()
         # Get the WH calendar

--- a/stock_warehouse_calendar_orderpoint/models/stock_warehouse_orderpoint.py
+++ b/stock_warehouse_calendar_orderpoint/models/stock_warehouse_orderpoint.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
 
-from odoo import api, fields, models
+from odoo import api, models
 
 
 class StockWarehouseOrderpoint(models.Model):
@@ -22,11 +22,11 @@ class StockWarehouseOrderpoint(models.Model):
             if not orderpoint.product_id or not orderpoint.location_id:
                 orderpoint.lead_days_date = False
                 continue
-            # Get the reordering date from the OP calendar
-            reordering_date = orderpoint._get_next_reordering_date()
+            wh = orderpoint.warehouse_id
             # Get the lead days for this orderpoint
             lead_days = orderpoint._get_lead_days()
-            wh = orderpoint.warehouse_id
+            # Get the reordering date from the OP calendar
+            reordering_date = wh._get_next_reordering_date()
             # Compute the lead_days_date, according to the calendar
             orderpoint.lead_days_date = wh._get_lead_date(reordering_date, lead_days)
 
@@ -34,14 +34,6 @@ class StockWarehouseOrderpoint(models.Model):
         self.ensure_one()
         lead_days, __ = self.rule_ids._get_lead_days(self.product_id)
         return lead_days
-
-    def _get_next_reordering_date(self):
-        self.ensure_one()
-        now = fields.Datetime.now()
-        calendar = self.warehouse_id.orderpoint_calendar_id
-        # TODO: should we take into account days off of the reordering calendar with
-        #  'compute_leaves=True' here?
-        return calendar and calendar.plan_hours(0, now) or now
 
     @api.depends("rule_ids", "product_id.seller_ids", "product_id.seller_ids.delay")
     def _compute_json_popover(self):

--- a/stock_warehouse_calendar_orderpoint/models/stock_warehouse_orderpoint.py
+++ b/stock_warehouse_calendar_orderpoint/models/stock_warehouse_orderpoint.py
@@ -35,6 +35,11 @@ class StockWarehouseOrderpoint(models.Model):
         lead_days, __ = self.rule_ids._get_lead_days(self.product_id)
         return lead_days
 
+    # DEPRECATED
+    def _get_next_reordering_date(self):
+        self.ensure_one()
+        return self.warehouse_id._get_next_reordering_date()
+
     @api.depends("rule_ids", "product_id.seller_ids", "product_id.seller_ids.delay")
     def _compute_json_popover(self):
         # Overridden to send the OP ID to 'stock.rule._get_lead_days()'

--- a/stock_warehouse_calendar_orderpoint/tests/test_orderpoint_lead_days_date.py
+++ b/stock_warehouse_calendar_orderpoint/tests/test_orderpoint_lead_days_date.py
@@ -41,7 +41,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_00_monday_with_orderpoint_calendar_set(self):
         self.wh.orderpoint_calendar_id = self.reordering_calendar
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-03 08:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-03 08:00:00"
         )
         self._test_with_values(
             self.reordering_calendar,
@@ -71,7 +71,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_01_monday_with_orderpoint_calendar_unset(self):
         self.wh.orderpoint_calendar_id = False
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-01 12:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-01 12:00:00"
         )
         self._test_with_values(
             False, self.working_hours_calendar, "skip_to_first_workday", 6, "2024-04-08"
@@ -89,7 +89,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_02_wednesday_with_orderpoint_calendar_set_before_first_slot(self):
         self.wh.orderpoint_calendar_id = self.reordering_calendar
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-03 08:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-03 08:00:00"
         )
         self._test_with_values(
             self.reordering_calendar,
@@ -119,7 +119,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_03_wednesday_with_orderpoint_calendar_set_during_first_slot(self):
         self.wh.orderpoint_calendar_id = self.reordering_calendar
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-03 10:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-03 10:00:00"
         )
         self._test_with_values(
             self.reordering_calendar,
@@ -149,7 +149,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_04_wednesday_with_orderpoint_calendar_set_between_slots(self):
         self.wh.orderpoint_calendar_id = self.reordering_calendar
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-03 13:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-03 13:00:00"
         )
         self._test_with_values(
             self.reordering_calendar,
@@ -179,7 +179,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_05_wednesday_with_orderpoint_calendar_set_during_second_slot(self):
         self.wh.orderpoint_calendar_id = self.reordering_calendar
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-03 15:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-03 15:00:00"
         )
         self._test_with_values(
             self.reordering_calendar,
@@ -209,7 +209,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_06_wednesday_with_orderpoint_calendar_set_after_second_slot(self):
         self.wh.orderpoint_calendar_id = self.reordering_calendar
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-06 13:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-06 13:00:00"
         )
         self._test_with_values(
             self.reordering_calendar,
@@ -239,7 +239,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_07_wednesday_with_orderpoint_calendar_unset(self):
         self.wh.orderpoint_calendar_id = False
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-03 12:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-03 12:00:00"
         )
         self._test_with_values(
             False, self.working_hours_calendar, "skip_to_first_workday", 4, "2024-04-08"
@@ -257,7 +257,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_08_saturday_with_orderpoint_calendar_set_before_slot(self):
         self.wh.orderpoint_calendar_id = self.reordering_calendar
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-06 13:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-06 13:00:00"
         )
         self._test_with_values(
             self.reordering_calendar,
@@ -287,7 +287,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_09_saturday_with_orderpoint_calendar_set_during_slot(self):
         self.wh.orderpoint_calendar_id = self.reordering_calendar
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-06 15:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-06 15:00:00"
         )
         self._test_with_values(
             self.reordering_calendar,
@@ -317,7 +317,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_10_saturday_with_orderpoint_calendar_set_after_slot(self):
         self.wh.orderpoint_calendar_id = self.reordering_calendar
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-10 08:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-10 08:00:00"
         )
         self._test_with_values(
             self.reordering_calendar,
@@ -347,7 +347,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_11_saturday_with_orderpoint_calendar_unset(self):
         self.wh.orderpoint_calendar_id = False
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-06 12:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-06 12:00:00"
         )
         self._test_with_values(
             False, self.working_hours_calendar, "skip_to_first_workday", 7, "2024-04-15"
@@ -365,7 +365,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_12_sunday_with_orderpoint_calendar_set(self):
         self.wh.orderpoint_calendar_id = self.reordering_calendar
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-10 08:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-10 08:00:00"
         )
         self._test_with_values(
             self.reordering_calendar,
@@ -395,7 +395,7 @@ class TestOrderpointLeadDaysDate(CommonCalendarOrderpoint):
     def test_13_sunday_with_orderpoint_calendar_unset(self):
         self.wh.orderpoint_calendar_id = False
         self.assertEqual(
-            str(self.orderpoint._get_next_reordering_date()), "2024-04-07 12:00:00"
+            str(self.wh._get_next_reordering_date()), "2024-04-07 12:00:00"
         )
         self._test_with_values(
             False, self.working_hours_calendar, "skip_to_first_workday", 7, "2024-04-15"


### PR DESCRIPTION
Method is related to the Warehouse, not the Replenishment line.

It is private method, we don't have to preserve the old method.