### PR TITLE
[16.0][FIX] stock_picking_volume: volume not computed on record creation

### DIFF
--- a/stock_picking_volume/models/stock_move.py
+++ b/stock_picking_volume/models/stock_move.py
@@ -10,10 +10,8 @@ class StockMove(models.Model):
 
     volume = fields.Float(
         compute="_compute_volume",
-        readonly=False,
         store=True,
         compute_sudo=True,
-        states={"done": [("readonly", True)], "cancel": [("readonly", True)]},
     )
 
     volume_uom_name = fields.Char(

--- a/stock_picking_volume/models/stock_picking.py
+++ b/stock_picking_volume/models/stock_picking.py
@@ -10,10 +10,8 @@ class StockPicking(models.Model):
 
     volume = fields.Float(
         compute="_compute_volume",
-        readonly=False,
         store=True,
         compute_sudo=True,
-        states={"done": [("readonly", True)], "cancel": [("readonly", True)]},
     )
     volume_uom_name = fields.Char(
         string="Volume unit of measure label", compute="_compute_volume_uom_name"

--- a/stock_picking_volume/views/stock_move.xml
+++ b/stock_picking_volume/views/stock_move.xml
@@ -11,7 +11,11 @@
                 <field name="location_dest_id" position="after">
                     <label for="volume" />
                     <div>
-                        <field name="volume" class="oe_inline" />
+                        <field
+                        name="volume"
+                        class="oe_inline"
+                        attrs="{'readonly': [('state', 'in', ['done', 'cancel'])]}"
+                    />
                         <field
                         name="volume_uom_name"
                         nolabel="1"

--- a/stock_picking_volume/views/stock_picking.xml
+++ b/stock_picking_volume/views/stock_picking.xml
@@ -12,7 +12,11 @@
                 <group name='logistics_data' string="Logistics">
                     <label for="volume" />
                     <div>
-                        <field name="volume" class="oe_inline" />
+                        <field
+                            name="volume"
+                            class="oe_inline"
+                            attrs="{'readonly': [('state', 'in', ['done', 'cancel'])]}"
+                        />
                         <field
                             name="volume_uom_name"
                             nolabel="1"


### PR DESCRIPTION
- Volume field was not computed when creating pickings/moves from the UI
- Root cause: `readonly=False` on a stored computed field causes the ORM to treat the explicit `0` sent by the web client as a manual override, skipping recompute
- Removed `readonly=False` and `states` from Python field definitions
- Moved readonly logic to XML views via `attrs` (editable in draft, readonly in done/cancel)