### PR TITLE
[IMP] stock_location_release_channel_restriction: Check a zone of locations

### DIFF
--- a/stock_location_release_channel_restriction/README.rst
+++ b/stock_location_release_channel_restriction/README.rst
@@ -70,7 +70,32 @@ Configuration
 Usage
 =====
 
+- When transferring stock movements with assigned release channel to a
+  location where the restriction feature is enabled, the next moves
+  should have the same release channel in order to be allowed to be
+  transferred.
 
+- When the last movement that restrict the location to a particular
+  release channel has left the location, the release channel is removed
+  on the location and all locations that belong to the same family and
+  restriction:
+
+  ::
+
+                                Output (No restriction)
+           OUTPUT CASE 1 (Restriction)                                      OUTPUT CASE 2 (Restriction)
+
+  CASE A (Restriction) CASE B (Restriction) CASE C (R) CASE D
+  (Restriction)
+
+  So, when an outgoing move is leaving the CASE A, the release channel
+  restriction is removed from CASE B and CASE C too if no outgoing move
+  is waiting in those locations
+
+- To remove the restriction on some locations, select them in the list
+  view and click on 'Remove Release Channel' action. It will force the
+  restriction removal. If you select the 'Reset Family' option, the
+  behaviour described here above is applied too.
 
 Bug Tracker
 ===========

--- a/stock_location_release_channel_restriction/README.rst
+++ b/stock_location_release_channel_restriction/README.rst
@@ -66,10 +66,6 @@ Configuration
 - If you want to apply that restriction only on some specific locations,
   check the 'Specific Release Channel Restriction'. It won't be applied
   on children locations.
-- If you want to take into account all pending incoming operations in
-  that location too, check the 'Release Channel Restriction For Incoming
-  Moves' box too (that appears only if 'mixed' restriction is not
-  selected above).
 
 Usage
 =====

--- a/stock_location_release_channel_restriction/__init__.py
+++ b/stock_location_release_channel_restriction/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/stock_location_release_channel_restriction/__manifest__.py
+++ b/stock_location_release_channel_restriction/__manifest__.py
@@ -11,7 +11,9 @@
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "maintainers": ["rousseldenis"],
     "depends": [
+        "base_partition",
         "stock_location_pending_move",
+        "stock_location_children",
         "stock_picking_delivery_link",
         "stock_release_channel",
     ],

--- a/stock_location_release_channel_restriction/__manifest__.py
+++ b/stock_location_release_channel_restriction/__manifest__.py
@@ -12,6 +12,7 @@
     "maintainers": ["rousseldenis"],
     "depends": [
         "stock_location_pending_move",
+        "stock_picking_delivery_link",
         "stock_release_channel",
     ],
     "data": [

--- a/stock_location_release_channel_restriction/__manifest__.py
+++ b/stock_location_release_channel_restriction/__manifest__.py
@@ -18,6 +18,8 @@
         "stock_release_channel",
     ],
     "data": [
+        "security/security.xml",
         "views/stock_location.xml",
+        "wizards/stock_location_reset_channel.xml",
     ],
 }

--- a/stock_location_release_channel_restriction/models/exception.py
+++ b/stock_location_release_channel_restriction/models/exception.py
@@ -10,7 +10,12 @@ from odoo.addons.stock_release_channel.models.stock_release_channel import (
 )
 
 
-class ReleaseChannelLocationRestrictionError(ValidationError):
+class ReleaseChannelRestrictionError(ValidationError):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class ReleaseChannelLocationPickingRestrictionError(ReleaseChannelRestrictionError):
     def __init__(
         self,
         picking: Picking,
@@ -28,6 +33,31 @@ class ReleaseChannelLocationRestrictionError(ValidationError):
             "and/or pending incoming moves for "
             "%(incoming_channel_names)s.",
             picking_name=picking.name,
+            location_name=location.name,
+            incoming_channel_names=", ".join(
+                incoming_channel.name for incoming_channel in incoming_channels
+            ),
+            release_channel_name=(
+                channel.name if channel else _("Undefined")
+            ),  # Pending moves with no release channel can be contained in location
+        )
+        super().__init__(error_msg)
+
+
+class ReleaseChannelLocationRestrictionError(ReleaseChannelRestrictionError):
+    def __init__(
+        self,
+        location: Location,
+        incoming_channels: StockReleaseChannel,
+        channel: StockReleaseChannel,
+        env,
+    ):
+        self.env = env
+        error_msg = _(
+            "The location %(location_name)s is already restricted to "
+            "%(release_channel_name)s release channel "
+            "and you try to modify it to "
+            "%(incoming_channel_names)s.",
             location_name=location.name,
             incoming_channel_names=", ".join(
                 incoming_channel.name for incoming_channel in incoming_channels

--- a/stock_location_release_channel_restriction/models/stock_location.py
+++ b/stock_location_release_channel_restriction/models/stock_location.py
@@ -88,7 +88,10 @@ class StockLocation(models.Model):
         """
         This will compute the current release channel that
         """
-        for location in self:
+        locations_with_restriction = self.filtered(
+            lambda location: location.release_channel_restriction == "same"
+        )
+        for location in locations_with_restriction:
             # Get all locations related to this one
             # (same parent with "same" restriction)
             parent = self._get_first_ancestor_with_same_restriction()
@@ -98,6 +101,9 @@ class StockLocation(models.Model):
             )
 
             location.current_release_channel_restriction_id = release_channel_id
+        (
+            self - locations_with_restriction
+        ).current_release_channel_restriction_id = False
 
     @api.depends(
         "specific_release_channel_restriction", "parent_release_channel_restriction"

--- a/stock_location_release_channel_restriction/models/stock_location.py
+++ b/stock_location_release_channel_restriction/models/stock_location.py
@@ -147,7 +147,8 @@ class StockLocation(models.Model):
                 family_locations = self.browse()
             locations = family_locations | location
             if not (locations.pending_out_move_line_ids - lines) or force:
-                locations.current_release_channel_restriction_id = False
+                # users may not have write access on locations
+                locations.sudo().current_release_channel_restriction_id = False
 
     def action_reset_release_channel(self):
         view_id = self.env.ref(

--- a/stock_location_release_channel_restriction/models/stock_location.py
+++ b/stock_location_release_channel_restriction/models/stock_location.py
@@ -62,13 +62,16 @@ class StockLocation(models.Model):
         This will retrieve all first parent with "same" restriction
         on the recordset.
         """
-        parents = self.search(
-            [
-                ("id", "parent_of", self.ids),
-                ("location_id.release_channel_restriction", "!=", "same"),
-            ]
-        )
-        return parents
+        self.ensure_one()
+        location = self
+        while parent := location.location_id:
+            if (
+                parent.release_channel_restriction == "same"
+                and parent.location_id.release_channel_restriction != "same"
+            ):
+                return parent
+            location = parent
+        return self.browse()
 
     @api.depends(
         "release_channel_restriction",
@@ -79,16 +82,13 @@ class StockLocation(models.Model):
         """
         This will compute the current release channel that
         """
-        parents = self._get_first_ancestor_with_same_restriction()
         for location in self:
-            # Get all locations related to this one (same parent with "same" restriction)
-            family_location_ids = parents.filtered_domain(
-                [("id", "parent_of", location.id)]
-            ).child_ids.filtered(
-                lambda record: record.release_channel_restriction == "same"
-            )
+            # Get all locations related to this one
+            # (same parent with "same" restriction)
+            parent = self._get_first_ancestor_with_same_restriction()
+            family_location_ids = parent.child_ids
             release_channel_id = first(
-                family_location_ids.pending_out_move_line_ids.picking_id.release_channel_id
+                family_location_ids.pending_out_move_line_ids.picking_id.ship_picking_id.release_channel_id
             )
 
             location.current_release_channel_restriction_id = release_channel_id

--- a/stock_location_release_channel_restriction/models/stock_location.py
+++ b/stock_location_release_channel_restriction/models/stock_location.py
@@ -23,12 +23,8 @@ class StockLocation(models.Model):
         compute="_compute_current_release_channel_restriction_id",
         recursive=True,
         store=True,
-    )
-
-    has_release_channel_restriction = fields.Boolean(
-        compute="_compute_has_release_channel_restriction",
-        recursive=True,
-        store=True,
+        help="This is the current release channel that restrict this "
+        "location for future incoming movements.",
     )
 
     release_channel_restriction = fields.Selection(
@@ -46,6 +42,8 @@ class StockLocation(models.Model):
         readonly=True,
         related="location_id.release_channel_restriction",
         recursive=True,
+        help="This field is used to compute recursively the restriction parameter"
+        " from parent hierarchy.",
     )
 
     specific_release_channel_restriction = fields.Selection(
@@ -100,13 +98,6 @@ class StockLocation(models.Model):
             )
 
             location.current_release_channel_restriction_id = release_channel_id
-
-    @api.depends("current_release_channel_restriction_id")
-    def _compute_has_release_channel_restriction(self):
-        for location in self:
-            location.has_release_channel_restriction = bool(
-                location.current_release_channel_restriction_id
-            )
 
     @api.model
     def _selection_release_channel_restriction(self):

--- a/stock_location_release_channel_restriction/models/stock_location.py
+++ b/stock_location_release_channel_restriction/models/stock_location.py
@@ -1,6 +1,6 @@
 # Copyright 2024 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.fields import first
 
 RELEASE_RESTRICTION = [
@@ -98,25 +98,6 @@ class StockLocation(models.Model):
             )
 
             location.current_release_channel_restriction_id = release_channel_id
-
-    @api.model
-    def _selection_release_channel_restriction(self):
-        return [
-            (
-                "mixed",
-                _(
-                    "Movements of different release channels are allowed "
-                    "into the location"
-                ),
-            ),
-            (
-                "same",
-                _(
-                    "Only movements of the same release channel are "
-                    "allowed into the location"
-                ),
-            ),
-        ]
 
     @api.depends(
         "specific_release_channel_restriction", "parent_release_channel_restriction"

--- a/stock_location_release_channel_restriction/models/stock_location.py
+++ b/stock_location_release_channel_restriction/models/stock_location.py
@@ -1,7 +1,12 @@
 # Copyright 2024 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
-from odoo.fields import first
+
+from odoo.addons.stock_release_channel.models.stock_release_channel import (
+    StockReleaseChannel,
+)
+
+from .exception import ReleaseChannelLocationRestrictionError
 
 RELEASE_RESTRICTION = [
     (
@@ -20,9 +25,6 @@ class StockLocation(models.Model):
 
     current_release_channel_restriction_id = fields.Many2one(
         comodel_name="stock.release.channel",
-        compute="_compute_current_release_channel_restriction_id",
-        recursive=True,
-        store=True,
         help="This is the current release channel that restrict this "
         "location for future incoming movements.",
     )
@@ -52,14 +54,19 @@ class StockLocation(models.Model):
         help="If specified the restriction specified will apply to "
         "the current location and all its children",
     )
-    release_channel_restriction_in_move = fields.Boolean(
-        string="Release Channel Restriction For Incoming Moves",
-        help=(
-            "Check this box if you want to take into account all pending "
-            "incoming movements to restrict the future movements to be "
-            "in the same release channel."
-        ),
-    )
+
+    def _set_release_channel_restriction_family(
+        self, release_channel: StockReleaseChannel
+    ):
+        for location in self:
+            parent = location._get_first_ancestor_with_same_restriction()
+            parent.children_ids.filtered(
+                lambda child: child.release_channel_restriction == "same"
+            ).sudo().write(
+                {
+                    "current_release_channel_restriction_id": release_channel.id,
+                }
+            )
 
     def _get_first_ancestor_with_same_restriction(self):
         """
@@ -78,34 +85,6 @@ class StockLocation(models.Model):
         return self.browse()
 
     @api.depends(
-        "location_id.release_channel_restriction",
-        "release_channel_restriction",
-        "pending_in_move_line_ids",
-        "pending_out_move_line_ids",
-        "location_id.current_release_channel_restriction_id",
-    )
-    def _compute_current_release_channel_restriction_id(self):
-        """
-        This will compute the current release channel that
-        """
-        locations_with_restriction = self.filtered(
-            lambda location: location.release_channel_restriction == "same"
-        )
-        for location in locations_with_restriction:
-            # Get all locations related to this one
-            # (same parent with "same" restriction)
-            parent = self._get_first_ancestor_with_same_restriction()
-            family_location_ids = parent.child_ids
-            release_channel_id = first(
-                family_location_ids.pending_out_move_line_ids.picking_id.ship_picking_id.release_channel_id
-            )
-
-            location.current_release_channel_restriction_id = release_channel_id
-        (
-            self - locations_with_restriction
-        ).current_release_channel_restriction_id = False
-
-    @api.depends(
         "specific_release_channel_restriction", "parent_release_channel_restriction"
     )
     def _compute_release_channel_restriction(self):
@@ -116,3 +95,27 @@ class StockLocation(models.Model):
                 or rec.parent_release_channel_restriction
                 or default_value
             )
+
+    def write(self, vals):
+        if "current_release_channel_restriction_id" in vals and bool(
+            vals.get("current_release_channel_restriction_id")
+        ):
+            channel = self.env["stock.release.channel"].browse(
+                vals.get("current_release_channel_restriction_id")
+            )
+            self._check_current_release_channel_restriction(channel)
+        return super().write(vals)
+
+    def _check_current_release_channel_restriction(self, release_channel):
+        locations_to_check = self.filtered(
+            lambda location: location.release_channel_restriction == "same"
+            and location.current_release_channel_restriction_id
+        )
+        for location in locations_to_check:
+            if location.current_release_channel_restriction_id != release_channel:
+                raise ReleaseChannelLocationRestrictionError(
+                    location=location,
+                    channel=location.current_release_channel_restriction_id,
+                    incoming_channels=release_channel,
+                    env=self.env,
+                )

--- a/stock_location_release_channel_restriction/models/stock_location.py
+++ b/stock_location_release_channel_restriction/models/stock_location.py
@@ -1,7 +1,7 @@
 # Copyright 2024 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from odoo import _, api, fields, models
+from odoo.fields import first
 
 RELEASE_RESTRICTION = [
     (
@@ -17,6 +17,12 @@ RELEASE_RESTRICTION = [
 
 class StockLocation(models.Model):
     _inherit = "stock.location"
+
+    current_release_channel_restriction_id = fields.Many2one(
+        comodel_name="stock.release.channel",
+        compute="_compute_current_release_channel_restriction_id",
+        recursive=True,
+    )
 
     release_channel_restriction = fields.Selection(
         selection=RELEASE_RESTRICTION,
@@ -50,6 +56,42 @@ class StockLocation(models.Model):
             "in the same release channel."
         ),
     )
+
+    def _get_first_ancestor_with_same_restriction(self):
+        """
+        This will retrieve all first parent with "same" restriction
+        on the recordset.
+        """
+        parents = self.search(
+            [
+                ("id", "parent_of", self.ids),
+                ("location_id.release_channel_restriction", "!=", "same"),
+            ]
+        )
+        return parents
+
+    @api.depends(
+        "release_channel_restriction",
+        "pending_in_move_line_ids",
+        "pending_out_move_line_ids",
+    )
+    def _compute_current_release_channel_restriction_id(self):
+        """
+        This will compute the current release channel that
+        """
+        parents = self._get_first_ancestor_with_same_restriction()
+        for location in self:
+            # Get all locations related to this one (same parent with "same" restriction)
+            family_location_ids = parents.filtered_domain(
+                [("id", "parent_of", location.id)]
+            ).child_ids.filtered(
+                lambda record: record.release_channel_restriction == "same"
+            )
+            release_channel_id = first(
+                family_location_ids.pending_out_move_line_ids.picking_id.release_channel_id
+            )
+
+            location.current_release_channel_restriction_id = release_channel_id
 
     @api.model
     def _selection_release_channel_restriction(self):

--- a/stock_location_release_channel_restriction/models/stock_location.py
+++ b/stock_location_release_channel_restriction/models/stock_location.py
@@ -1,7 +1,9 @@
 # Copyright 2024 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.fields import Command
 
+from odoo.addons.stock.models.stock_move_line import StockMoveLine
 from odoo.addons.stock_release_channel.models.stock_release_channel import (
     StockReleaseChannel,
 )
@@ -59,7 +61,7 @@ class StockLocation(models.Model):
         self, release_channel: StockReleaseChannel
     ):
         for location in self:
-            parent = location._get_first_ancestor_with_same_restriction()
+            parent = location._get_first_ancestor_with_same_channel_restriction()
             parent.children_ids.filtered(
                 lambda child: child.release_channel_restriction == "same"
             ).sudo().write(
@@ -68,7 +70,7 @@ class StockLocation(models.Model):
                 }
             )
 
-    def _get_first_ancestor_with_same_restriction(self):
+    def _get_first_ancestor_with_same_channel_restriction(self):
         """
         This will retrieve all first parent with "same" restriction
         on the recordset.
@@ -119,3 +121,46 @@ class StockLocation(models.Model):
                     incoming_channels=release_channel,
                     env=self.env,
                 )
+
+    def _remove_current_release_channel_restriction(
+        self, lines: StockMoveLine | None = None, force=False, family=True
+    ):
+        """
+            This will remove the current release channel restriction on locations.
+
+        Args:
+            lines (_type_, optional): The stock move lines to not take into account.
+            force (bool, optional): Force the removal on self recordset.
+            family (bool, optional): Remove the release channel on family locations too.
+        """
+        if lines is None:
+            lines = self.env["stock.move.line"].browse()
+        for location in self:
+            # Remove it if no family location has pending outgoing moves
+            parent = location._get_first_ancestor_with_same_channel_restriction()
+            if family:
+                family_locations = parent.children_ids.filtered(
+                    lambda child: child.release_channel_restriction == "same"
+                )
+            else:
+                family_locations = self.browse()
+            locations = family_locations | location
+            if not (locations.pending_out_move_line_ids - lines) or force:
+                locations.current_release_channel_restriction_id = False
+
+    def action_reset_release_channel(self):
+        view_id = self.env.ref(
+            "stock_location_release_channel_restriction.stock_location_reset_release_channel_form_view"
+        ).id
+        return {
+            "name": _("Reset Release Channel"),
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "res_model": "stock.location.reset.release.channel",
+            "view_id": view_id,
+            "views": [(view_id, "form")],
+            "target": "new",
+            "context": {
+                "default_location_ids": [Command.set(self.ids)],
+            },
+        }

--- a/stock_location_release_channel_restriction/models/stock_location.py
+++ b/stock_location_release_channel_restriction/models/stock_location.py
@@ -22,13 +22,19 @@ class StockLocation(models.Model):
         comodel_name="stock.release.channel",
         compute="_compute_current_release_channel_restriction_id",
         recursive=True,
+        store=True,
+    )
+
+    has_release_channel_restriction = fields.Boolean(
+        compute="_compute_has_release_channel_restriction",
+        recursive=True,
+        store=True,
     )
 
     release_channel_restriction = fields.Selection(
         selection=RELEASE_RESTRICTION,
         help="If 'same' is selected the system will prevent to put "
         "items of different release channels into the same location.",
-        index=True,
         compute="_compute_release_channel_restriction",
         store=True,
         recursive=True,
@@ -74,9 +80,11 @@ class StockLocation(models.Model):
         return self.browse()
 
     @api.depends(
+        "location_id.release_channel_restriction",
         "release_channel_restriction",
         "pending_in_move_line_ids",
         "pending_out_move_line_ids",
+        "location_id.current_release_channel_restriction_id",
     )
     def _compute_current_release_channel_restriction_id(self):
         """
@@ -92,6 +100,13 @@ class StockLocation(models.Model):
             )
 
             location.current_release_channel_restriction_id = release_channel_id
+
+    @api.depends("current_release_channel_restriction_id")
+    def _compute_has_release_channel_restriction(self):
+        for location in self:
+            location.has_release_channel_restriction = bool(
+                location.current_release_channel_restriction_id
+            )
 
     @api.model
     def _selection_release_channel_restriction(self):

--- a/stock_location_release_channel_restriction/models/stock_location.py
+++ b/stock_location_release_channel_restriction/models/stock_location.py
@@ -27,6 +27,7 @@ class StockLocation(models.Model):
 
     current_release_channel_restriction_id = fields.Many2one(
         comodel_name="stock.release.channel",
+        readonly=True,
         help="This is the current release channel that restrict this "
         "location for future incoming movements.",
     )

--- a/stock_location_release_channel_restriction/models/stock_move_line.py
+++ b/stock_location_release_channel_restriction/models/stock_move_line.py
@@ -94,14 +94,9 @@ class StockMoveLine(models.Model):
             .partition("location_id")
             .items()
         ):
-            # Remove it if no family location has pending outgoing moves
-            parent = location._get_first_ancestor_with_same_restriction()
-            family_locations = parent.children_ids.filtered(
-                lambda child: child.release_channel_restriction == "same"
+            location._remove_current_release_channel_restriction(
+                lines=lines, force=force
             )
-            if not (family_locations.pending_out_move_line_ids - lines) or force:
-                location.current_release_channel_restriction_id = False
-                family_locations.current_release_channel_restriction_id = False
 
     def _action_done(self):
         """

--- a/stock_location_release_channel_restriction/models/stock_move_line.py
+++ b/stock_location_release_channel_restriction/models/stock_move_line.py
@@ -2,81 +2,116 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
 
-from .exception import ReleaseChannelLocationRestrictionError
+from .exception import ReleaseChannelLocationPickingRestrictionError
 
 
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    for_restriction_incoming_location_channel_ids = fields.Many2many(
-        compute="_compute_for_restriction_incoming_location_channel_ids",
-        comodel_name="stock.release.channel",
-        help="Technical field in order to retrieve the release channel of "
-        "pending incoming moves on destination location.",
+    has_location_destination_release_channel_restriction = fields.Boolean(
+        compute="_compute_has_location_destination_release_channel_restriction",
+        help="This is used to easily check if the move line has a restriction "
+        "for currrent destination location on release channel.",
     )
-    for_restriction_destination_location_channel_id = fields.Many2one(
-        compute="_compute_for_restriction_destination_location_channel_id",
-        comodel_name="stock.release.channel",
-        help="Technical field in order to retrieve the release channel of pending moves"
-        "on destination location.",
-    )
-
-    @api.depends(
-        "location_dest_id.pending_in_move_line_ids.picking_id.release_channel_id"
-    )
-    def _compute_for_restriction_incoming_location_channel_ids(self):
-        for line in self:
-            line.for_restriction_incoming_location_channel_ids = line.location_dest_id.pending_in_move_line_ids.picking_id.release_channel_id  # noqa: E501
 
     @api.depends("location_dest_id.current_release_channel_restriction_id")
-    def _compute_for_restriction_destination_location_channel_id(self):
+    def _compute_has_location_destination_release_channel_restriction(self):
+        void_lines = self.browse()
         for line in self:
-            line.for_restriction_destination_location_channel_id = (
+            if line.location_dest_id.release_channel_restriction != "same":
+                void_lines |= line
+                continue
+            channel = line.picking_id.ship_picking_id.release_channel_id
+            current_channel = (
                 line.location_dest_id.current_release_channel_restriction_id
             )
+            if current_channel and current_channel != channel:
+                line.has_location_destination_release_channel_restriction = True
+            else:
+                void_lines |= line
+        if void_lines:
+            void_lines.has_location_destination_release_channel_restriction = False
 
-    @property
-    def _has_incoming_location_release_channel_restriction(self):
-        """
-        For better readability, this will check if incoming operations restriction
-        is applicable
-        """
-        destination_channel = self.for_restriction_destination_location_channel_id
-        in_channel = self.for_restriction_incoming_location_channel_ids
-        return bool(
-            self.location_dest_id.release_channel_restriction_in_move
-            and (
-                len(in_channel) > 1
-                or (destination_channel and in_channel != destination_channel)
-            )
-        )
-
-    @property
-    def _has_destination_location_release_channel_restriction(self):
-        """
-        Check if the destination location has no pending moves
-        with another release channel
-        """
-        self.ensure_one()
-        # We are not sure existing pending moves are not in
-        destination_channel = self.for_restriction_destination_location_channel_id
-        return bool(
-            self.location_dest_id.release_channel_restriction == "same"
-            and (
-                destination_channel
-                and (self.picking_id.release_channel_id != destination_channel)
-                or self._has_incoming_location_release_channel_restriction
-            )
-        )
-
-    def _action_done(self):
+    def _check_location_destination_release_channel_restriction(self) -> None:
         for line in self:
-            if line._has_destination_location_release_channel_restriction:
-                raise ReleaseChannelLocationRestrictionError(
+            if line.has_location_destination_release_channel_restriction:
+                current_channel = (
+                    line.location_dest_id.current_release_channel_restriction_id
+                )
+                raise ReleaseChannelLocationPickingRestrictionError(
                     line.picking_id,
                     line.location_dest_id,
-                    line.for_restriction_incoming_location_channel_ids,
-                    line.for_restriction_destination_location_channel_id,
+                    line.location_dest_id.current_release_channel_restriction_id,
+                    current_channel,
                     line.env,
                 )
+
+    def _valid_location_release_channel_restriction(self, location) -> bool:
+        """
+        Helper method to check if the location can be used as destination
+        for the current moves.
+
+        Return False if not a valid destination location for the line
+        Returns True if valid destination location
+        """
+        self.ensure_one()
+        if location.release_channel_restriction != "same":
+            return True
+
+        if (
+            not location.current_release_channel_restriction_id
+            or self.picking_id.ship_picking_id.release_channel_id
+            == location.current_release_channel_restriction_id
+        ):
+            return True
+        return False
+
+    def _set_release_channel_current_restriction(self):
+        """
+        Set the release channel that restrict the destination locations
+        Set it to the children too
+        """
+        moves_to_restrict = self.filtered(
+            lambda line: line.location_dest_id.release_channel_restriction == "same"
+        )
+        for release_channel, moves in moves_to_restrict.partition(
+            "picking_id.ship_picking_id.release_channel_id"
+        ).items():
+            moves._check_location_destination_release_channel_restriction()
+            # Normal users could not have rights to write on locations
+            moves.location_dest_id.sudo().write(
+                {"current_release_channel_restriction_id": release_channel.id}
+            )
+            moves.location_dest_id._set_release_channel_restriction_family(
+                release_channel
+            )
+
+    def _remove_release_channel_current_restriction(self, force=False):
+        # Group the removal
+        # Check if there is currently a release channel restriction
+        for location, lines in (
+            self.filtered("location_id.current_release_channel_restriction_id")
+            .partition("location_id")
+            .items()
+        ):
+            # Remove it if no family location has pending outgoing moves
+            parent = location._get_first_ancestor_with_same_restriction()
+            family_locations = parent.children_ids.filtered(
+                lambda child: child.release_channel_restriction == "same"
+            )
+            if not (family_locations.pending_out_move_line_ids - lines) or force:
+                location.current_release_channel_restriction_id = False
+                family_locations.current_release_channel_restriction_id = False
+
+    def _action_done(self):
+        """
+        Before setting lines as done, remove the release channel
+        on source location if needed (if all pending moves are done).
+
+        Then, set the release channel on destination location.
+        """
+        # Remove it if needed on location source
+        self._remove_release_channel_current_restriction()
+        # Set the release channel that restricts the locations if needed
+        self._set_release_channel_current_restriction()
         return super()._action_done()

--- a/stock_location_release_channel_restriction/models/stock_move_line.py
+++ b/stock_location_release_channel_restriction/models/stock_move_line.py
@@ -1,7 +1,6 @@
 # Copyright 2024 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
-from odoo.fields import first
 
 from .exception import ReleaseChannelLocationRestrictionError
 
@@ -29,13 +28,11 @@ class StockMoveLine(models.Model):
         for line in self:
             line.for_restriction_incoming_location_channel_ids = line.location_dest_id.pending_in_move_line_ids.picking_id.release_channel_id  # noqa: E501
 
-    @api.depends(
-        "location_dest_id.pending_out_move_line_ids.picking_id.release_channel_id"
-    )
+    @api.depends("location_dest_id.current_release_channel_restriction_id")
     def _compute_for_restriction_destination_location_channel_id(self):
         for line in self:
-            line.for_restriction_destination_location_channel_id = first(
-                line.location_dest_id.pending_out_move_line_ids.picking_id.release_channel_id
+            line.for_restriction_destination_location_channel_id = (
+                line.location_dest_id.current_release_channel_restriction_id
             )
 
     @property

--- a/stock_location_release_channel_restriction/readme/CONFIGURE.md
+++ b/stock_location_release_channel_restriction/readme/CONFIGURE.md
@@ -8,6 +8,3 @@
 - If you want to apply that restriction only on some specific locations,
   check the 'Specific Release Channel Restriction'. It won't be applied
   on children locations.
-- If you want to take into account all pending incoming operations in that 
-  location too, check the 'Release Channel Restriction For Incoming Moves' box too
-  (that appears only if 'mixed' restriction is not selected above).

--- a/stock_location_release_channel_restriction/readme/USAGE.md
+++ b/stock_location_release_channel_restriction/readme/USAGE.md
@@ -1,0 +1,18 @@
+- When transferring stock movements with assigned release channel to a
+  location where the restriction feature is enabled, the next moves should have
+  the same release channel in order to be allowed to be transferred.
+- When the last movement that restrict the location to a particular release channel
+  has left the location, the release channel is removed on the location and all
+  locations that belong to the same family and restriction:
+
+                                 Output (No restriction)
+            OUTPUT CASE 1 (Restriction)                                      OUTPUT CASE 2 (Restriction)
+    CASE A (Restriction)  CASE B (Restriction)  CASE C (R)                        CASE D (Restriction)
+
+
+    So, when an outgoing move is leaving the CASE A, the release channel restriction
+    is removed from CASE B and CASE C too if no outgoing move is waiting in those locations
+- To remove the restriction on some locations, select them in the list view and
+  click on 'Remove Release Channel' action. It will force the restriction removal.
+  If you select the 'Reset Family' option, the behaviour described here above is applied
+  too.

--- a/stock_location_release_channel_restriction/security/security.xml
+++ b/stock_location_release_channel_restriction/security/security.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.model.access" id="stock_location_release_channel_stock_user">
+        <field name="name">Stock Location Reset Release Channel</field>
+        <field
+            name="model_id"
+            ref="stock_location_release_channel_restriction.model_stock_location_reset_release_channel"
+        />
+        <field name="group_id" ref="stock.group_stock_user" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+</odoo>

--- a/stock_location_release_channel_restriction/static/description/index.html
+++ b/stock_location_release_channel_restriction/static/description/index.html
@@ -420,6 +420,32 @@ on children locations.</li>
 </div>
 <div class="section" id="usage">
 <h2><a class="toc-backref" href="#toc-entry-3">Usage</a></h2>
+<ul>
+<li><p class="first">When transferring stock movements with assigned release channel to a
+location where the restriction feature is enabled, the next moves
+should have the same release channel in order to be allowed to be
+transferred.</p>
+</li>
+<li><p class="first">When the last movement that restrict the location to a particular
+release channel has left the location, the release channel is removed
+on the location and all locations that belong to the same family and
+restriction:</p>
+<pre class="literal-block">
+                     Output (No restriction)
+OUTPUT CASE 1 (Restriction)                                      OUTPUT CASE 2 (Restriction)
+</pre>
+<p>CASE A (Restriction) CASE B (Restriction) CASE C (R) CASE D
+(Restriction)</p>
+<p>So, when an outgoing move is leaving the CASE A, the release channel
+restriction is removed from CASE B and CASE C too if no outgoing move
+is waiting in those locations</p>
+</li>
+<li><p class="first">To remove the restriction on some locations, select them in the list
+view and click on ‘Remove Release Channel’ action. It will force the
+restriction removal. If you select the ‘Reset Family’ option, the
+behaviour described here above is applied too.</p>
+</li>
+</ul>
 </div>
 <div class="section" id="bug-tracker">
 <h2><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h2>

--- a/stock_location_release_channel_restriction/static/description/index.html
+++ b/stock_location_release_channel_restriction/static/description/index.html
@@ -416,10 +416,6 @@ parameter will be applied to children locations.</li>
 <li>If you want to apply that restriction only on some specific locations,
 check the ‘Specific Release Channel Restriction’. It won’t be applied
 on children locations.</li>
-<li>If you want to take into account all pending incoming operations in
-that location too, check the ‘Release Channel Restriction For Incoming
-Moves’ box too (that appears only if ‘mixed’ restriction is not
-selected above).</li>
 </ul>
 </div>
 <div class="section" id="usage">

--- a/stock_location_release_channel_restriction/tests/test_release_channel_restriction.py
+++ b/stock_location_release_channel_restriction/tests/test_release_channel_restriction.py
@@ -500,3 +500,66 @@ class TestReleaseChannelRestriction(BaseCommon):
         self.delivery_2._action_done()
         self.assertFalse(self.out_1.current_release_channel_restriction_id)
         self.assertFalse(self.out_2.current_release_channel_restriction_id)
+
+    def test_release_channel_restriction_reset_wizard(self):
+        """
+
+        Assign the channel to the first delivery
+        Transfer the linked picking
+        """
+        self.delivery_1 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.out.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_1.id),
+            ]
+        )
+        self.delivery_1.assign_release_channel()
+        self.assertEqual(self.default_channel, self.delivery_1.release_channel_id)
+        self.picking_1 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_1.id),
+            ]
+        )
+        # Check if destination is valid
+        self.assertTrue(
+            self.picking_1.move_line_ids._valid_location_release_channel_restriction(
+                self.out_1
+            )
+        )
+
+        self.picking_1.move_line_ids.location_dest_id = self.out_1
+        self.picking_1.move_line_ids.qty_done = (
+            self.picking_1.move_line_ids.reserved_qty
+        )
+
+        self.picking_1._action_done()
+        self.assertEqual("done", self.picking_1.state)
+        self.assertTrue(self.out_1.current_release_channel_restriction_id)
+        self.assertTrue(self.out_2.current_release_channel_restriction_id)
+
+        action = self.out_1.action_reset_release_channel()
+        context = action.get("context")
+        wizard = (
+            self.env["stock.location.reset.release.channel"]
+            .with_context(**context)
+            .create({})
+        )
+        wizard.reset()
+        self.assertFalse(self.out_1.current_release_channel_restriction_id)
+        self.assertTrue(self.out_2.current_release_channel_restriction_id)
+
+        wizard = (
+            self.env["stock.location.reset.release.channel"]
+            .with_context(**context)
+            .create(
+                {
+                    "reset_family": True,
+                }
+            )
+        )
+        wizard.reset()
+        self.assertFalse(self.out_1.current_release_channel_restriction_id)
+        self.assertFalse(self.out_2.current_release_channel_restriction_id)

--- a/stock_location_release_channel_restriction/tests/test_release_channel_restriction.py
+++ b/stock_location_release_channel_restriction/tests/test_release_channel_restriction.py
@@ -297,3 +297,55 @@ class TestReleaseChannelRestriction(BaseCommon):
         )
         self.picking_2.release_channel_id = self.default_channel
         self.picking_1._action_done()
+
+    def test_release_channel_restriction_children(self):
+        """
+        Check that a restriction on a location in the same family
+        applies.
+
+                        OUT
+
+                OUT1            OUT2
+        """
+        self.delivery_1 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.out.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_1.id),
+            ]
+        )
+        self.delivery_1.assign_release_channel()
+        self.assertEqual(self.default_channel, self.delivery_1.release_channel_id)
+        self.picking_1 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_1.id),
+            ]
+        )
+
+        self.picking_1.move_line_ids.location_dest_id = self.out_1
+        self.picking_1.move_line_ids.qty_done = (
+            self.picking_1.move_line_ids.reserved_qty
+        )
+
+        self.picking_1._action_done()
+        self.assertEqual("done", self.picking_1.state)
+
+        self.assertEqual("assigned", self.delivery_1.state)
+
+        self.picking_2 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_2.id),
+            ]
+        )
+        # Use another sub-location
+        self.picking_2.move_line_ids.location_dest_id = self.out_2
+        self.picking_2.move_line_ids.qty_done = (
+            self.picking_2.move_line_ids.reserved_qty
+        )
+
+        with self.assertRaises(ReleaseChannelLocationRestrictionError):
+            self.picking_2._action_done()

--- a/stock_location_release_channel_restriction/tests/test_release_channel_restriction.py
+++ b/stock_location_release_channel_restriction/tests/test_release_channel_restriction.py
@@ -4,7 +4,10 @@ from odoo.fields import Command
 
 from odoo.addons.base.tests.common import BaseCommon
 
-from ..models.exception import ReleaseChannelLocationRestrictionError
+from ..models.exception import (
+    ReleaseChannelLocationPickingRestrictionError,
+    ReleaseChannelLocationRestrictionError,
+)
 
 
 class TestReleaseChannelRestriction(BaseCommon):
@@ -126,6 +129,12 @@ class TestReleaseChannelRestriction(BaseCommon):
                 ("group_id", "=", self.group_1.id),
             ]
         )
+        # Check if destination is valid
+        self.assertTrue(
+            self.picking_1.move_line_ids._valid_location_release_channel_restriction(
+                self.out_1
+            )
+        )
 
         self.picking_1.move_line_ids.location_dest_id = self.out_1
         self.picking_1.move_line_ids.qty_done = (
@@ -134,6 +143,74 @@ class TestReleaseChannelRestriction(BaseCommon):
 
         self.picking_1._action_done()
         self.assertEqual("done", self.picking_1.state)
+        self.assertTrue(self.out_1.current_release_channel_restriction_id)
+
+        self.assertEqual("assigned", self.delivery_1.state)
+
+        self.picking_2 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_2.id),
+            ]
+        )
+        # Check if destination is valid
+        self.assertFalse(
+            self.picking_2.move_line_ids._valid_location_release_channel_restriction(
+                self.out_1
+            )
+        )
+
+        # Do it anyway
+        self.picking_2.move_line_ids.location_dest_id = self.out_1
+        self.picking_2.move_line_ids.qty_done = (
+            self.picking_2.move_line_ids.reserved_qty
+        )
+
+        with self.assertRaises(ReleaseChannelLocationPickingRestrictionError):
+            self.picking_2._action_done()
+
+    def test_release_channel_restriction_removal(self):
+        """
+
+        Assign the channel to both deliveries
+        Transfer the linked picking
+        """
+        self.delivery_1 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.out.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_1.id),
+            ]
+        )
+        self.delivery_1.assign_release_channel()
+        self.assertEqual(self.default_channel, self.delivery_1.release_channel_id)
+
+        self.delivery_2 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.out.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_2.id),
+            ]
+        )
+        self.delivery_2.assign_release_channel()
+        self.assertEqual(self.default_channel, self.delivery_2.release_channel_id)
+        self.picking_1 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_1.id),
+            ]
+        )
+
+        self.picking_1.move_line_ids.location_dest_id = self.out_1
+        self.picking_1.move_line_ids.qty_done = (
+            self.picking_1.move_line_ids.reserved_qty
+        )
+
+        self.picking_1._action_done()
+        self.assertEqual("done", self.picking_1.state)
+        self.assertTrue(self.out_1.current_release_channel_restriction_id)
 
         self.assertEqual("assigned", self.delivery_1.state)
 
@@ -149,8 +226,24 @@ class TestReleaseChannelRestriction(BaseCommon):
             self.picking_2.move_line_ids.reserved_qty
         )
 
-        with self.assertRaises(ReleaseChannelLocationRestrictionError):
-            self.picking_2._action_done()
+        self.picking_2._action_done()
+
+        self.delivery_1.move_line_ids.qty_done = (
+            self.delivery_1.move_line_ids.reserved_qty
+        )
+        self.delivery_1._action_done()
+
+        # Check the release channel still restricts the out
+        self.assertEqual(
+            self.default_channel, self.out_1.current_release_channel_restriction_id
+        )
+
+        # Do the second delivery
+        self.delivery_2.move_line_ids.qty_done = (
+            self.delivery_2.move_line_ids.reserved_qty
+        )
+        self.delivery_2._action_done()
+        self.assertFalse(self.out_1.current_release_channel_restriction_id)
 
     def test_release_channel_no_restriction(self):
         """
@@ -199,104 +292,7 @@ class TestReleaseChannelRestriction(BaseCommon):
         )
 
         self.picking_2._action_done()
-
-    def test_release_channel_restriction_pending_incoming(self):
-        """
-
-        Assign the channel to the first delivery
-        Transfer the linked picking
-        """
-        self.out_1.release_channel_restriction_in_move = True
-        self.delivery_1 = self.env["stock.picking"].search(
-            [
-                ("move_ids.location_id", "=", self.out.id),
-                ("product_id", "=", self.product.id),
-                ("group_id", "=", self.group_1.id),
-            ]
-        )
-        self.delivery_1.assign_release_channel()
-        self.assertEqual(self.default_channel, self.delivery_1.release_channel_id)
-        self.picking_1 = self.env["stock.picking"].search(
-            [
-                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
-                ("product_id", "=", self.product.id),
-                ("group_id", "=", self.group_1.id),
-            ]
-        )
-        self.picking_1.release_channel_id = self.default_channel
-        self.picking_1.move_line_ids.location_dest_id = self.out_1
-        self.picking_1.move_line_ids.qty_done = (
-            self.picking_1.move_line_ids.reserved_qty
-        )
-
-        # Set the second delivery in the second channel
-        self.delivery_2 = self.env["stock.picking"].search(
-            [
-                ("move_ids.location_id", "=", self.out.id),
-                ("product_id", "=", self.product.id),
-                ("group_id", "=", self.group_2.id),
-            ]
-        )
-        self.delivery_2.release_channel_id = self.channel_2
-        self.picking_2 = self.env["stock.picking"].search(
-            [
-                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
-                ("product_id", "=", self.product.id),
-                ("group_id", "=", self.group_2.id),
-            ]
-        )
-        self.picking_2.release_channel_id = self.channel_2
-
-        with self.assertRaises(ReleaseChannelLocationRestrictionError):
-            self.picking_1._action_done()
-
-    def test_release_channel_restriction_pending_incoming_done(self):
-        """
-        Set both deliveries and pickings in same channel
-        Transfer the first picking
-        No error should be raised
-        """
-        self.out_1.release_channel_restriction_in_move = True
-        self.delivery_1 = self.env["stock.picking"].search(
-            [
-                ("move_ids.location_id", "=", self.out.id),
-                ("product_id", "=", self.product.id),
-                ("group_id", "=", self.group_1.id),
-            ]
-        )
-        self.delivery_1.assign_release_channel()
-        self.assertEqual(self.default_channel, self.delivery_1.release_channel_id)
-        self.picking_1 = self.env["stock.picking"].search(
-            [
-                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
-                ("product_id", "=", self.product.id),
-                ("group_id", "=", self.group_1.id),
-            ]
-        )
-        self.picking_1.release_channel_id = self.default_channel
-        self.picking_1.move_line_ids.location_dest_id = self.out_1
-        self.picking_1.move_line_ids.qty_done = (
-            self.picking_1.move_line_ids.reserved_qty
-        )
-
-        # Set the second delivery in the second channel
-        self.delivery_2 = self.env["stock.picking"].search(
-            [
-                ("move_ids.location_id", "=", self.out.id),
-                ("product_id", "=", self.product.id),
-                ("group_id", "=", self.group_2.id),
-            ]
-        )
-        self.delivery_2.release_channel_id = self.default_channel
-        self.picking_2 = self.env["stock.picking"].search(
-            [
-                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
-                ("product_id", "=", self.product.id),
-                ("group_id", "=", self.group_2.id),
-            ]
-        )
-        self.picking_2.release_channel_id = self.default_channel
-        self.picking_1._action_done()
+        self.assertFalse(self.out_1.current_release_channel_restriction_id)
 
     def test_release_channel_restriction_children(self):
         """
@@ -347,5 +343,160 @@ class TestReleaseChannelRestriction(BaseCommon):
             self.picking_2.move_line_ids.reserved_qty
         )
 
-        with self.assertRaises(ReleaseChannelLocationRestrictionError):
+        with self.assertRaises(ReleaseChannelLocationPickingRestrictionError):
             self.picking_2._action_done()
+
+    def test_release_channel_restriction_family_different(self):
+        """
+        Check that a restriction on a location in the same family
+        applies with a different channel on the brother.
+
+                        OUT
+
+                OUT1            OUT2
+        """
+
+        self.delivery_1 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.out.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_1.id),
+            ]
+        )
+        self.delivery_1.assign_release_channel()
+        self.assertEqual(self.default_channel, self.delivery_1.release_channel_id)
+        self.picking_1 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_1.id),
+            ]
+        )
+
+        self.picking_1.move_line_ids.location_dest_id = self.out_1
+        self.picking_1.move_line_ids.qty_done = (
+            self.picking_1.move_line_ids.reserved_qty
+        )
+
+        self.picking_1._action_done()
+        self.assertEqual("done", self.picking_1.state)
+
+        self.assertEqual("assigned", self.delivery_1.state)
+
+        self.channel_2 = self.env["stock.release.channel"].create(
+            {
+                "name": "CH 2",
+            }
+        )
+
+        with self.assertRaises(ReleaseChannelLocationRestrictionError):
+            self.out_2.current_release_channel_restriction_id = self.channel_2
+
+        self.delivery_2 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.out.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_2.id),
+            ]
+        )
+        self.delivery_2.release_channel_id = self.channel_2
+        self.picking_2 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_2.id),
+            ]
+        )
+
+        self.picking_2.move_line_ids.location_dest_id = self.out_2
+        self.picking_2.move_line_ids.qty_done = (
+            self.picking_2.move_line_ids.reserved_qty
+        )
+
+        with self.assertRaises(ReleaseChannelLocationPickingRestrictionError):
+            self.picking_2._action_done()
+
+    def test_remove_release_channel_restriction_family_different(self):
+        """
+        Check the restriction is removed after all pending moves are done.
+
+                        OUT
+
+                OUT1            OUT2
+        """
+
+        self.delivery_1 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.out.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_1.id),
+            ]
+        )
+        self.delivery_1.assign_release_channel()
+        self.assertEqual(self.default_channel, self.delivery_1.release_channel_id)
+        self.picking_1 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_1.id),
+            ]
+        )
+
+        self.picking_1.move_line_ids.location_dest_id = self.out_1
+        self.picking_1.move_line_ids.qty_done = (
+            self.picking_1.move_line_ids.reserved_qty
+        )
+
+        self.picking_1._action_done()
+        self.assertEqual("done", self.picking_1.state)
+
+        self.assertEqual("assigned", self.delivery_1.state)
+
+        # Check the OUT 2 is also restricted
+        self.assertEqual(
+            self.default_channel, self.out_2.current_release_channel_restriction_id
+        )
+
+        self.delivery_2 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.out.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_2.id),
+            ]
+        )
+        self.delivery_2.assign_release_channel()
+        self.assertEqual(self.default_channel, self.delivery_2.release_channel_id)
+
+        self.picking_2 = self.env["stock.picking"].search(
+            [
+                ("move_ids.location_id", "=", self.warehouse.lot_stock_id.id),
+                ("product_id", "=", self.product.id),
+                ("group_id", "=", self.group_2.id),
+            ]
+        )
+
+        self.picking_2.move_line_ids.location_dest_id = self.out_2
+        self.picking_2.move_line_ids.qty_done = (
+            self.picking_2.move_line_ids.reserved_qty
+        )
+        self.picking_2._action_done()
+
+        # Deliver the first picking
+        self.delivery_1.move_line_ids.qty_done = (
+            self.delivery_1.move_line_ids.reserved_qty
+        )
+        self.delivery_1._action_done()
+
+        self.assertEqual(
+            self.default_channel, self.out_1.current_release_channel_restriction_id
+        )
+        self.assertEqual(
+            self.default_channel, self.out_2.current_release_channel_restriction_id
+        )
+
+        self.delivery_2.move_line_ids.qty_done = (
+            self.delivery_2.move_line_ids.reserved_qty
+        )
+        self.delivery_2._action_done()
+        self.assertFalse(self.out_1.current_release_channel_restriction_id)
+        self.assertFalse(self.out_2.current_release_channel_restriction_id)

--- a/stock_location_release_channel_restriction/views/stock_location.xml
+++ b/stock_location_release_channel_restriction/views/stock_location.xml
@@ -40,7 +40,7 @@
                 <filter
                     string="Has Release Channel Restriction"
                     name="release_channel_restriction"
-                    domain="[('has_release_channel_restriction','=',True)]"
+                    domain="[('current_release_channel_restriction_id','=',True)]"
                 />
             </filter>
         </field>

--- a/stock_location_release_channel_restriction/views/stock_location.xml
+++ b/stock_location_release_channel_restriction/views/stock_location.xml
@@ -19,10 +19,6 @@
                         name="specific_release_channel_restriction"
                         class="oe_edit_only"
                     />
-                    <field
-                        name="release_channel_restriction_in_move"
-                        attrs="{'invisible': [('release_channel_restriction', '!=', 'same')]}"
-                    />
                 </group>
             </xpath>
 

--- a/stock_location_release_channel_restriction/views/stock_location.xml
+++ b/stock_location_release_channel_restriction/views/stock_location.xml
@@ -19,8 +19,21 @@
                         name="specific_release_channel_restriction"
                         class="oe_edit_only"
                     />
+                    <field name="current_release_channel_restriction_id" />
                 </group>
             </xpath>
+            <sheet position="before">
+                <div
+                    class="alert alert-warning"
+                    style="margin-bottom:0px;font-weight: bolder;text-align: center;"
+                    role="alert"
+                    attrs="{'invisible': [('current_release_channel_restriction_id', '=', False)]}"
+                >
+                                The location is restricted to <field
+                        name="current_release_channel_restriction_id"
+                    />
+                </div>
+            </sheet>
 
 
         </field>
@@ -48,7 +61,12 @@
         <field name="inherit_id" ref="stock.view_location_tree2" />
         <field name="arch" type="xml">
             <field name="storage_category_id" position="after">
-                <field name="current_release_channel_restriction_id" optional="hide" />
+                <field
+                    name="current_release_channel_restriction_id"
+                    widget="badge"
+                    decoration-warning="True"
+                    optional="hide"
+                />
             </field>
         </field>
     </record>

--- a/stock_location_release_channel_restriction/views/stock_location.xml
+++ b/stock_location_release_channel_restriction/views/stock_location.xml
@@ -49,7 +49,7 @@
                 <filter
                     string="Has Release Channel Restriction"
                     name="release_channel_restriction"
-                    domain="[('current_release_channel_restriction_id','=',True)]"
+                    domain="[('current_release_channel_restriction_id','!=',False)]"
                 />
             </filter>
         </field>

--- a/stock_location_release_channel_restriction/views/stock_location.xml
+++ b/stock_location_release_channel_restriction/views/stock_location.xml
@@ -30,4 +30,31 @@
         </field>
     </record>
 
+    <record id="view_location_search" model="ir.ui.view">
+        <field name="name">stock.location.search</field>
+        <field name="model">stock.location</field>
+        <field name="inherit_id" ref="stock.view_location_search" />
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <separator />
+                <filter
+                    string="Has Release Channel Restriction"
+                    name="release_channel_restriction"
+                    domain="[('has_release_channel_restriction','=',True)]"
+                />
+            </filter>
+        </field>
+    </record>
+
+    <record id="view_location_tree2" model="ir.ui.view">
+        <field name="name">stock.location.tree</field>
+        <field name="model">stock.location</field>
+        <field name="inherit_id" ref="stock.view_location_tree2" />
+        <field name="arch" type="xml">
+            <field name="storage_category_id" position="after">
+                <field name="current_release_channel_restriction_id" optional="hide" />
+            </field>
+        </field>
+    </record>
+
 </odoo>

--- a/stock_location_release_channel_restriction/wizards/__init__.py
+++ b/stock_location_release_channel_restriction/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_location_reset_channel

--- a/stock_location_release_channel_restriction/wizards/stock_location_reset_channel.py
+++ b/stock_location_release_channel_restriction/wizards/stock_location_reset_channel.py
@@ -1,0 +1,22 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class StockLocationResetReleaseChannel(models.TransientModel):
+    _name = "stock.location.reset.release.channel"
+    _description = "Wizard to reset Release Channel on Locations"
+
+    location_ids = fields.Many2many(
+        comodel_name="stock.location",
+    )
+    reset_family = fields.Boolean(
+        help="Check this in order to reset the blocking release channel on other "
+        "locations from the same family."
+    )
+
+    def reset(self):
+        for wizard in self:
+            wizard.location_ids._remove_current_release_channel_restriction(
+                force=True, family=wizard.reset_family
+            )

--- a/stock_location_release_channel_restriction/wizards/stock_location_reset_channel.xml
+++ b/stock_location_release_channel_restriction/wizards/stock_location_reset_channel.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="stock_location_reset_release_channel_form_view">
+        <field name="model">stock.location.reset.release.channel</field>
+        <field name="name">stock.location.reset.release.channel form</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="reset_family" />
+                    <field name="location_ids" />
+
+                </group>
+                <footer>
+                    <button
+                        name="reset"
+                        string="Reset"
+                        class="btn-primary"
+                        type="object"
+                    />
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_stock_location_reset_release_channel" model="ir.actions.server">
+        <field name="name">Remove Release Channel</field>
+        <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]" />
+        <field name="model_id" ref="stock.model_stock_location" />
+        <field name="binding_model_id" ref="stock.model_stock_location" />
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+            action = records.action_reset_release_channel()
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When several orders are grouped into several sub-locations of a parent, check that all pending outgoing moves are concerning the same release channel.

Use case: You have a chariot with several sub-locations. That chariot (parent location) should be dedicated to a same release channel.