### PR TITLE
[16.0][FIX] stock_lot_multi_image: image_1920 max_width and max_height

### DIFF
--- a/stock_lot_multi_image/models/stock_lot.py
+++ b/stock_lot_multi_image/models/stock_lot.py
@@ -8,9 +8,11 @@ class StockLot(models.Model):
     _name = "stock.lot"
     _inherit = ["stock.lot", "base_multi_image.owner", "image.mixin"]
 
-    image_1920 = fields.Binary(
+    image_1920 = fields.Image(
         compute="_compute_image_1920",
         store=True,
+        max_width=1920,
+        max_height=1920,
     )
 
     @api.depends("image_ids")


### PR DESCRIPTION
@Escodoo HT01605
cc @marcelsavegnago @kaynnan @WesleyOliveira98 
Fix for this error here
```
2026-02-18 12:52:14,602 532 ERROR odoo odoo.addons.stock_inventory_preparation_filter.tests.test_stock_inventory_preparation_filter: ERROR: TestStockInventoryPreparationFilterCategories.test_inventory_filter
Traceback (most recent call last):
  File "/__w/stock-logistics-warehouse/stock-logistics-warehouse/stock_inventory_preparation_filter/tests/test_stock_inventory_preparation_filter.py", line 90, in setUp
    self.env.user.groups_id = [(4, self.env.ref("stock.group_production_lot").id)]
  File "/opt/odoo/odoo/fields.py", line 1337, in __set__
    records.write({self.name: write_value})
  File "/opt/odoo/addons/auth_signup/models/res_users.py", line 258, in write
    return super().write(vals)
  File "/opt/odoo/addons/mail/models/res_users.py", line 96, in write
    write_res = super(Users, self).write(vals)
  File "/opt/odoo/addons/resource/models/res_users.py", line 17, in write
    rslt = super().write(vals)
  File "/opt/odoo/odoo/addons/base/models/res_users.py", line 1709, in write
    res = super(UsersView, self).write(values)
  File "/opt/odoo/odoo/addons/base/models/res_users.py", line 1407, in write
    res = super(UsersImplied, self).write(values)
  File "/opt/odoo/odoo/addons/base/models/res_users.py", line 726, in write
    self.env['ir.model.access'].call_cache_clearing_methods()
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1951, in call_cache_clearing_methods
    self.env.invalidate_all()
  File "/opt/odoo/odoo/api.py", line 761, in invalidate_all
    self.flush_all()
  File "/opt/odoo/odoo/api.py", line 771, in flush_all
    self._recompute_all()
  File "/opt/odoo/odoo/api.py", line 767, in _recompute_all
    self[field.model_name]._recompute_field(field)
  File "/opt/odoo/odoo/models.py", line 6335, in _recompute_field
    field.recompute(records)
  File "/opt/odoo/odoo/fields.py", line 1382, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/opt/odoo/odoo/fields.py", line 1355, in apply_except_missing
    func(records)
  File "/opt/odoo/odoo/fields.py", line 2378, in compute_value
    super().compute_value(records)
  File "/opt/odoo/odoo/fields.py", line 1404, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/addons/mail/models/mail_thread.py", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File "/opt/odoo/odoo/models.py", line 4276, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/odoo/fields.py", line 101, in determine
    return needle(records, *args)
  File "/opt/odoo/odoo/fields.py", line 702, in _compute_related
    record[self.name] = self._process_related(value[self.related_field.name])
  File "/opt/odoo/odoo/fields.py", line 2541, in _process_related
    return self._image_process(super()._process_related(value))
  File "/opt/odoo/odoo/fields.py", line 2523, in _image_process
    and self.max_width == self.related_field.max_width
AttributeError: 'Binary' object has no attribute 'max_width'
```