### PR TITLE
[IMP] stock_available_mrp: allow a negative quantity for bom products

### DIFF
--- a/stock_available_mrp/models/product_product.py
+++ b/stock_available_mrp/models/product_product.py
@@ -70,14 +70,20 @@ class ProductProduct(models.Model):
                     ]
                 )
                 potential_qty = bom_id.product_qty * components_potential_qty
-                potential_qty = potential_qty > 0.0 and potential_qty or 0.0
+                sign = -1 if potential_qty < 0.0 else 1
+                potential_qty = (
+                    potential_qty > 0.0 and potential_qty or potential_qty * -1
+                )
 
                 # We want to respect the rounding factor of the potential_qty
                 # Rounding down as we want to be pesimistic.
-                potential_qty = bom_id.product_uom_id._compute_quantity(
-                    potential_qty,
-                    bom_id.product_tmpl_id.uom_id,
-                    rounding_method="DOWN",
+                potential_qty = (
+                    bom_id.product_uom_id._compute_quantity(
+                        potential_qty,
+                        bom_id.product_tmpl_id.uom_id,
+                        rounding_method="DOWN",
+                    )
+                    * sign
                 )
 
             res[product.id]["potential_qty"] = potential_qty

--- a/stock_available_mrp/tests/test_potential_qty.py
+++ b/stock_available_mrp/tests/test_potential_qty.py
@@ -284,6 +284,56 @@ class TestPotentialQty(SavepointCase):
             "Wrong potential quantity in Chicago WH location",
         )
 
+    def test_potential_minus_qty(self):
+        for i in [self.tmpl, self.var1, self.var2]:
+            self.assertPotentialQty(i, 0.0, "The potential quantity should start at 0")
+        outgoing_transfer = self.env["stock.picking"].create(
+            {
+                "partner_id": self.env.ref("base.partner_demo").id,
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "location_id": self.env.ref("stock.stock_location_stock").id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+                "move_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.var1.id,
+                            "product_uom_id": self.var1.uom_id.id,
+                            "qty_done": 5,
+                            "location_id": self.env.ref(
+                                "stock.stock_location_stock"
+                            ).id,
+                            "location_dest_id": self.env.ref(
+                                "stock.stock_location_customers"
+                            ).id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.var2.id,
+                            "product_uom_id": self.var2.uom_id.id,
+                            "qty_done": 5,
+                            "location_id": self.env.ref(
+                                "stock.stock_location_stock"
+                            ).id,
+                            "location_dest_id": self.env.ref(
+                                "stock.stock_location_customers"
+                            ).id,
+                        },
+                    ),
+                ],
+            }
+        )
+        outgoing_transfer.action_confirm()
+        outgoing_transfer._action_done()
+        for i in [self.tmpl, self.var1, self.var2]:
+            self.assertPotentialQty(
+                i, -10.0, "The potential quantity should start at 0"
+            )
+
     def test_multi_unit_recursive_bom(self):
         # Test multi-level and multi-units BOM
         uom_unit = self.env.ref("uom.product_uom_unit")


### PR DESCRIPTION
Before this commit BOM product never showed a negative quantity in potential quantity, even if all its components had a negative qty, to be consistent for the user, we also need to show a negative quantity for the parent product