### PR TITLE
[18.0][FIX] stock_cycle_count: use sudo() in check_zero_confirmation call

### DIFF
--- a/stock_cycle_count/models/stock_move.py
+++ b/stock_cycle_count/models/stock_move.py
@@ -11,5 +11,7 @@ class StockMove(models.Model):
 
     def _action_done(self, cancel_backorder=False):
         res = super()._action_done(cancel_backorder=cancel_backorder)
-        self.mapped("location_id").check_zero_confirmation()
+        # Use sudo() because the user triggering _action_done may not have
+        # access to cycle count models (stock.cycle.count.rule, stock.cycle.count).
+        self.mapped("location_id").sudo().check_zero_confirmation()
         return res


### PR DESCRIPTION
Use `sudo()` when calling `check_zero_confirmation` from `_action_done`, as it is an internal system operation that should not depend on the user's access rights. This follows the same pattern used in stock_account (odoo/addons/stock_account/models/stock_move.py) where `sudo()` is used to create stock.valuation.layer records and update product standard prices within `_action_done`.


@ForgeFlow