### PR TITLE
[18.0][FIX] stock_move_purchase_uom: prevent unreservation in create

### DIFF
--- a/stock_move_purchase_uom/models/stock_move.py
+++ b/stock_move_purchase_uom/models/stock_move.py
@@ -24,7 +24,9 @@ class StockMove(models.Model):
                     rounding_method=move.picking_type_id.purchase_uom_rounding_method,
                 )
                 move.product_uom = move.product_id.uom_po_id
-                move.product_uom_qty = updated_product_uom_qty
+                move.with_context(
+                    do_not_unreserve=True
+                ).product_uom_qty = updated_product_uom_qty
         return moves
 
     @api.onchange("product_id", "picking_type_id")

--- a/stock_move_purchase_uom/tests/test_stock_move.py
+++ b/stock_move_purchase_uom/tests/test_stock_move.py
@@ -1,5 +1,6 @@
 # Copyright 2024 ForgeFlow S.L. (https://www.forgeflow.com)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from odoo import Command
 from odoo.tests import Form
 
 from .test_common import TestCommon
@@ -99,3 +100,42 @@ class TestStockMove(TestCommon):
             }
         )
         self.assertEqual(move.product_uom_qty, 5.0)
+
+    def test_create_move_linked_sml_not_unreserved(self):
+        # The UoM conversion in create must not trigger unreservation of
+        # explicitly linked SML
+        sml = self.env["stock.move.line"].create(
+            {
+                "product_id": self.product.id,
+                "product_uom_id": self.cm_uom.id,
+                "quantity": 70,
+                "location_id": self.location.id,
+                "location_dest_id": self.location_dest.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        move = self.env["stock.move"].create(
+            {
+                "name": self.product.display_name,
+                "location_id": self.location.id,
+                "location_dest_id": self.location_dest.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 30,
+                "product_uom": self.cm_uom.id,
+                "picking_type_id": self.stock_picking_type_2.id,
+                "state": "assigned",
+                "move_line_ids": [Command.link(sml.id)],
+            }
+        )
+        self.assertTrue(sml.exists())
+        self.assertEqual(sml.move_id, move)
+        # UoM was converted on the SM but not on the SML
+        self.assertEqual(move.product_uom, self.meter_uom)
+        self.assertEqual(sml.product_uom_id, self.cm_uom)
+        # SML quantity is unchanged (70 cm)
+        self.assertEqual(sml.quantity, 70)
+        # SM demand converted: 30 cm --> 0.3 m
+        self.assertEqual(move.product_uom_qty, 0.3)
+        # SM reserved qty is computed from SML: 70 cm --> 0.7 m
+        # Quantities are coherent, but SML is kept as original
+        self.assertEqual(move.quantity, 0.7)


### PR DESCRIPTION
The `create` override writes `product_uom_qty` on the created move to convert the quantity into the purchase UoM. Because this is a `write()` on an existing record, it triggers the unreservation logic in `stock.move.write()`, which deletes `stock.move.line` records when `product_uom_qty` changes on a non-draft move.

Odoo interprets this numerical change as a demand reduction, which is incorrect: the write is not a demand reduction, it's the same physical quantity in a different UoM as part of the creation. The existing reservation (if any SML were linked during create via Command.link) remains valid and should not be discarded. Add `do_not_unreserve=True` to the context of the `product_uom_qty` write, to avoid triggering unreservation. This is consistent with how Odoo itself handles equivalent situations in the stock module.