### PR TITLE
[18.0][IMP] stock_vertical_lift: revamp UI

### DIFF
--- a/stock_vertical_lift/static/src/scss/vertical_lift.scss
+++ b/stock_vertical_lift/static/src/scss/vertical_lift.scss
@@ -45,6 +45,7 @@
         }
 
         .o_shuttle_operation {
+            min-width: 70%;
             text-align: center;
             font-size: 2.5em;
             padding: 0 0.5em;
@@ -89,6 +90,7 @@
             }
 
             .o_shuttle_highlight {
+                padding: 2px;
                 padding: 6px;
                 border-radius: 10px;
             }

--- a/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
+++ b/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
@@ -118,55 +118,51 @@
             <xpath expr="//div[hasclass('o_shuttle_data')]" position="inside">
                 <field name="current_move_line_id" invisible="True" force_save="1" />
                 <!-- on the left of the screen -->
-                <div class="o_shuttle_data_content o_shuttle_move">
-                    <div>
+                <div class="o_shuttle_data_content">
+                    <group>
+                        <label for="picking_id" />
+                        <div>
+                            <div>
+                                <field
+                                    name="picking_id"
+                                    options="{'no_open': True}"
+                                    class="oe_inline mr8"
+                                />
+                                <span>/</span>
+                                <field name="picking_origin" class="oe_inline ml8" />
+                            </div>
+                        </div>
+                        <label for="picking_partner_id" />
+                        <div>
+                            <field
+                                name="picking_partner_id"
+                                options="{'no_open': True}"
+                            />
+                        </div>
+                        <label for="location_dest_id" />
+                        <div>
+                            <field
+                                name="location_dest_id"
+                                class="bg-primary o_shuttle_highlight text-white"
+                                readonly="1"
+                                force_save="1"
+                                options="{'no_open': True}"
+                            />
+                        </div>
+                        <field
+                            name="product_id"
+                            class="h1"
+                            options="{'no_open': True}"
+                        />
+                    </group>
+                    <group>
                         <group>
-                            <label for="picking_id" />
-                            <div>
-                                <div>
-                                    <field
-                                        name="picking_id"
-                                        options="{'no_open': True}"
-                                        class="oe_inline mr8"
-                                    />
-                                    <span>/</span>
-                                    <field
-                                        name="picking_origin"
-                                        class="oe_inline ml8"
-                                    />
-                                </div>
-                            </div>
-                            <label for="picking_partner_id" />
-                            <div>
-                                <field
-                                    name="picking_partner_id"
-                                    options="{'no_open': True}"
-                                />
-                            </div>
-                            <label for="location_dest_id" />
-                            <div>
-                                <field
-                                    name="location_dest_id"
-                                    class="bg-primary o_shuttle_highlight text-white"
-                                    readonly="1"
-                                    force_save="1"
-                                    options="{'no_open': True}"
-                                />
-                            </div>
-                            <label for="product_id" />
-                            <div>
-                                <field
-                                    name="product_id"
-                                    options="{'no_open': True}"
-                                    class="fw-bold fs-1"
-                                />
-                            </div>
                             <div colspan="2">
                                 <field name="product_packagings" />
                             </div>
                             <field name="lot_id" />
                             <label for="quantity" string="Quantity" class="ml32" />
-                            <div colspan="2" class="ml32">
+                            <div class="ml32">
                                 <h1 class="bg-primary o_shuttle_highlight">
                                     <field
                                         name="quantity"
@@ -180,29 +176,25 @@
                                 </h1>
                             </div>
                         </group>
-                    </div>
-                </div>
-                <!-- on the right of the screen -->
-                <div
-                    class="o_shuttle_data_content o_shuttle_tray"
-                    invisible="not tray_type_id"
-                >
-                    <group col="1">
-                        <field name="tray_name" />
-                        <field name="tray_type_code" />
-                        <field name="tray_x" />
-                        <field name="tray_y" />
-                        <label for="tray_qty" />
-                        <div colspan="2" class="oe_title">
-                            <h1>
-                                <field name="tray_qty" />
-                            </h1>
-                        </div>
-                    </group>
-                    <group>
-                        <div>
-                            <field name="tray_matrix" widget="location_tray_matrix" />
-                        </div>
+                        <!-- on the right of the screen -->
+                        <group>
+                            <group>
+                                <field name="tray_qty" class="h1" />
+                                <field
+                                    name="tray_matrix"
+                                    nolabel="1"
+                                    widget="location_tray_matrix"
+                                />
+                            </group>
+                            <group
+                                style="width: 80%; display: grid; grid-template-columns: repeat(4, 1fr);"
+                            >
+                                <field name="tray_x" />
+                                <field name="tray_name" />
+                                <field name="tray_y" />
+                                <field name="tray_type_code" />
+                            </group>
+                        </group>
                     </group>
                 </div>
             </xpath>

--- a/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
+++ b/stock_vertical_lift/views/vertical_lift_operation_base_views.xml
@@ -64,6 +64,18 @@
                                 title="Barcode Input"
                             />
                         </div>
+                        <div
+                            class="o_shuttle_operation bg-primary jumbotron jumbotron-fluid"
+                        >
+                            <div class="container">
+                                <field
+                                    name="state"
+                                    invisible="0"
+                                    readonly="True"
+                                    force_save="1"
+                                />
+                            </div>
+                        </div>
                         <div class="o_shuttle_content o_shuttle_content_right">
                             <div>
                                 <!-- will react on barcode 'O-BTN.save' -->
@@ -86,18 +98,6 @@
                                     invisible="state != 'release'"
                                 />
                             </div>
-                        </div>
-                    </div>
-                    <div
-                        class="o_shuttle_operation bg-primary jumbotron jumbotron-fluid"
-                    >
-                        <div class="container">
-                            <field
-                                name="state"
-                                invisible="0"
-                                readonly="True"
-                                force_save="1"
-                            />
                         </div>
                     </div>
                     <div class="o_shuttle_data" />


### PR DESCRIPTION
The UI can overflow the screen vertically when we have too many data.
It has a lot of space lost that we can retrieve so that it can hold more data.

The current version of the UI:
- Maximize the use of the space
- Ensure compatibility with known modules that inherit the view.

The gained space is now more than enough to prevent overflow.


## New Visual

<img width="1551" height="807" alt="image" src="https://github.com/user-attachments/assets/1a1f3fb3-4050-439a-a942-ea6d6efb54ef" />
