### PR TITLE
[18.0][FIX] stock_inventory_lockdown: use sudo() in _get_locations_open_inventories call

### DIFF
--- a/stock_inventory_lockdown/models/stock_move_line.py
+++ b/stock_inventory_lockdown/models/stock_move_line.py
@@ -21,10 +21,12 @@ class StockMoveLine(models.Model):
     @api.constrains("location_dest_id", "location_id", "state")
     def _check_locked_location(self):
         for move_line in self.filtered(lambda m: m.state == "done"):
-            locked_location_ids = self.env[
-                "stock.inventory"
-            ]._get_locations_open_inventories(
-                [move_line.location_dest_id.id, move_line.location_id.id]
+            locked_location_ids = (
+                self.env["stock.inventory"]
+                .sudo()
+                ._get_locations_open_inventories(
+                    [move_line.location_dest_id.id, move_line.location_id.id]
+                )
             )
             if locked_location_ids and not any(
                 [


### PR DESCRIPTION
The method _get_locations_open_inventories was executed using the current user's permissions, which could lead to inconsistent behavior if the user lacked access rights to inventory records. This change adds a sudo() call when retrieving locations with ongoing inventory adjustments inside the _check_locked_location constraint, ensuring the validation is performed consistently regardless of user permissions.