### PR TITLE
[16.0] [FIX] stock_move_location: consistent return type in _get_available_q…

### DIFF
--- a/stock_move_location/tests/__init__.py
+++ b/stock_move_location/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_common
+from . import test_get_available_quantity
 from . import test_move_location
 from . import test_stock_fillwithstock

--- a/stock_move_location/tests/test_get_available_quantity.py
+++ b/stock_move_location/tests/test_get_available_quantity.py
@@ -1,0 +1,70 @@
+# Copyright 2025 FactorLibre
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from .test_common import TestsCommon
+
+
+class TestGetAvailableQuantity(TestsCommon):
+    """Test _get_available_quantity returns consistent tuples."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setup_product_amounts()
+        cls.product_no_stock = cls.env["product.product"].create(
+            {"name": "No Stock Product", "type": "product", "tracking": "none"}
+        )
+
+    def _create_wizard_line(self, wizard, product, move_quantity, max_quantity):
+        return self.env["wiz.stock.move.location.line"].create(
+            {
+                "move_location_wizard_id": wizard.id,
+                "product_id": product.id,
+                "origin_location_id": wizard.origin_location_id.id,
+                "destination_location_id": wizard.destination_location_id.id,
+                "move_quantity": move_quantity,
+                "max_quantity": max_quantity,
+                "product_uom_id": product.uom_id.id,
+            }
+        )
+
+    def test01_no_available_quantity(self):
+        """Product with no stock returns tuple (0, 0)."""
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        line = self._create_wizard_line(wizard, self.product_no_stock, 5, 5)
+        result = line._get_available_quantity()
+        self.assertIsInstance(result, tuple)
+        qty_todo, qty_done = result
+        self.assertEqual(qty_todo, 0)
+        self.assertEqual(qty_done, 0)
+
+    def test02_available_less_than_requested(self):
+        """Available qty < requested returns tuple (0, available_qty)."""
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        # product_no_lots has 123 units, request 200
+        line = self._create_wizard_line(wizard, self.product_no_lots, 200, 200)
+        result = line._get_available_quantity()
+        self.assertIsInstance(result, tuple)
+        qty_todo, qty_done = result
+        self.assertEqual(qty_todo, 0)
+        self.assertEqual(qty_done, 123)
+
+    def test03_available_enough(self):
+        """Available qty >= requested returns tuple (0, move_quantity)."""
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        line = self._create_wizard_line(wizard, self.product_no_lots, 50, 123)
+        result = line._get_available_quantity()
+        self.assertIsInstance(result, tuple)
+        qty_todo, qty_done = result
+        self.assertEqual(qty_todo, 0)
+        self.assertEqual(qty_done, 50)
+
+    def test04_planned_transfer(self):
+        """Planned transfer returns tuple (move_quantity, 0)."""
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        line = self._create_wizard_line(wizard, self.product_no_lots, 50, 123)
+        result = line.with_context(planned=True)._get_available_quantity()
+        self.assertIsInstance(result, tuple)
+        qty_todo, qty_done = result
+        self.assertEqual(qty_todo, 50)
+        self.assertEqual(qty_done, 0)

--- a/stock_move_location/wizard/stock_move_location_line.py
+++ b/stock_move_location/wizard/stock_move_location_line.py
@@ -123,7 +123,7 @@ class StockMoveLocationWizardLine(models.TransientModel):
         more than exists."""
         self.ensure_one()
         if not self.product_id:
-            return 0
+            return 0, 0
         if self.env.context.get("planned"):
             # for planned transfer we don't care about the amounts at all
             return self.move_quantity, 0
@@ -148,11 +148,11 @@ class StockMoveLocationWizardLine(models.TransientModel):
         if not available_qty:
             # if it is immediate transfer and product doesn't exist in that
             # location -> make the transfer of 0.
-            return 0
+            return 0, 0
         rounding = self.product_uom_id.rounding
         available_qty_lt_move_qty = (
             self._compare(available_qty, self.move_quantity, rounding) == -1
         )
         if available_qty_lt_move_qty:
-            return available_qty
+            return 0, available_qty
         return 0, self.move_quantity


### PR DESCRIPTION
## Description

The method `_get_available_quantity()` in `wiz.stock.move.location.line` has 5 return
paths but only 2 return tuples. The caller in `_get_move_line_values()` (line 104)
unpacks the result as:

```python
qty_todo, qty_done = self._get_available_quantity()
```

This causes `TypeError: cannot unpack non-iterable int object` when the method
hits any of the 3 paths that return a scalar instead of a tuple.

## Root cause

| Return path | Condition | Before (broken) | After (fixed) |
|-------------|-----------|-----------------|---------------|
| Line 126 | No product set | `return 0` | `return 0, 0` |
| Line 151 | No available qty in location | `return 0` | `return 0, 0` |
| Line 157 | Available qty < requested | `return available_qty` | `return 0, available_qty` |

The other 2 return paths (planned transfer and normal case) already returned tuples correctly.

## Steps to reproduce

1. Go to Inventory > Operations > Move from location...
2. Select an origin location
3. Add a product that has **no stock** in that location (or set move quantity higher than available)
4. Click "Immediate Transfer"
5. **Result:** `TypeError: cannot unpack non-iterable int object`
6. **Expected:** Transfer completes with qty_done=0 (no stock) or qty_done=available_qty (partial)

## Changes

- `stock_move_location/wizard/stock_move_location_line.py`: Fix 3 return statements to always return `(qty_todo, qty_done)` tuples
- `stock_move_location/tests/test_get_available_quantity.py`: Add 4 tests covering all return paths
