### PR TITLE
[16.0] [FIX] stock_move_location: prevent picking type reset on origin change

### DIFF
--- a/stock_move_location/tests/test_move_location.py
+++ b/stock_move_location/tests/test_move_location.py
@@ -356,3 +356,33 @@ class TestMoveLocation(TestsCommon):
         self.assertEqual(len(delivery_move.move_line_ids), 1)
         self.assertEqual(delivery_move.move_line_ids.reserved_uom_qty, 20.0)
         self.assertEqual(delivery_move.move_line_ids.location_id, wh_stock_shelf_3)
+
+    def test_picking_type_preserved_on_origin_change(self):
+        """picking_type_id must not be reset when origin_location changes."""
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        # Pick a picking type different from the default to assert preservation
+        other_picking_type = self.env["stock.picking.type"].search(
+            [
+                ("code", "in", ("internal", "outgoing")),
+                ("id", "!=", wizard.picking_type_id.id),
+            ],
+            limit=1,
+        )
+        self.assertTrue(
+            other_picking_type,
+            "Test requires at least two picking types to exist",
+        )
+        wizard.picking_type_id = other_picking_type
+        wizard.origin_location_id = self.internal_loc_2
+        wizard.onchange_origin_location()
+        self.assertEqual(wizard.picking_type_id, other_picking_type)
+
+    def test_destination_propagated_to_lines_without_dest(self):
+        """Lines without destination receive the wizard's destination on transfer."""
+        wizard = self._create_wizard(self.internal_loc_1, self.internal_loc_2)
+        wizard.onchange_origin_location()
+        # Simulate a line that ended up without destination
+        wizard.stock_move_location_line_ids[0].destination_location_id = False
+        wizard.action_move_location()
+        self.assertTrue(wizard.picking_id)
+        self.assertEqual(wizard.picking_id.location_dest_id, self.internal_loc_2)

--- a/stock_move_location/wizard/stock_move_location.py
+++ b/stock_move_location/wizard/stock_move_location.py
@@ -7,12 +7,25 @@ from itertools import groupby
 
 from odoo import api, fields, models
 from odoo.fields import first
-from odoo.osv import expression
 
 
 class StockMoveLocationWizard(models.TransientModel):
     _name = "wiz.stock.move.location"
     _description = "Wizard move location"
+
+    def _get_default_picking_type_id(self):
+        company_id = self.env.context.get("company_id") or self.env.company.id
+        return (
+            self.env["stock.picking.type"]
+            .search(
+                [
+                    ("code", "in", ("internal", "outgoing")),
+                    ("warehouse_id.company_id", "=", company_id),
+                ],
+                limit=1,
+            )
+            .id
+        )
 
     origin_location_disable = fields.Boolean(
         compute="_compute_readonly_locations",
@@ -40,10 +53,8 @@ class StockMoveLocationWizard(models.TransientModel):
         string="Move Location lines",
     )
     picking_type_id = fields.Many2one(
-        compute="_compute_picking_type_id",
         comodel_name="stock.picking.type",
-        readonly=False,
-        store=True,
+        default=_get_default_picking_type_id,
     )
     picking_id = fields.Many2one(
         string="Connected Picking", comodel_name="stock.picking"
@@ -63,28 +74,6 @@ class StockMoveLocationWizard(models.TransientModel):
             if not rec.edit_locations:
                 rec.origin_location_disable = True
                 rec.destination_location_disable = True
-
-    @api.depends_context("company")
-    @api.depends("origin_location_id")
-    def _compute_picking_type_id(self):
-        company_id = self.env.context.get("company_id") or self.env.company.id
-        for rec in self:
-            picking_type = self.env["stock.picking.type"]
-            base_domain = [
-                ("code", "in", ("internal", "outgoing")),
-                ("warehouse_id.company_id", "=", company_id),
-            ]
-            if rec.origin_location_id:
-                location_id = rec.origin_location_id
-                while location_id and not picking_type:
-                    domain = [("default_location_src_id", "=", location_id.id)]
-                    domain = expression.AND([base_domain, domain])
-                    picking_type = picking_type.search(domain, limit=1)
-                    # Move up to the parent location if no picking type found
-                    location_id = not picking_type and location_id.location_id or False
-            if not picking_type:
-                picking_type = picking_type.search(base_domain, limit=1)
-            rec.picking_type_id = picking_type.id
 
     @api.model
     def default_get(self, fields):
@@ -281,6 +270,10 @@ class StockMoveLocationWizard(models.TransientModel):
 
     def action_move_location(self):
         self.ensure_one()
+        # Ensure all lines have a destination location
+        for line in self.stock_move_location_line_ids:
+            if not line.destination_location_id:
+                line.destination_location_id = self.destination_location_id
         if not self.picking_id:
             picking = self._create_picking()
         else:


### PR DESCRIPTION
## Description

The move location wizard (`wiz.stock.move.location`) had two related issues that caused user-entered data to be silently overwritten or lost:

1. **The operation type (`picking_type_id`) was reset** whenever the user changed the origin location or saved the wizard (e.g. clicking "Immediate Transfer" or "Planned Transfer"), discarding any manual selection the user had made.
2. **The destination location could be missing on wizard lines** when they were built from the origin onchange before the user had set the destination, causing a NOT NULL constraint error on `stock.move.location_dest_id` when the transfer was executed.

## Root cause

### 1. Picking type reset

```python
picking_type_id = fields.Many2one(
    compute="_compute_picking_type_id",
    comodel_name="stock.picking.type",
    readonly=False,
    store=True,
)

@api.depends("origin_location_id")
def _compute_picking_type_id(self):
    ...
    rec.picking_type_id = picking_type.id
```

The combination of `compute` + `store=True` + `readonly=False` with a dependency on `origin_location_id` means the user could edit the field in the UI, but any write to the record (including button clicks that save the wizard) re-triggered the compute and silently overwrote the manual selection.

Before this behaviour was introduced, the module used a plain `default` that returned the first internal picking type of the company. The computed variant was added to auto-pick a type based on the origin location, but the side effect of losing the user's input was never intended.

### 2. Destination missing on lines

When the origin location changes, `onchange_origin_location` calls `_reset_stock_move_location_lines`, which builds lines using `self.destination_location_id`. If the user sets the origin before the destination, the lines end up with no destination. The line-level onchange for the destination propagates the value to the existing lines afterwards, but there is no safeguard when the flow gets the wizard into a state where at least one line reaches the picking creation step without a destination.

## Fix

- Revert `picking_type_id` to a regular `Many2one` field with a simple `default=_get_default_picking_type_id` returning the first internal or outgoing picking type of the company. This matches the original module behaviour before the compute-based change (stable user selection) while keeping the support for outgoing picking types added later in the compute variant.
- Add a safeguard in `action_move_location` that copies `self.destination_location_id` to any line lacking one before the picking is created, so a transfer no longer fails on a NOT NULL constraint when lines were built before the destination was set.
- Add regression tests that cover both scenarios.

Existing tests that instantiate the wizard via `create(...)` keep working thanks to the default, and all flows that already set `destination_location_id` on the lines via onchange are unaffected by the safeguard.

## Steps to reproduce

### 1. Picking type reset

1. Go to Inventory > Operations > Move from location...
2. Select an origin location.
3. Change the "Operation Type" field to a different picking type of your choice.
4. Click "Planned Transfer" (or change the origin location).
5. **Before the fix:** the operation type is reset to the one computed from the origin, discarding the user's selection.
6. **After the fix:** the operation type keeps the user's selection.

### 2. Destination missing

1. Go to Inventory > Operations > Move from location...
2. Select an origin location (lines are created without destination at this point).
3. Select a destination location.
4. Click "Planned Transfer".
5. **Before the fix:** `IntegrityError: null value in column "location_dest_id" of relation "stock_move" violates not-null constraint`.
6. **After the fix:** the picking is created with the expected destination.

## Changes

- `stock_move_location/wizard/stock_move_location.py`:
  - Restore `picking_type_id` to a regular field with `default=_get_default_picking_type_id` (first internal or outgoing picking type).
  - Remove the compute, helper and onchange introduced by the computed variant.
  - Add a safeguard in `action_move_location` to fill `destination_location_id` on lines missing it.
- `stock_move_location/tests/test_move_location.py`:
  - Add `test_picking_type_preserved_on_origin_change` to assert the user's manual picking type is not overwritten when the origin location changes.
  - Add `test_destination_propagated_to_lines_without_dest` to assert the safeguard fills the destination on lines lacking one before creating the picking.
