### PR TITLE
[18.0][FIX] stock_move_packaging_qty: ml pack columns order

### DIFF
--- a/stock_move_packaging_qty/i18n/es.po
+++ b/stock_move_packaging_qty/i18n/es.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-18 07:54+0000\n"
-"PO-Revision-Date: 2026-04-16 15:45+0000\n"
+"POT-Creation-Date: 2026-04-17 07:22+0000\n"
+"PO-Revision-Date: 2026-04-17 07:22+0000\n"
 "Last-Translator: David Vidal <david.vidal@tecnativa.com>\n"
 "Language-Team: none\n"
 "Language: es\n"
@@ -19,48 +19,38 @@ msgstr ""
 
 #. module: stock_move_packaging_qty
 #: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_operations
-msgid "<span> / </span>"
-msgstr "<span> / </span>"
+msgid "<span>(</span>"
+msgstr "<span>(</span>"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,help:stock_move_packaging_qty.field_stock_move__product_packaging_qty
-msgid "Amount of product packagings demanded."
-msgstr "Cantidad de envases pedidos."
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_operations
+msgid "<span>)</span>"
+msgstr "<span>)</span>"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,help:stock_move_packaging_qty.field_stock_move__product_packaging_qty_done
-msgid "Amount of product packagings done."
-msgstr "Cantidad de envases hecha."
+#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move__product_packaging_quantity
+#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move_line__product_packaging_quantity
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
+msgid "Done Packaging Quantity"
+msgstr "Cantidad de envases hechos"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move_line__product_packaging_qty_done
-msgid "Done Pkg. Qty."
-msgstr "Envs. hechos"
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_move_line_tree_detailed
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_picking_move_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_detailed_operation_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
+msgid "Done Pkg."
+msgstr "Env. hechos"
 
 #. module: stock_move_packaging_qty
 #: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move_line__product_packaging_id
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_move_line_form
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_move_line_tree_detailed
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_picking_move_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_detailed_operation_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
 msgid "Packaging"
 msgstr "Envase"
-
-#. module: stock_move_packaging_qty
-#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_operations
-msgid "Packagings demanded"
-msgstr "Envases pedidos"
-
-#. module: stock_move_packaging_qty
-#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_operations
-msgid "Packagings done"
-msgstr "Envases hechos"
-
-#. module: stock_move_packaging_qty
-#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move__product_packaging_qty
-msgid "Pkgs. Demand"
-msgstr "Envs. pedidos"
-
-#. module: stock_move_packaging_qty
-#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move__product_packaging_qty_done
-msgid "Pkgs. Done"
-msgstr "Envs. hechos"
 
 #. module: stock_move_packaging_qty
 #: model:ir.model,name:stock_move_packaging_qty.model_stock_move_line
@@ -68,19 +58,20 @@ msgid "Product Moves (Stock Move Line)"
 msgstr "Movimientos de existencias"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,help:stock_move_packaging_qty.field_stock_move_line__product_packaging_qty_done
-msgid "Product packaging quantity done."
-msgstr "Cantidad de envases hechos."
+#: model:ir.model.fields,help:stock_move_packaging_qty.field_stock_move_line__product_packaging_quantity
+msgid "Quantity done in Product Packaging"
+msgstr "Cantidad hecha en envase de producto"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,help:stock_move_packaging_qty.field_stock_move_line__product_packaging_qty_reserved
-msgid "Product packaging quantity reserved."
-msgstr "Cantidad de envases de productos reservados."
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
+msgid "Reserved Packaging Quantity"
+msgstr "Cantidad de envases reservada"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move_line__product_packaging_qty_reserved
-msgid "Reserved Pkg. Qty."
-msgstr "Envs. Reservados"
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_detailed_operation_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
+msgid "Reserved Pkg."
+msgstr "Envs. reservados"
 
 #. module: stock_move_packaging_qty
 #: model:ir.model,name:stock_move_packaging_qty.model_stock_move
@@ -90,16 +81,9 @@ msgstr "Movimiento de existencias"
 #. module: stock_move_packaging_qty
 #. odoo-python
 #: code:addons/stock_move_packaging_qty/models/stock_move.py:0
-#, python-format
 msgid ""
 "There are %d move lines involved. Please set their product packaging done "
 "qty directly."
 msgstr ""
-"Hay %d líneas de movimiento de existencias envueltas. Por favor, establezca "
-"sus cantidades de envases directamente."
-
-#~ msgid "Amount of packages demanded."
-#~ msgstr "Cantidad de envases pedidos."
-
-#~ msgid "Pkg. Qty."
-#~ msgstr "Cant. Envs."
+"Hay %d lineas de movimiento implicadas. Configure directamente su cantidad "
+"de envases hecha."

--- a/stock_move_packaging_qty/i18n/it.po
+++ b/stock_move_packaging_qty/i18n/it.po
@@ -4,62 +4,53 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2025-06-26 08:25+0000\n"
-"Last-Translator: mymage <stefano.consolaro@mymage.it>\n"
-"Language-Team: none\n"
+"POT-Creation-Date: 2026-04-17 07:22+0000\n"
+"PO-Revision-Date: 2026-04-17 07:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.10.4\n"
+"X-Generator: OpenCode\n"
 
 #. module: stock_move_packaging_qty
 #: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_operations
-msgid "<span> / </span>"
-msgstr "<span> / </span>"
+msgid "<span>(</span>"
+msgstr "<span>(</span>"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,help:stock_move_packaging_qty.field_stock_move__product_packaging_qty
-msgid "Amount of product packagings demanded."
-msgstr "Quantità di confezioni prodotto richieste."
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_operations
+msgid "<span>)</span>"
+msgstr "<span>)</span>"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,help:stock_move_packaging_qty.field_stock_move__product_packaging_qty_done
-msgid "Amount of product packagings done."
-msgstr "Quantità di confezioni prodotto completate."
+#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move__product_packaging_quantity
+#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move_line__product_packaging_quantity
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
+msgid "Done Packaging Quantity"
+msgstr "Quantita imballaggi completata"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move_line__product_packaging_qty_done
-msgid "Done Pkg. Qty."
-msgstr "Q.tà confezioni completate"
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_move_line_tree_detailed
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_picking_move_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_detailed_operation_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
+msgid "Done Pkg."
+msgstr "Imball. compl."
 
 #. module: stock_move_packaging_qty
 #: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move_line__product_packaging_id
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_move_line_form
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_move_line_tree_detailed
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_picking_move_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_detailed_operation_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
 msgid "Packaging"
 msgstr "Imballaggio"
-
-#. module: stock_move_packaging_qty
-#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_operations
-msgid "Packagings demanded"
-msgstr "Confezioni richieste"
-
-#. module: stock_move_packaging_qty
-#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_operations
-msgid "Packagings done"
-msgstr "Confezioni completate"
-
-#. module: stock_move_packaging_qty
-#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move__product_packaging_qty
-msgid "Pkgs. Demand"
-msgstr "Confezioni richieste"
-
-#. module: stock_move_packaging_qty
-#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move__product_packaging_qty_done
-msgid "Pkgs. Done"
-msgstr "Confezioni completate"
 
 #. module: stock_move_packaging_qty
 #: model:ir.model,name:stock_move_packaging_qty.model_stock_move_line
@@ -67,19 +58,20 @@ msgid "Product Moves (Stock Move Line)"
 msgstr "Movimenti prodotto (riga movimento di magazzino)"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,help:stock_move_packaging_qty.field_stock_move_line__product_packaging_qty_done
-msgid "Product packaging quantity done."
-msgstr "Quantità confezione prodotto completata."
+#: model:ir.model.fields,help:stock_move_packaging_qty.field_stock_move_line__product_packaging_quantity
+msgid "Quantity done in Product Packaging"
+msgstr "Quantita completata nell'imballaggio prodotto"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,help:stock_move_packaging_qty.field_stock_move_line__product_packaging_qty_reserved
-msgid "Product packaging quantity reserved."
-msgstr "Quantità imballo prodotto prenotata."
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
+msgid "Reserved Packaging Quantity"
+msgstr "Quantita imballaggi riservata"
 
 #. module: stock_move_packaging_qty
-#: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move_line__product_packaging_qty_reserved
-msgid "Reserved Pkg. Qty."
-msgstr "Q.tà imballo prenotata"
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_detailed_operation_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
+msgid "Reserved Pkg."
+msgstr "Imball. ris."
 
 #. module: stock_move_packaging_qty
 #: model:ir.model,name:stock_move_packaging_qty.model_stock_move
@@ -89,19 +81,9 @@ msgstr "Movimento di magazzino"
 #. module: stock_move_packaging_qty
 #. odoo-python
 #: code:addons/stock_move_packaging_qty/models/stock_move.py:0
-#, python-format
 msgid ""
 "There are %d move lines involved. Please set their product packaging done "
 "qty directly."
 msgstr ""
-"Ci sono %d righe movimento coinvolte. Impostare direttamente la loro "
-"quantità di confezione prodotto completata."
-
-#~ msgid "Amount of packages demanded."
-#~ msgstr "Quantità dei colli richiesti."
-
-#~ msgid "Pkg. Qty."
-#~ msgstr "Q.tà collo"
-
-#~ msgid "Package quantity"
-#~ msgstr "Quantità collo"
+"Sono coinvolte %d righe di movimento. Impostare direttamente la quantita "
+"completata del loro imballaggio prodotto."

--- a/stock_move_packaging_qty/i18n/stock_move_packaging_qty.pot
+++ b/stock_move_packaging_qty/i18n/stock_move_packaging_qty.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-17 07:22+0000\n"
+"PO-Revision-Date: 2026-04-17 07:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -31,8 +33,20 @@ msgid "Done Packaging Quantity"
 msgstr ""
 
 #. module: stock_move_packaging_qty
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_move_line_tree_detailed
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_picking_move_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_detailed_operation_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
+msgid "Done Pkg."
+msgstr ""
+
+#. module: stock_move_packaging_qty
 #: model:ir.model.fields,field_description:stock_move_packaging_qty.field_stock_move_line__product_packaging_id
 #: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_move_line_form
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_move_line_tree_detailed
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_picking_move_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_detailed_operation_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
 msgid "Packaging"
 msgstr ""
 
@@ -49,6 +63,12 @@ msgstr ""
 #. module: stock_move_packaging_qty
 #: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
 msgid "Reserved Packaging Quantity"
+msgstr ""
+
+#. module: stock_move_packaging_qty
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_detailed_operation_tree
+#: model_terms:ir.ui.view,arch_db:stock_move_packaging_qty.view_stock_move_line_operation_tree
+msgid "Reserved Pkg."
 msgstr ""
 
 #. module: stock_move_packaging_qty

--- a/stock_move_packaging_qty/views/stock_move_line_view.xml
+++ b/stock_move_packaging_qty/views/stock_move_line_view.xml
@@ -7,12 +7,10 @@
         <field name="model">stock.move.line</field>
         <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//field[@name='product_uom_id' and @readonly]"
-                position="after"
-            >
+            <xpath expr="//field[@name='quantity']" position="before">
                 <field
                     name="product_packaging_qty"
+                    string="Reserved Pkg."
                     invisible="not product_packaging_id"
                     groups="product.group_stock_packaging"
                     optional="hide"
@@ -20,6 +18,7 @@
                 />
                 <field
                     name="product_packaging_quantity"
+                    string="Done Pkg."
                     groups="product.group_stock_packaging"
                     invisible="not product_packaging_id"
                     readonly="(state == 'done' and is_locked) or (package_level_id and parent.picking_type_entire_packs)"
@@ -27,6 +26,7 @@
                 />
                 <field
                     name="product_packaging_id"
+                    string="Packaging"
                     groups="product.group_stock_packaging"
                 />
             </xpath>
@@ -63,19 +63,22 @@
             ref="stock.view_stock_move_line_detailed_operation_tree"
         />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='product_uom_id']" position="after">
+            <xpath expr="//field[@name='quantity']" position="before">
                 <field
                     name="product_packaging_qty"
+                    string="Reserved Pkg."
                     groups="product.group_stock_packaging"
                     optional="hide"
                 />
                 <field
                     name="product_packaging_quantity"
+                    string="Done Pkg."
                     groups="product.group_stock_packaging"
                     readonly="state in ('done', 'cancel') and is_locked"
                 />
                 <field
                     name="product_packaging_id"
+                    string="Packaging"
                     groups="product.group_stock_packaging"
                 />
             </xpath>
@@ -87,15 +90,17 @@
         <field name="model">stock.move.line</field>
         <field name="inherit_id" ref="stock.view_move_line_tree_detailed" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='product_uom_id']" position="after">
+            <xpath expr="//field[@name='quantity']" position="before">
                 <field
                     name="product_packaging_quantity"
+                    string="Done Pkg."
                     groups="product.group_stock_packaging"
                     invisible="not product_packaging_id"
                     optional="show"
                 />
                 <field
                     name="product_packaging_id"
+                    string="Packaging"
                     groups="product.group_stock_packaging"
                     optional="show"
                 />

--- a/stock_move_packaging_qty/views/stock_move_view.xml
+++ b/stock_move_packaging_qty/views/stock_move_view.xml
@@ -35,12 +35,14 @@
             <xpath expr="//field[@name='product_uom']" position="after">
                 <field
                     name="product_packaging_quantity"
+                    string="Done Pkg."
                     groups="product.group_stock_packaging"
                     readonly="not product_id or not is_quantity_done_editable or move_lines_count != 1"
                     invisible="not product_packaging_id"
                 />
                 <field
                     name="product_packaging_id"
+                    string="Packaging"
                     groups="product.group_stock_packaging"
                 />
             </xpath>


### PR DESCRIPTION
After the migration, users find annoying the change of column order as they expect it to be to the left of quantity instead of to the right.

<img width="963" height="229" alt="image" src="https://github.com/user-attachments/assets/49ca4b05-f43e-4477-9ba5-8e9bbe915d47" />
<img width="1091" height="170" alt="image" src="https://github.com/user-attachments/assets/bb57bb57-5ac0-4fc9-815e-930e8dda4cd2" />


cc @moduon MT-14533

please review @shide @EmilioPascual 