### PR TITLE
[FIX] stock_secondary_unit: skip missing keys in _get_aggregated_product_quantities

### DIFF
--- a/stock_secondary_unit/models/stock_move.py
+++ b/stock_secondary_unit/models/stock_move.py
@@ -68,6 +68,8 @@ class StockMoveLine(models.Model):
         aggregated_move_lines = super()._get_aggregated_product_quantities(**kwargs)
         for move_line in self:
             line_key = self._get_aggregated_properties(move_line=move_line)["line_key"]
+            if line_key not in aggregated_move_lines:
+                continue
             aggregated_move_lines[line_key]["secondary_uom_qty"] = (
                 move_line.secondary_uom_qty
             )


### PR DESCRIPTION
## Problem

When packages are used on a picking, `super()._get_aggregated_product_quantities()` filters out some move lines (e.g. those assigned to a package via `strict=True` or `except_package=True`). Their `line_key` is therefore absent from `aggregated_move_lines`, and the subsequent direct dict access raises `KeyError`:

```python
aggregated_move_lines[line_key]["secondary_uom_qty"] = ...  # KeyError
```

## Fix

Add a guard to skip move lines whose key was not included by the parent method:

```python
if line_key not in aggregated_move_lines:
    continue
```

## Steps to reproduce

1. Install `stock_secondary_unit`
2. Create a picking with products that have a secondary UOM
3. Assign move lines to packages
4. Validate the picking → `KeyError` in `_get_aggregated_product_quantities`