### PR TITLE
[16.0][FIX] base_product_merge: Use ORM method as default / stock_move_auto_assign_auto_release: Don't test wrong move

### DIFF
--- a/base_product_merge/wizard/base_product_merge.py
+++ b/base_product_merge/wizard/base_product_merge.py
@@ -51,7 +51,7 @@ class BaseProductMerge(models.Model):
         "product_tmpl_id",
         string="Products Template to merge",
     )
-    merge_method = fields.Selection([("sql", "SQL"), ("orm", "ORM")], default="sql")
+    merge_method = fields.Selection([("sql", "SQL"), ("orm", "ORM")], default="orm")
 
     def action_merge(self):
         if self.ptype == "product.product":

--- a/stock_move_auto_assign_auto_release/tests/test_assign_auto_release.py
+++ b/stock_move_auto_assign_auto_release/tests/test_assign_auto_release.py
@@ -108,7 +108,7 @@ class TestAssignAutoRelease(PromiseReleaseCommonCase):
                 self.unreleased_move.picking_id.auto_release_available_to_promise,
             )
             job.perform()
-        self.assertFalse(self.unreleased_move.need_release)
+        self.assertFalse(self.picking.move_ids.need_release)
         self.assertEqual(1, len(self.picking.move_ids))
         self.assertEqual(10, self.picking.move_ids.product_qty)
 


### PR DESCRIPTION
@JasminSForgeFlow @metaminux 

Related to : https://github.com/OCA/stock-logistics-warehouse/issues/2585