### PR TITLE
[18.0][IMP] stock_location_lockdown: add outbound lock

### DIFF
--- a/stock_location_lockdown/README.rst
+++ b/stock_location_lockdown/README.rst
@@ -77,6 +77,7 @@ Authors
 -------
 
 * Akretion
+* Camptocamp
 
 Contributors
 ------------
@@ -84,6 +85,7 @@ Contributors
 - Florian da Costa <florian.dacosta@akretion.com>
 - David Montull Guasch <david.montull@bt-group.com>
 - Urvisha Desai <udesai@opensourceintegrators.com>
+- David Gallay <david.gallay@camptocamp.com>
 
 Maintainers
 -----------

--- a/stock_location_lockdown/__init__.py
+++ b/stock_location_lockdown/__init__.py
@@ -2,3 +2,19 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+
+
+def pre_init_hook(env):
+    """Create the outbound reservation lock columns with a SQL default so the
+    existing (potentially huge) stock_quant table is initialised in one pass,
+    instead of the ORM filling the default row by row when the fields are
+    loaded."""
+    env.cr.execute(
+        """
+        ALTER TABLE stock_quant
+        ADD COLUMN IF NOT EXISTS lock_real_reserved double precision DEFAULT 0.0;
+        ALTER TABLE stock_quant
+        ADD COLUMN IF NOT EXISTS is_outbound_reservation_locked boolean
+            DEFAULT false;
+        """
+    )

--- a/stock_location_lockdown/__manifest__.py
+++ b/stock_location_lockdown/__manifest__.py
@@ -4,13 +4,17 @@
 {
     "name": "Stock Location Lockdown",
     "summary": "Prevent to add stock on locked locations",
-    "author": "Akretion, Odoo Community Association (OCA)",
+    "author": "Akretion, Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "category": "Warehouse",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["stock"],
-    "data": ["views/stock_location.xml"],
+    "pre_init_hook": "pre_init_hook",
+    "depends": ["stock", "stock_inventory"],
+    "data": [
+        "views/res_config_settings_views.xml",
+        "views/stock_location.xml",
+    ],
 }

--- a/stock_location_lockdown/models/__init__.py
+++ b/stock_location_lockdown/models/__init__.py
@@ -1,5 +1,11 @@
 # Copyright 2019 Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import res_company
+from . import res_config_settings
+from . import stock_inventory
 from . import stock_location
+from . import stock_move_line
 from . import stock_quant
+from . import stock_rule
+from . import stock_route

--- a/stock_location_lockdown/models/res_company.py
+++ b/stock_location_lockdown/models/res_company.py
@@ -1,4 +1,3 @@
-# Copyright 2026 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models

--- a/stock_location_lockdown/models/res_company.py
+++ b/stock_location_lockdown/models/res_company.py
@@ -1,0 +1,36 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    allow_lockdown_on_stocked_location = fields.Boolean(
+        string="Allow Inbound Lockdown on Stocked Locations",
+        help="When enabled, an internal location can be marked as "
+        "'Block Stock Entrance' even if it already contains stock.",
+    )
+    block_location_on_inventory = fields.Boolean(
+        string="Block Location on Inventory",
+        help="When enabled, a location (and its descendants) is treated as "
+        "blocked for both inbound and outbound while an inventory is "
+        "in progress on it.",
+    )
+
+    def _refresh_inventory_blocked(self, company_ids):
+        locations = (
+            self.env["stock.location"]
+            .sudo()
+            .search([("company_id", "in", company_ids)])
+        )
+        if locations:
+            locations._compute_is_inventory_blocked()
+
+    def write(self, vals):
+        refresh_inventory = "block_location_on_inventory" in vals
+        res = super().write(vals)
+        if refresh_inventory:
+            self._refresh_inventory_blocked(self.ids + [False])
+        return res

--- a/stock_location_lockdown/models/res_config_settings.py
+++ b/stock_location_lockdown/models/res_config_settings.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    allow_lockdown_on_stocked_location = fields.Boolean(
+        related="company_id.allow_lockdown_on_stocked_location",
+        readonly=False,
+    )
+    block_location_on_inventory = fields.Boolean(
+        related="company_id.block_location_on_inventory",
+        readonly=False,
+    )

--- a/stock_location_lockdown/models/res_config_settings.py
+++ b/stock_location_lockdown/models/res_config_settings.py
@@ -1,4 +1,3 @@
-# Copyright 2026 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models

--- a/stock_location_lockdown/models/stock_inventory.py
+++ b/stock_location_lockdown/models/stock_inventory.py
@@ -1,4 +1,3 @@
-# Copyright 2026 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models

--- a/stock_location_lockdown/models/stock_inventory.py
+++ b/stock_location_lockdown/models/stock_inventory.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class StockInventory(models.Model):
+    _inherit = "stock.inventory"
+
+    def _block_location_on_inventory(self):
+        """Return the subset of ``self`` whose effective company has the
+        ``block_location_on_inventory`` setting enabled. Inventories not in
+        this subset have no impact on stock.location.is_inventory_blocked and
+        must not trigger recomputes for their own location subtree."""
+        return self.filtered(
+            lambda inv: (inv.company_id or inv.env.company).block_location_on_inventory
+        )
+
+    def _affected_inventory_lock_locations(self):
+        if not self.location_ids:
+            return self.env["stock.location"]
+        return self.env["stock.location"].search(
+            [("id", "child_of", self.location_ids)]
+        )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        relevant = records._block_location_on_inventory()
+        if relevant:
+            affected_locs = relevant._affected_inventory_lock_locations()
+            affected_locs._compute_is_inventory_blocked()
+        return records
+
+    def write(self, vals):
+        relevant = self._block_location_on_inventory()
+        track = bool(relevant and {"state", "location_ids"} & set(vals))
+        before_locs = self.env["stock.location"]
+        if track:
+            before_locs = relevant._affected_inventory_lock_locations()
+        res = super().write(vals)
+        if track:
+            after_locs = relevant._affected_inventory_lock_locations()
+            affected_locs = before_locs | after_locs
+            affected_locs._compute_is_inventory_blocked()
+        return res
+
+    def unlink(self):
+        relevant = self._block_location_on_inventory()
+        locs = (
+            relevant._affected_inventory_lock_locations()
+            if relevant
+            else self.env["stock.location"]
+        )
+        res = super().unlink()
+        if locs:
+            locs._compute_is_inventory_blocked()
+        return res

--- a/stock_location_lockdown/models/stock_location.py
+++ b/stock_location_lockdown/models/stock_location.py
@@ -14,7 +14,7 @@ class StockLocation(models.Model):
         "aggregation."
     )
     block_stock_exit = fields.Boolean(
-        help="If checked, taking stock out of this location won't be allowed. "
+        help="If checked, moving goods out of this location won't be allowed. "
         "Quants on this location are treated as if reserved and won't be "
         "available for picking. Propagates to descendant locations through "
         "the outbound block aggregation."

--- a/stock_location_lockdown/models/stock_location.py
+++ b/stock_location_lockdown/models/stock_location.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -9,25 +9,223 @@ class StockLocation(models.Model):
     _inherit = "stock.location"
 
     block_stock_entrance = fields.Boolean(
-        help="If this box is checked, putting stock on this location won't be "
-        "allowed. Use this to temporarily block stock movements or to enforce "
-        "restrictions in both physical and virtual locations."
+        help="If checked, putting stock on this location won't be allowed. "
+        "Propagates to descendant locations through the inbound block "
+        "aggregation."
+    )
+    block_stock_exit = fields.Boolean(
+        help="If checked, taking stock out of this location won't be allowed. "
+        "Quants on this location are treated as if reserved and won't be "
+        "available for picking. Propagates to descendant locations through "
+        "the outbound block aggregation."
+    )
+    no_physical_stock = fields.Boolean(
+        help="If checked, this location is a grouping / non-physical node: "
+        "stock cannot enter or leave it. Use this on internal-tree "
+        "intermediate locations that can't be marked as 'View' (Odoo bug "
+        "#26679). Does NOT propagate to child locations."
+    )
+    is_ancestor_inbound_blocked = fields.Boolean(
+        compute="_compute_is_ancestor_inbound_blocked",
+        store=True,
+        recursive=True,
+        help="True if a strict ancestor of this location has "
+        "'Block Stock Entrance' set.",
+    )
+    is_ancestor_outbound_blocked = fields.Boolean(
+        compute="_compute_is_ancestor_outbound_blocked",
+        store=True,
+        recursive=True,
+        help="True if a strict ancestor of this location has "
+        "'Block Stock Exit' set.",
+    )
+    is_inventory_blocked = fields.Boolean(
+        compute="_compute_is_inventory_blocked",
+        store=True,
+        help="True if the company opts into inventory-driven lockdown and an "
+        "in-progress inventory covers this location or any ancestor. "
+        "Inventory locks both directions, so a single flag is used.",
+    )
+    is_inbound_blocked = fields.Boolean(
+        compute="_compute_is_inbound_blocked",
+        store=True,
+        help="Aggregated inbound block flag (self / ancestor / inventory). "
+        "Use this for condition evaluation, not 'Block Stock Entrance' "
+        "directly.",
+    )
+    is_outbound_blocked = fields.Boolean(
+        compute="_compute_is_outbound_blocked",
+        store=True,
+        help="Aggregated outbound block flag (self / ancestor / inventory). "
+        "Use this for condition evaluation, not 'Block Stock Exit' directly.",
     )
 
-    # Raise error if the location that you're trying to block
-    # has already got quants
-    def write(self, values):
-        res = super().write(values)
+    # ------------------------------------------------------------------
+    # Depends declarations as overridable model methods so child modules
+    # can extend the dependency graph without rewriting the decorator.
+    # ------------------------------------------------------------------
 
-        if "block_stock_entrance" in values and values["block_stock_entrance"]:
-            # Unlink zero quants before checking
-            # if there are quants on the location
-            self.env["stock.quant"]._unlink_zero_quants()
-            if self.mapped("quant_ids"):
-                raise UserError(
-                    self.env._(
-                        "It is impossible to prohibit this location from\
-                    receiving products as it already contains some."
-                    )
-                )
+    @api.model
+    def _is_ancestor_inbound_blocked_depends(self):
+        return (
+            "location_id.block_stock_entrance",
+            "location_id.is_ancestor_inbound_blocked",
+        )
+
+    @api.model
+    def _is_ancestor_outbound_blocked_depends(self):
+        return (
+            "location_id.block_stock_exit",
+            "location_id.is_ancestor_outbound_blocked",
+        )
+
+    @api.model
+    def _is_inventory_blocked_depends(self):
+        return ("parent_path", "company_id")
+
+    @api.model
+    def _is_inbound_blocked_depends(self):
+        return (
+            "block_stock_entrance",
+            "no_physical_stock",
+            "is_ancestor_inbound_blocked",
+            "is_inventory_blocked",
+        )
+
+    @api.model
+    def _is_outbound_blocked_depends(self):
+        return (
+            "block_stock_exit",
+            "no_physical_stock",
+            "is_ancestor_outbound_blocked",
+            "is_inventory_blocked",
+        )
+
+    # ------------------------------------------------------------------
+    # Compute methods
+    # ------------------------------------------------------------------
+
+    @api.depends(lambda self: self._is_ancestor_inbound_blocked_depends())
+    def _compute_is_ancestor_inbound_blocked(self):
+        for loc in self:
+            parent = loc.location_id
+            loc.is_ancestor_inbound_blocked = bool(
+                parent
+                and (parent.block_stock_entrance or parent.is_ancestor_inbound_blocked)
+            )
+
+    @api.depends(lambda self: self._is_ancestor_outbound_blocked_depends())
+    def _compute_is_ancestor_outbound_blocked(self):
+        for loc in self:
+            parent = loc.location_id
+            loc.is_ancestor_outbound_blocked = bool(
+                parent
+                and (parent.block_stock_exit or parent.is_ancestor_outbound_blocked)
+            )
+
+    @api.depends(lambda self: self._is_inventory_blocked_depends())
+    def _compute_is_inventory_blocked(self):
+        for loc in self:
+            loc.is_inventory_blocked = loc._is_inventory_locked()
+
+    @api.depends(lambda self: self._is_inbound_blocked_depends())
+    def _compute_is_inbound_blocked(self):
+        for loc in self:
+            loc.is_inbound_blocked = (
+                loc.block_stock_entrance
+                or loc.no_physical_stock
+                or loc.is_ancestor_inbound_blocked
+                or loc.is_inventory_blocked
+            )
+
+    @api.depends(lambda self: self._is_outbound_blocked_depends())
+    def _compute_is_outbound_blocked(self):
+        for loc in self:
+            loc.is_outbound_blocked = (
+                loc.block_stock_exit
+                or loc.no_physical_stock
+                or loc.is_ancestor_outbound_blocked
+                or loc.is_inventory_blocked
+            )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _ancestor_location_ids(self, include_self=True):
+        """Return ids on the materialized parent_path."""
+        self.ensure_one()
+        ids = [int(x) for x in (self.parent_path or "").split("/") if x]
+        if not include_self:
+            ids = [i for i in ids if i != self.id]
+        return ids
+
+    def _is_inventory_locked(self):
+        """True if an in-progress inventory covers this location (or an
+        ancestor) and the relevant company opts in."""
+        self.ensure_one()
+        company = self.company_id or self.env.company
+        if not company.block_location_on_inventory:
+            return False
+        ancestor_ids = self._ancestor_location_ids(include_self=True)
+        if not ancestor_ids:
+            return False
+        return bool(
+            self.env["stock.inventory"]
+            .sudo()
+            .search_count(
+                [
+                    ("state", "=", "in_progress"),
+                    ("location_ids", "in", ancestor_ids),
+                ],
+                limit=1,
+            )
+        )
+
+    def write(self, vals):
+        res = super().write(vals)
+        # When the outbound block is toggled directly on a location, pin/unpin
+        # the reservation lock on the stock in its subtree so blocked quants
+        # stop being available for picking (and unblocked ones come back).
+        # TODO(?): is_outbound_blocked also flips via ancestors and via the
+        # inventory toggle (res.company / stock.inventory triggers). Those
+        # paths do not pass through this write and would need to resync the
+        # reservation lock too.
+        if "block_stock_exit" in vals:
+            self.env["stock.quant"].sudo().search(
+                [("location_id", "child_of", self.ids)]
+            )._resync_outbound_reservation_lock()
         return res
+
+    # ------------------------------------------------------------------
+    # Constraints
+    # ------------------------------------------------------------------
+
+    @api.constrains("block_stock_entrance")
+    def _check_block_stock_entrance(self):
+        self.filtered("block_stock_entrance")._check_lockdown_against_existing_stock(
+            "Block Stock Entrance"
+        )
+
+    @api.constrains("no_physical_stock")
+    def _check_no_physical_stock(self):
+        self.filtered("no_physical_stock")._check_lockdown_against_existing_stock(
+            "No Physical Stock"
+        )
+
+    def _check_lockdown_against_existing_stock(self, label):
+        """Raise if a location to be blocked already contains stock and the
+        company has not opted in to allowing that."""
+        if not self or self.env.company.allow_lockdown_on_stocked_location:
+            return
+        self.env["stock.quant"]._unlink_zero_quants()
+        stocked = self.filtered("quant_ids")
+        if stocked:
+            raise UserError(
+                self.env._(
+                    "Cannot enable '%(label)s' on locations that already "
+                    "contain stock: %(locs)s",
+                    label=label,
+                    locs=", ".join(stocked.mapped("display_name")),
+                )
+            )

--- a/stock_location_lockdown/models/stock_move_line.py
+++ b/stock_location_lockdown/models/stock_move_line.py
@@ -1,4 +1,3 @@
-# Copyright 2026 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models

--- a/stock_location_lockdown/models/stock_move_line.py
+++ b/stock_location_lockdown/models/stock_move_line.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+from odoo.exceptions import ValidationError
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    @api.constrains("location_id", "location_dest_id", "state")
+    def _check_blocked_location(self):
+        for line in self.filtered(lambda m: m.state == "done"):
+            if line.location_id.is_outbound_blocked:
+                raise ValidationError(
+                    self.env._(
+                        "The location %(location)s is blocked for outbound and "
+                        "stock cannot be moved out of it.",
+                        location=line.location_id.display_name,
+                    )
+                )
+            if line.location_dest_id.is_inbound_blocked:
+                raise ValidationError(
+                    self.env._(
+                        "The location %(location)s is blocked for inbound and "
+                        "stock cannot be moved into it.",
+                        location=line.location_dest_id.display_name,
+                    )
+                )

--- a/stock_location_lockdown/models/stock_move_line.py
+++ b/stock_location_lockdown/models/stock_move_line.py
@@ -23,7 +23,7 @@ class StockMoveLine(models.Model):
                 raise ValidationError(
                     self.env._(
                         "The location %(location)s is blocked for inbound and "
-                        "stock cannot be moved into it.",
+                        "goods cannot be moved into it.",
                         location=line.location_dest_id.display_name,
                     )
                 )

--- a/stock_location_lockdown/models/stock_move_line.py
+++ b/stock_location_lockdown/models/stock_move_line.py
@@ -15,7 +15,7 @@ class StockMoveLine(models.Model):
                 raise ValidationError(
                     self.env._(
                         "The location %(location)s is blocked for outbound and "
-                        "stock cannot be moved out of it.",
+                        "goods cannot be moved out of it.",
                         location=line.location_id.display_name,
                     )
                 )

--- a/stock_location_lockdown/models/stock_quant.py
+++ b/stock_location_lockdown/models/stock_quant.py
@@ -1,19 +1,54 @@
 # Copyright 2019 Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
 
 class StockQuant(models.Model):
     _inherit = "stock.quant"
 
+    # Outbound reservation lock: for a quant in an outbound-blocked location we
+    # hold ``reserved_quantity == quantity`` so the stock is not available for
+    # picking (available = quantity - reserved = 0) and is removed from the
+    # forecast figures natively. The genuine reservation is parked here so it
+    # can be restored when the location is unblocked.
+    lock_real_reserved = fields.Float(default=0.0)
+    is_outbound_reservation_locked = fields.Boolean(default=False)
+
+    def _check_location_outbound_blocked(self):
+        # Outbound block: a quant cannot leave a location that is outbound
+        # blocked. @api.constrains sees only the post-write location_id, so the
+        # source must be checked before the value is overwritten.
+        for quant in self:
+            if quant.location_id.is_outbound_blocked:
+                raise ValidationError(
+                    self.env._(
+                        "The location %(location)s is blocked for outbound "
+                        "and the product %(product)s cannot be moved out of it"
+                    )
+                    % {
+                        "location": quant.location_id.display_name,
+                        "product": quant.product_id.display_name,
+                    }
+                )
+
+    def write(self, vals):
+        if "location_id" in vals:
+            self._check_location_outbound_blocked()
+        # TODO(?): a direct write({"reserved_quantity": ...}) bypasses
+        # _update_reserved_quantity and would desync the outbound reservation
+        # lock (reserved_quantity vs lock_real_reserved). Do we enforce that all
+        # reserved_quantity changes go through the _update_reserved_quantity
+        # funnel, or accept that direct writes are not lock-aware?
+        return super().write(vals)
+
     # Raise an error when trying to change a quant
     # which corresponding stock location is blocked
     @api.constrains("location_id")
     def check_location_blocked(self):
         for record in self:
-            if record.location_id.block_stock_entrance:
+            if record.location_id.is_inbound_blocked:
                 raise ValidationError(
                     self.env._(
                         "The location %(location)s is blocked and can "
@@ -24,3 +59,111 @@ class StockQuant(models.Model):
                         "product": record.product_id.display_name,
                     }
                 )
+
+    # ------------------------------------------------------------------
+    # Outbound reservation lock
+
+    # TODO: the reservation pinning should be a dedicated module
+    def _is_outbound_reservation_pinned(self):
+        """Whether this quant's reserved_quantity is currently held at quantity
+        for the outbound lock. Single source of truth for the pinned state, so
+        callers never read the storage field directly."""
+        self.ensure_one()
+        return self.is_outbound_reservation_locked
+
+    def _pin_outbound_reservation(self):
+        """Hold reserved_quantity at quantity, parking the genuine reservation
+        in lock_real_reserved, so the stock is unavailable for picking."""
+        for quant in self:
+            if quant._is_outbound_reservation_pinned():
+                continue
+            quant.lock_real_reserved = quant.reserved_quantity
+            quant.reserved_quantity = quant.quantity
+            quant.is_outbound_reservation_locked = True
+
+    def _unpin_outbound_reservation(self):
+        """Restore the genuine reserved_quantity so core logic operates on the
+        real numbers."""
+        for quant in self:
+            if not quant._is_outbound_reservation_pinned():
+                continue
+            quant.reserved_quantity = quant.lock_real_reserved
+            quant.lock_real_reserved = 0.0
+            quant.is_outbound_reservation_locked = False
+
+    def _resync_outbound_reservation_lock(self):
+        """Pin/unpin each quant to match its location's outbound-blocked
+        state."""
+        for quant in self:
+            if quant.location_id.is_outbound_blocked:
+                quant._pin_outbound_reservation()
+            else:
+                quant._unpin_outbound_reservation()
+
+    @api.model
+    def _update_reserved_quantity(
+        self,
+        product_id,
+        location_id,
+        quantity,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=True,
+    ):
+        inner = self.with_context(skip_outbound_reservation_lock=True)
+        quants = inner._gather(
+            product_id,
+            location_id,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )
+        pinned = quants.filtered(lambda q: q._is_outbound_reservation_pinned())
+        # Normal behavior unless some targeted quants are pinned by the outbound
+        # reservation lock (and the lock is not bypassed via context): then
+        # divert the change to the genuine reserved value (lock_real_reserved)
+        # and keep reserved_quantity pinned at quantity so the stock stays
+        # unavailable.
+        if self.env.context.get("skip_outbound_reservation_lock") or not pinned:
+            return super()._update_reserved_quantity(
+                product_id,
+                location_id,
+                quantity,
+                lot_id=lot_id,
+                package_id=package_id,
+                owner_id=owner_id,
+                strict=strict,
+            )
+        # Expose the genuine reserved values, let core apply the delta, then
+        # re-pin so picking still sees nothing available.
+        quants._unpin_outbound_reservation()
+        res = super(StockQuant, inner)._update_reserved_quantity(
+            product_id,
+            location_id,
+            quantity,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )
+        # Re-pin the same quants we unpinned, rather than re-gathering: a child
+        # module could override _gather to conditionally drop quants, which
+        # would leave some unpinned. .exists() guards against a zero quant that
+        # super may have unlinked.
+        quants.exists()._resync_outbound_reservation_lock()
+        return res
+
+    @api.model
+    def _clean_reservations(self):
+        # The reconciler compares reserved_quantity against the real move-line
+        # reservations and would otherwise erase the pinned inflation. Expose
+        # the genuine reserved values, reconcile, then re-pin.
+        locked = self.sudo().search([("is_outbound_reservation_locked", "=", True)])
+        locked._unpin_outbound_reservation()
+        res = super()._clean_reservations()
+        self.sudo().search(
+            [("location_id.is_outbound_blocked", "=", True)]
+        )._resync_outbound_reservation_lock()
+        return res

--- a/stock_location_lockdown/models/stock_route.py
+++ b/stock_location_lockdown/models/stock_route.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# from odoo import api, fields, models
+
+
+# class StockRoute(models.Model):
+#     _inherit = "stock.route"
+
+#     is_location_blocked = fields.Boolean(
+#         compute="_compute_is_location_blocked",
+#         store=True,
+#         help="True if any of the route's rules has a blocked source or "
+#         "destination location. Use this for route selection filtering.",
+#     )
+
+#     @api.model
+#     def _is_location_blocked_depends(self):
+#         return ("rule_ids.is_location_blocked",)
+
+#     @api.depends(lambda self: self._is_location_blocked_depends())
+#     def _compute_is_location_blocked(self):
+#         for route in self:
+#             route.is_location_blocked = any(
+#                 rule.is_location_blocked for rule in route.rule_ids
+#             )

--- a/stock_location_lockdown/models/stock_route.py
+++ b/stock_location_lockdown/models/stock_route.py
@@ -1,4 +1,3 @@
-# Copyright 2026 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 # from odoo import api, fields, models

--- a/stock_location_lockdown/models/stock_rule.py
+++ b/stock_location_lockdown/models/stock_rule.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    is_location_blocked = fields.Boolean(
+        compute="_compute_is_location_blocked",
+        store=True,
+        help="True if the rule's source location is outbound-blocked or its "
+        "destination location is inbound-blocked. Use this for rule/route "
+        "selection filtering, not the underlying location flags directly.",
+    )
+
+    @api.model
+    def _is_location_blocked_depends(self):
+        return (
+            "location_src_id.is_outbound_blocked",
+            "location_dest_id.is_inbound_blocked",
+        )
+
+    @api.depends(lambda self: self._is_location_blocked_depends())
+    def _compute_is_location_blocked(self):
+        for rule in self:
+            rule.is_location_blocked = (
+                rule.location_src_id.is_outbound_blocked
+                or rule.location_dest_id.is_inbound_blocked
+            )

--- a/stock_location_lockdown/models/stock_rule.py
+++ b/stock_location_lockdown/models/stock_rule.py
@@ -1,4 +1,3 @@
-# Copyright 2026 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models

--- a/stock_location_lockdown/readme/CONTRIBUTORS.md
+++ b/stock_location_lockdown/readme/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 - Florian da Costa \<<florian.dacosta@akretion.com>\>
 - David Montull Guasch \<<david.montull@bt-group.com>\>
 - Urvisha Desai \<<udesai@opensourceintegrators.com>\>
+- David Gallay \<<david.gallay@camptocamp.com>\>

--- a/stock_location_lockdown/static/description/index.html
+++ b/stock_location_lockdown/static/description/index.html
@@ -424,6 +424,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
 <ul class="simple">
 <li>Akretion</li>
+<li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -432,6 +433,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Florian da Costa &lt;<a class="reference external" href="mailto:florian.dacosta&#64;akretion.com">florian.dacosta&#64;akretion.com</a>&gt;</li>
 <li>David Montull Guasch &lt;<a class="reference external" href="mailto:david.montull&#64;bt-group.com">david.montull&#64;bt-group.com</a>&gt;</li>
 <li>Urvisha Desai &lt;<a class="reference external" href="mailto:udesai&#64;opensourceintegrators.com">udesai&#64;opensourceintegrators.com</a>&gt;</li>
+<li>David Gallay &lt;<a class="reference external" href="mailto:david.gallay&#64;camptocamp.com">david.gallay&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_location_lockdown/tests/__init__.py
+++ b/stock_location_lockdown/tests/__init__.py
@@ -2,3 +2,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_block_stock_location_entrance
+from . import test_block_stock_location_exit
+from . import test_block_stock_location_reservation
+from . import test_block_stock_location_routing

--- a/stock_location_lockdown/tests/common.py
+++ b/stock_location_lockdown/tests/common.py
@@ -1,4 +1,3 @@
-# Copyright 2026 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.addons.base.tests.common import BaseCommon

--- a/stock_location_lockdown/tests/common.py
+++ b/stock_location_lockdown/tests/common.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.base.tests.common import BaseCommon
+
+
+class StockLocationLockdownCommon(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Location = cls.env["stock.location"]
+        cls.Quant = cls.env["stock.quant"]
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+        cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test product lockdown",
+                "type": "consu",
+                "is_storable": True,
+                "tracking": "none",
+            }
+        )
+        cls.free_location = cls.Location.create(
+            {
+                "name": "free",
+                "usage": "internal",
+                "location_id": cls.stock_location.id,
+            }
+        )
+
+    def _create_move(self, source, dest, qty):
+        return self.env["stock.move"].create(
+            {
+                "location_id": source.id,
+                "location_dest_id": dest.id,
+                "product_id": self.product.id,
+                "product_uom_qty": qty,
+                "quantity": qty,
+                "picked": True,
+                "product_uom": self.product.uom_id.id,
+                "name": "test move",
+                "move_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_id": self.product.uom_id.id,
+                            "quantity": qty,
+                            "location_id": source.id,
+                            "location_dest_id": dest.id,
+                        },
+                    )
+                ],
+            }
+        )

--- a/stock_location_lockdown/tests/test_block_stock_location_entrance.py
+++ b/stock_location_lockdown/tests/test_block_stock_location_entrance.py
@@ -2,97 +2,85 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests.common import TransactionCase
+
+from .common import StockLocationLockdownCommon
 
 
-class TestStockLocationLockdown(TransactionCase):
+class TestStockLocationInboundLockdown(StockLocationLockdownCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # Empty internal location blocked for inbound, plus a child (to assert
+        # descendant propagation) and a separately stocked location (to assert
+        # the "cannot block stocked location" guard).
+        cls.locked_location = cls.Location.create(
+            {
+                "name": "inbound_locked",
+                "usage": "internal",
+                "location_id": cls.stock_location.id,
+            }
+        )
+        cls.child_location = cls.Location.create(
+            {
+                "name": "inbound_locked_child",
+                "usage": "internal",
+                "location_id": cls.locked_location.id,
+            }
+        )
+        cls.stocked_location = cls.Location.create(
+            {
+                "name": "stocked",
+                "usage": "internal",
+                "location_id": cls.stock_location.id,
+            }
+        )
+        cls.Quant._update_available_quantity(cls.product, cls.stocked_location, 10)
+        cls.locked_location.block_stock_entrance = True
 
-        # Create a new stock location with no quants and blocked stock entrance
-        new_loc = {"name": "location_test", "usage": "internal"}
-        cls.new_stock_location = cls.env["stock.location"].create(new_loc)
-        cls.new_stock_location.block_stock_entrance = True
+    def test_inbound_flag_propagates_to_child(self):
+        """The inbound block aggregates down the location tree."""
+        self.assertTrue(self.locked_location.is_inbound_blocked)
+        self.assertTrue(self.child_location.is_inbound_blocked)
+        # Inbound block must not imply outbound block.
+        self.assertFalse(self.locked_location.is_outbound_blocked)
 
-        cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
-        cls.customer_location = cls.env.ref("stock.stock_location_customers")
-
-        # Call an existing product and force no Lot/Serial Number tracking
-        cls.product = cls.env.ref("product.product_product_27")
-        cls.product.tracking = "none"
-
-        # Catch the first quant's stock location
-        cls.stock_location = cls.env["stock.quant"].search([])[0].location_id
-
-    def test_transfer_stock_in_locked_location(self):
-        """
-        Test to move stock within a location that should not accept
-        stock entrance.
-        """
-        move_vals = {
-            "location_id": self.supplier_location.id,
-            "location_dest_id": self.new_stock_location.id,
-            "product_id": self.product.id,
-            "product_uom_qty": self.product.qty_available + 1,
-            "quantity": self.product.qty_available + 1,
-            "picked": True,
-            "product_uom": self.product.uom_id.id,
-            "name": "test",
-            "move_line_ids": [
-                (
-                    0,
-                    0,
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "quantity": self.product.qty_available + 1,
-                        "location_id": self.supplier_location.id,
-                        "location_dest_id": self.new_stock_location.id,
-                    },
-                )
-            ],
-        }
-        stock_move = self.env["stock.move"].create(move_vals)
-
+    def test_move_into_blocked_location(self):
+        """Validating a move into an inbound-blocked location is refused."""
+        move = self._create_move(self.supplier_location, self.locked_location, 5)
         with self.assertRaises(ValidationError):
-            stock_move._action_done()
+            move._action_done()
 
-    def test_transfer_stock_out_locked_location(self):
-        """
-        Test to move stock out from a location that should not accept
-        stock removal.
-        """
-        move_vals = {
-            "location_id": self.new_stock_location.id,
-            "location_dest_id": self.customer_location.id,
-            "product_id": self.product.id,
-            "product_uom_qty": self.product.qty_available + 1,
-            "quantity": self.product.qty_available + 1,
-            "picked": True,
-            "product_uom": self.product.uom_id.id,
-            "name": "test",
-            "move_line_ids": [
-                (
-                    0,
-                    0,
-                    {
-                        "product_id": self.product.id,
-                        "product_uom_id": self.product.uom_id.id,
-                        "quantity": self.product.qty_available + 1,
-                        "location_id": self.new_stock_location.id,
-                        "location_dest_id": self.customer_location.id,
-                    },
-                )
-            ],
-        }
+    def test_move_into_blocked_child_location(self):
+        """The block reaches descendants through is_inbound_blocked."""
+        move = self._create_move(self.supplier_location, self.child_location, 5)
         with self.assertRaises(ValidationError):
-            self.env["stock.move"].create(move_vals)
+            move._action_done()
 
-    def test_block_location_with_quants(self):
-        """
-        Test to click on block_stock_entrance checkbox in a location
-        that should not be blocked because it has already got quants
-        """
+    def test_move_out_of_blocked_location_allowed(self):
+        """Inbound block does not prevent taking stock out of the location."""
+        # Allow blocking a stocked location, seed stock, then block inbound.
+        self.env.company.allow_lockdown_on_stocked_location = True
+        out_location = self.Location.create(
+            {
+                "name": "inbound_locked_with_stock",
+                "usage": "internal",
+                "location_id": self.stock_location.id,
+            }
+        )
+        self.Quant._update_available_quantity(self.product, out_location, 10)
+        out_location.block_stock_entrance = True
+
+        move = self._create_move(out_location, self.customer_location, 3)
+        move._action_done()
+        self.assertEqual(move.state, "done")
+
+    def test_block_location_with_quants_refused(self):
+        """Enabling the inbound block on a stocked location is refused."""
         with self.assertRaises(UserError):
-            self.stock_location.write({"block_stock_entrance": True})
+            self.stocked_location.write({"block_stock_entrance": True})
+
+    def test_block_stocked_location_allowed_with_company_setting(self):
+        """The company setting bypasses the stocked-location guard."""
+        self.env.company.allow_lockdown_on_stocked_location = True
+        self.stocked_location.write({"block_stock_entrance": True})
+        self.assertTrue(self.stocked_location.is_inbound_blocked)

--- a/stock_location_lockdown/tests/test_block_stock_location_exit.py
+++ b/stock_location_lockdown/tests/test_block_stock_location_exit.py
@@ -1,4 +1,3 @@
-# Copyright 2026 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import ValidationError

--- a/stock_location_lockdown/tests/test_block_stock_location_exit.py
+++ b/stock_location_lockdown/tests/test_block_stock_location_exit.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import ValidationError
+
+from .common import StockLocationLockdownCommon
+
+
+class TestStockLocationOutboundLockdown(StockLocationLockdownCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Internal location that holds stock, then gets blocked for outbound,
+        # plus a child to assert descendant propagation.
+        cls.locked_location = cls.Location.create(
+            {
+                "name": "outbound_locked",
+                "usage": "internal",
+                "location_id": cls.stock_location.id,
+            }
+        )
+        cls.child_location = cls.Location.create(
+            {
+                "name": "outbound_locked_child",
+                "usage": "internal",
+                "location_id": cls.locked_location.id,
+            }
+        )
+        cls.Quant._update_available_quantity(cls.product, cls.locked_location, 10)
+        cls.Quant._update_available_quantity(cls.product, cls.child_location, 10)
+
+        # block_stock_exit has no "cannot block stocked location" guard, so the
+        # flag can be set after stock is already present.
+        cls.locked_location.block_stock_exit = True
+
+    def test_outbound_flag_propagates_to_child(self):
+        """The outbound block aggregates down the location tree."""
+        self.assertTrue(self.locked_location.is_outbound_blocked)
+        self.assertTrue(self.child_location.is_outbound_blocked)
+        # Outbound block must not imply inbound block.
+        self.assertFalse(self.locked_location.is_inbound_blocked)
+
+    def test_move_out_of_blocked_location(self):
+        """Validating a move out of an outbound-blocked location is refused."""
+        move = self._create_move(self.locked_location, self.customer_location, 5)
+        with self.assertRaises(ValidationError):
+            move._action_done()
+
+    def test_move_out_of_blocked_child_location(self):
+        """The block reaches descendants through is_outbound_blocked."""
+        move = self._create_move(self.child_location, self.customer_location, 5)
+        with self.assertRaises(ValidationError):
+            move._action_done()
+
+    def test_move_into_blocked_location_allowed(self):
+        """Outbound block does not prevent putting stock into the location."""
+        move = self._create_move(self.supplier_location, self.locked_location, 3)
+        move._action_done()
+        self.assertEqual(move.state, "done")
+
+    def test_quant_cannot_leave_blocked_location(self):
+        """Reassigning a quant out of a blocked location is refused in write."""
+        quant = self.Quant.search(
+            [
+                ("product_id", "=", self.product.id),
+                ("location_id", "=", self.locked_location.id),
+            ]
+        )
+        with self.assertRaises(ValidationError):
+            quant.write({"location_id": self.free_location.id})
+
+    def test_quant_can_leave_once_unblocked(self):
+        """Once the flag is cleared the quant can be moved again."""
+        self.locked_location.block_stock_exit = False
+        quant = self.Quant.search(
+            [
+                ("product_id", "=", self.product.id),
+                ("location_id", "=", self.locked_location.id),
+            ]
+        )
+        quant.write({"location_id": self.free_location.id})
+        self.assertEqual(quant.location_id, self.free_location)

--- a/stock_location_lockdown/tests/test_block_stock_location_reservation.py
+++ b/stock_location_lockdown/tests/test_block_stock_location_reservation.py
@@ -1,4 +1,3 @@
-# Copyright 2026 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from .common import StockLocationLockdownCommon

--- a/stock_location_lockdown/tests/test_block_stock_location_reservation.py
+++ b/stock_location_lockdown/tests/test_block_stock_location_reservation.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from .common import StockLocationLockdownCommon
+
+
+class TestStockLocationReservationLock(StockLocationLockdownCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.loc = cls.Location.create(
+            {
+                "name": "resv_lock",
+                "usage": "internal",
+                "location_id": cls.stock_location.id,
+            }
+        )
+        cls.Quant._update_available_quantity(cls.product, cls.loc, 10)
+
+    def _quant(self):
+        return self.Quant.search(
+            [
+                ("product_id", "=", self.product.id),
+                ("location_id", "=", self.loc.id),
+            ]
+        )
+
+    def _available(self):
+        return self.Quant._get_available_quantity(self.product, self.loc, strict=True)
+
+    def test_block_makes_stock_unavailable(self):
+        self.assertEqual(self._available(), 10)
+        self.loc.block_stock_exit = True
+        quant = self._quant()
+        self.assertTrue(quant.is_outbound_reservation_locked)
+        self.assertEqual(quant.reserved_quantity, 10)
+        self.assertEqual(quant.lock_real_reserved, 0)
+        self.assertEqual(self._available(), 0)
+
+    def test_unblock_restores_availability(self):
+        self.loc.block_stock_exit = True
+        self.loc.block_stock_exit = False
+        quant = self._quant()
+        self.assertFalse(quant.is_outbound_reservation_locked)
+        self.assertEqual(quant.reserved_quantity, 0)
+        self.assertEqual(self._available(), 10)
+
+    def test_existing_reservation_preserved_through_block_cycle(self):
+        self.Quant._update_reserved_quantity(self.product, self.loc, 6)
+        self.assertEqual(self._available(), 4)
+
+        # Block: the real reservation is parked, reserved is pinned to quantity.
+        self.loc.block_stock_exit = True
+        quant = self._quant()
+        self.assertEqual(quant.reserved_quantity, 10)
+        self.assertEqual(quant.lock_real_reserved, 6)
+        self.assertEqual(self._available(), 0)
+
+        # Unblock: the genuine 6-unit reservation comes back untouched.
+        self.loc.block_stock_exit = False
+        quant = self._quant()
+        self.assertEqual(quant.reserved_quantity, 6)
+        self.assertEqual(self._available(), 4)
+
+    def test_unreserve_while_blocked_does_not_leak(self):
+        """The scenario that broke the snapshot field: a real reservation is
+        cancelled while the location is blocked. The freed stock must NOT
+        become available."""
+        self.Quant._update_reserved_quantity(self.product, self.loc, 6)
+        self.loc.block_stock_exit = True
+
+        # Cancel the genuine reservation while blocked.
+        self.Quant._update_reserved_quantity(self.product, self.loc, -6)
+        quant = self._quant()
+        self.assertEqual(quant.lock_real_reserved, 0)
+        self.assertEqual(quant.reserved_quantity, 10)  # still pinned
+        self.assertEqual(self._available(), 0)  # not reopened
+
+        # Unblock: nothing leaked, full stock available again.
+        self.loc.block_stock_exit = False
+        quant = self._quant()
+        self.assertEqual(quant.reserved_quantity, 0)
+        self.assertEqual(self._available(), 10)

--- a/stock_location_lockdown/tests/test_block_stock_location_routing.py
+++ b/stock_location_lockdown/tests/test_block_stock_location_routing.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import ValidationError
+
+from .common import StockLocationLockdownCommon
+
+
+class TestStockLocationLockdownRouting(StockLocationLockdownCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Two-step delivery (pick -> ship) so the route stages stock through an
+        # intermediate Output location between Stock and the customer.
+        cls.warehouse = cls.env["stock.warehouse"].create(
+            {
+                "name": "Lockdown WH",
+                "code": "LKD",
+                "delivery_steps": "pick_ship",
+            }
+        )
+        cls.output_location = cls.warehouse.wh_output_stock_loc_id
+        cls.Quant._update_available_quantity(
+            cls.product, cls.warehouse.lot_stock_id, 50
+        )
+
+    def _run_delivery_procurement(self):
+        """Procure the product at the customer through the warehouse delivery
+        route. Returns the first (pick) move created by the run."""
+        pg = self.env["procurement.group"].create({"name": "Lockdown routing"})
+        self.env["procurement.group"].run(
+            [
+                pg.Procurement(
+                    self.product,
+                    5.0,
+                    self.product.uom_id,
+                    self.customer_location,
+                    "lockdown",
+                    "lockdown",
+                    self.warehouse.company_id,
+                    {"warehouse_id": self.warehouse, "group_id": pg},
+                ),
+            ]
+        )
+        return self.env["stock.move"].search([("group_id", "=", pg.id)])
+
+    def _validate(self, move):
+        move._action_assign()
+        move.picked = True
+        move._action_done()
+
+    def test_blocked_rule_is_flagged(self):
+        """The delivery rule leaving the blocked Output location is flagged."""
+        self.output_location.block_stock_exit = True
+        ship_rule = self.warehouse.delivery_route_id.rule_ids.filtered(
+            lambda r: r.location_src_id == self.output_location
+        )
+        self.assertTrue(ship_rule)
+        self.assertTrue(ship_rule.is_location_blocked)
+
+    def test_chain_built_but_blocked_leg_unprocessable(self):
+        """With Output outbound-blocked the two-step chain still builds
+        normally (no crash): procurement creates the pick, validating it
+        pushes the ship leg into existence. Only the ship leg, which leaves
+        the blocked location, cannot be validated."""
+        self.output_location.block_stock_exit = True
+
+        pick = self._run_delivery_procurement()
+        self.assertEqual(len(pick), 1)
+        self.assertEqual(pick.location_id, self.warehouse.lot_stock_id)
+        self.assertEqual(pick.location_dest_id, self.output_location)
+
+        # Pick into Output is fine (outbound block does not block inbound); the
+        # push rule then creates the ship leg.
+        self._validate(pick)
+        moves = self.env["stock.move"].search([("group_id", "=", pick.group_id.id)])
+        self.assertEqual(len(moves), 2)
+        ship = moves - pick
+        self.assertEqual(ship.location_id, self.output_location)
+        self.assertEqual(ship.location_dest_id, self.customer_location)
+
+        # The ship leg leaves the blocked location: it cannot be validated.
+        ship._action_assign()
+        ship.picked = True
+        with self.assertRaises(ValidationError):
+            ship._action_done()

--- a/stock_location_lockdown/tests/test_block_stock_location_routing.py
+++ b/stock_location_lockdown/tests/test_block_stock_location_routing.py
@@ -1,4 +1,3 @@
-# Copyright 2026 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import ValidationError

--- a/stock_location_lockdown/views/res_config_settings_views.xml
+++ b/stock_location_lockdown/views/res_config_settings_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field
+            name="name"
+        >res.config.settings.form.inherit.stock.location.lockdown</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//block[@name='warehouse_setting_container']"
+                position="inside"
+            >
+                <setting
+                    id="allow_lockdown_on_stocked_location_setting"
+                    help="Allow blocking stock entrance on internal locations that already contain stock."
+                >
+                    <field name="allow_lockdown_on_stocked_location" />
+                </setting>
+                <setting
+                    id="block_location_on_inventory_setting"
+                    help="Treat a location (and its descendants) as blocked for both inbound and outbound while an inventory is in progress on it."
+                >
+                    <field name="block_location_on_inventory" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_location_lockdown/views/stock_location.xml
+++ b/stock_location_lockdown/views/stock_location.xml
@@ -8,6 +8,8 @@
         <field name="arch" type="xml">
             <field name="usage" position="after">
                 <field name="block_stock_entrance" invisible="usage != 'internal'" />
+                <field name="block_stock_exit" invisible="usage != 'internal'" />
+                <field name="no_physical_stock" invisible="usage != 'internal'" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
# Context

`stock_location_lockdown` only lock inbound stock, not outbound.
Furthermore, it can only apply on location that already has stock.

The module as it existed was in fact just adding a way to prevent a location from having stock.

## Retro-compatibility

The changes made to this module are retro-compatible by default with how it previously behaved.
It's possible to allow lockdown on a location with stock. The setting is on the company level.

# Features

It adds 3 options to a location:
- **Lock inbound**: prevent stock from moving **in** the location. Propagates to child locations.
- **Lock outbound**: prevent stock from moving **out** of the location. Propagates to child locations.
- **Location without physical stock**: that's what the module was previously doing. 
  This one does not propagate to children location

When we lock for `outbound`, the quantities of the locked location appear as reserved.
This way,  `Check Availability` and forecasting can correctly take it into account.

# NOTE
## `stock_inventory_lockdown`

I think the existing module `stock_inventory_lockdown` should rely on this one or even be merged.
