### PR TITLE
[17.0] [FIX] stock_inventory_discrepancy: Use native framework action to clear inventory

### DIFF
--- a/stock_inventory_discrepancy/README.rst
+++ b/stock_inventory_discrepancy/README.rst
@@ -86,14 +86,18 @@ Authors
 Contributors
 ------------
 
--  Lois Rilo <lois.rilo@forgeflow.com>
--  Andreas Dian Sukarno Putro <andreasdian777@gmail.com>
--  Bhavesh Odedra <bodedra@opensourceintegrators.com>
--  Héctor Villarreal <hector.villarreal@forgeflow.com>
--  `Tecnativa <https://www.tecnativa.com>`__:
+- Lois Rilo <lois.rilo@forgeflow.com>
+- Andreas Dian Sukarno Putro <andreasdian777@gmail.com>
+- Bhavesh Odedra <bodedra@opensourceintegrators.com>
+- Héctor Villarreal <hector.villarreal@forgeflow.com>
+- `Tecnativa <https://www.tecnativa.com>`__:
 
-   -  Ernesto Tejeda
-   -  Carolina Fernandez
+  - Ernesto Tejeda
+  - Carolina Fernandez
+
+- `Tradesolutions.Digital <https://www.tradesolutions.digital/>`__
+
+  - Prabakaran Ranganathan
 
 Maintainers
 -----------

--- a/stock_inventory_discrepancy/hooks.py
+++ b/stock_inventory_discrepancy/hooks.py
@@ -72,7 +72,7 @@ def post_load_hook():
         }
         for quant in self:
             quant.inventory_date = date_by_location[quant.location_id]
-        self.write({"inventory_quantity": 0, "user_id": False})
+        self.action_clear_inventory_quantity()
         self.write({"inventory_diff_quantity": 0})
 
     StockQuant._apply_inventory = _apply_inventory_discrepancy

--- a/stock_inventory_discrepancy/readme/CONTRIBUTORS.md
+++ b/stock_inventory_discrepancy/readme/CONTRIBUTORS.md
@@ -5,3 +5,5 @@
 - [Tecnativa](https://www.tecnativa.com):
   - Ernesto Tejeda
   - Carolina Fernandez
+- [Tradesolutions.Digital](https://www.tradesolutions.digital/)
+  - Prabakaran Ranganathan

--- a/stock_inventory_discrepancy/static/description/index.html
+++ b/stock_inventory_discrepancy/static/description/index.html
@@ -443,6 +443,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Carolina Fernandez</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.tradesolutions.digital/">Tradesolutions.Digital</a><ul>
+<li>Prabakaran Ranganathan</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
```
**Bug Fix**
Refactored a manual dictionary write in `stock_inventory_discrepancy/hooks.py` that was resetting inventory values but forgetting to clear the core framework flag `inventory_quantity_set`. 

Leaving this flag `True` caused adjacent modules like `stock_inventory_lockdown` to permanently treat locations as having an "inventory adjustment in progress," blocking subsequent stock moves and reservations with a `ValidationError`.

**Solution**
Replaced the manual assignment with Odoo's native framework method:
**python**
self.action_clear_inventory_quantity()
````
This native method resets inventory_quantity, user_id, and correctly sets inventory_quantity_set back to False.

References
Odoo Core: Identical bug fixed in core commit [b1da104](https://github.com/odoo/odoo/commit/b1da104f06efc3825a9d983149404050a861605e).

OCA 18.0: Backport of the fix already implemented via inheritance in 18.0 commit [0d56d32](https://github.com/OCA/stock-logistics-warehouse/commit/0d56d32da00fd50cd4c416a7985a3e469504f949).

Related Issue: Resolves underlying state related to [OCA issue #2499](https://github.com/OCA/stock-logistics-warehouse/issues/2499).