### PR TITLE
[15.0][FIX] stock_secondary_unit: keep secondary qty when merging moves

### DIFF
--- a/stock_secondary_unit/models/stock_move.py
+++ b/stock_secondary_unit/models/stock_move.py
@@ -51,6 +51,12 @@ class StockMove(models.Model):
             )
         return vals
 
+    def _merge_moves_fields(self):
+        """Sum secondary uom qty when merge positive stock moves."""
+        res = super()._merge_moves_fields()
+        res["secondary_uom_qty"] = sum(self.mapped("secondary_uom_qty"))
+        return res
+
     def _merge_moves(self, merge_into=False):
         """Set the last secondary uom qty when merge negative stock move"""
         # We have to do this when merging negative moves because the positive ones call
@@ -78,14 +84,17 @@ class StockMove(models.Model):
         for move in res:
             secondary_uom_qty = neg_qty_moves_dic.get(neg_key(move))
             if secondary_uom_qty is not None:
-                if move.product_uom_qty >= 0.0:
+                if (
+                    move.product_uom_qty >= 0.0
+                    and move.secondary_uom_id.dependency_type == "independent"
+                ):
                     new_secondary_uom_qty = move.secondary_uom_qty + secondary_uom_qty
                 else:
                     # Alternatively we must get values from candidate moves before
                     # merge for all cases and it has poor performance.
                     # Don't use _compute_secondary_uom_qty() because it is needed for
                     # any dependency_type
-                    new_secondary_uom_qty = self._get_secondary_uom_qty_from_uom_qty()
+                    new_secondary_uom_qty = move._get_secondary_uom_qty_from_uom_qty()
                 # Use _write to avoid recompute product_uom_qty
                 move._write({"secondary_uom_qty": new_secondary_uom_qty})
                 move.invalidate_cache(fnames=["secondary_uom_qty"])


### PR DESCRIPTION
When stock moves with secondary units were merged, the resulting move could get
an incorrect `secondary_uom_qty`.

This affected both positive and negative move merges:

- Positive moves with the same secondary unit must sum their secondary
  quantities.
- Negative moves used to adjust an existing demand must not apply the secondary
  delta twice when the secondary unit is dependent on the primary UoM quantity.

A common case is a warehouse with chained delivery moves:

1. Create a demand for 4 pieces.
2. Increase it to 6 pieces.
3. Reduce it to 3 pieces.

The stock move merge must leave the final chained move with 3 pieces, not with an
incorrect secondary quantity.

This change:
- sums `secondary_uom_qty` in `_merge_moves_fields()` for positive merges;
- only applies manual secondary delta accumulation for independent secondary
  units;
- recalculates dependent secondary quantities from the resulting merged move.

A regression is covered from `sale_stock_secondary_unit`, where chained PACK
moves are updated from 4 pieces to 6 pieces and then reduced to 3 pieces.

cc @Tecnativa TT62494
ping @carlosdauden @CarlosRoca13 