### PR TITLE
[16.0][IMP]stock_warehouse_calendar: add option to consider global time off

### DIFF
--- a/stock_warehouse_calendar/models/stock_warehouse.py
+++ b/stock_warehouse_calendar/models/stock_warehouse.py
@@ -12,6 +12,14 @@ class StockWarehouse(models.Model):
     calendar_id = fields.Many2one(
         comodel_name="resource.calendar", string="Working Hours", check_company=True
     )
+    calendar_compute_leaves = fields.Boolean(
+        string="Consider Global Time Off",
+        help="Take into account the Global Time Off defined in the warehouse "
+        "working hours (public holidays, plant shutdowns, ...) when planning "
+        "warehouse operations.\n"
+        "If not set, only the weekly working days are considered and those "
+        "days are planned as if the warehouse were open.",
+    )
 
     def wh_plan_days(self, date_from, delta):
         """Helper method to schedule warehouse operations based on its
@@ -37,7 +45,9 @@ class StockWarehouse(models.Model):
             else:
                 # We force the date planned at the end of the day.
                 dt_planned = date_from.replace(hour=23)
-            date_result = self.calendar_id.plan_days(delta, dt_planned)
+            date_result = self.calendar_id.plan_days(
+                delta, dt_planned, compute_leaves=self.calendar_compute_leaves
+            )
         else:
             date_result = date_from + timedelta(days=delta)
         return date_result

--- a/stock_warehouse_calendar/readme/CONFIGURE.rst
+++ b/stock_warehouse_calendar/readme/CONFIGURE.rst
@@ -6,6 +6,11 @@
 * Go to *Inventory > Configuration > Warehouse Management > Warehouses*
   and assign the Resource Calendar.
 
+* Optionally, mark 'Consider Global Time Off' in the warehouse to also take
+  the Global Time Off of that calendar (public holidays, plant shutdowns, ...)
+  into account when planning. It is disabled by default, so only the weekly
+  working days are considered.
+
 * Go to *Inventory > Configuration > Settings* and in *Warehouse* mark
   'Multi-Step Routes option'.
 

--- a/stock_warehouse_calendar/readme/USAGE.rst
+++ b/stock_warehouse_calendar/readme/USAGE.rst
@@ -4,3 +4,7 @@ expected date of the picking and moves. For example, if it takes 1 day to
 execute a stock transfer from another warehouse and it is Monday, the picking
 to resupply will be created with expected start date on the previous Friday,
 if the warehouse operates under a Mo-Fri working calendar.
+
+The 'Consider Global Time Off' setting only affects the computations done through
+the ``wh_plan_days()`` helper of the warehouse. Modules computing dates
+directly from the calendar of the warehouse are not affected by it.

--- a/stock_warehouse_calendar/tests/test_stock_warehouse_calendar.py
+++ b/stock_warehouse_calendar/tests/test_stock_warehouse_calendar.py
@@ -120,3 +120,24 @@ class TestStockWarehouseCalendar(TransactionCase):
         result = self.warehouse_3.wh_plan_days(reference, 3).date()
         saturday = fields.Date.to_date("2097-01-12")
         self.assertEqual(result, saturday)
+
+    def test_04_wh_plan_days_with_leave(self):
+        """Test plan days helper in warehouse with global time off."""
+        reference = "2097-01-09 12:00:00"  # Wednesday
+        result = self.warehouse_2.wh_plan_days(reference, -3).date()
+        self.assertEqual(result, fields.Date.to_date("2097-01-04"))
+        self.env["resource.calendar.leaves"].create(
+            {
+                "calendar_id": self.calendar.id,
+                "resource_id": False,
+                "date_from": "2097-01-07 00:00:00",  # Monday
+                "date_to": "2097-01-07 23:59:59",
+                "time_type": "leave",
+            }
+        )
+        # Global Time Off is ignored unless the warehouse is set to consider it
+        result = self.warehouse_2.wh_plan_days(reference, -3).date()
+        self.assertEqual(result, fields.Date.to_date("2097-01-04"))
+        self.warehouse_2.calendar_compute_leaves = True
+        result = self.warehouse_2.wh_plan_days(reference, -3).date()
+        self.assertEqual(result, fields.Date.to_date("2097-01-03"))

--- a/stock_warehouse_calendar/views/stock_warehouse_views.xml
+++ b/stock_warehouse_calendar/views/stock_warehouse_views.xml
@@ -9,6 +9,10 @@
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <field name="calendar_id" options="{'no_create': True}" />
+                <field
+                    name="calendar_compute_leaves"
+                    attrs="{'invisible': [('calendar_id', '=', False)]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Until now _wh_plan_days()_ only took the weekly working days of the warehouse calendar into account, ignoring its Global Time Off entries. Planning therefore treated a closing day as a regular working day.

This adds a **_Consider Global Time Off_** setting on the warehouse, disabled by default, so nothing changes unless it is explicitly enabled. It only governs the computations done through _wh_plan_days()_. Modules reading the warehouse calendar directly, like [mrp_multi_level](https://github.com/OCA/manufacture/blob/d589f0d759223381ba9d40a211e0b8813f15cba2/mrp_multi_level/models/mrp_planned_order.py#L97), are not affected.