### PR TITLE
[17.0][FIX] stock_inventory: fix move line ordering after filtering

### DIFF
--- a/stock_inventory/models/stock_quant.py
+++ b/stock_inventory/models/stock_quant.py
@@ -37,7 +37,7 @@ class StockQuant(models.Model):
                 lambda x, rec=rec: not x.company_id.id
                 or not rec.company_id.id
                 or rec.company_id.id == x.company_id.id
-            )
+            ).sorted(key=lambda m: (m.create_date or fields.Datetime.now(), m.id))
             if len(moves) == 0:
                 raise ValueError(_("No move lines have been created"))
             move = moves[len(moves) - 1]


### PR DESCRIPTION
Fixes #2499. The \iltered\ method does not guarantee order preservation, causing the wrong stock.move.line to be selected when linking it to an inventory adjustment. This commit enforces proper sorting by \create_date\ and \id\ after filtering.