### PR TITLE
[FIX] stock_inventory_preparation_filter: exclude virtual locations from domain filter

### DIFF
--- a/stock_inventory_preparation_filter/models/stock_inventory.py
+++ b/stock_inventory_preparation_filter/models/stock_inventory.py
@@ -42,5 +42,10 @@ class StockInventory(models.Model):
         if self.product_selection == "domain":
             domain = safe_eval(self.product_domain)
             products = self.env["product.product"].search(domain)
-            return self.env["stock.quant"].search([("product_id", "in", products.ids)])
+            return self.env["stock.quant"].search(
+                [
+                    ("product_id", "in", products.ids),
+                    ("location_id", "in", locations.ids),
+                ]
+            )
         return super()._get_quants(locations)

--- a/stock_inventory_preparation_filter/tests/test_stock_inventory_preparation_filter.py
+++ b/stock_inventory_preparation_filter/tests/test_stock_inventory_preparation_filter.py
@@ -146,3 +146,32 @@ class TestStockInventoryPreparationFilterCategories(common.TransactionCase):
         line1 = inventory.stock_quant_ids[0]
         self.assertEqual(line1.product_id, self.product1)
         self.assertEqual(line1.quantity, 2.0)
+
+    def test_inventory_domain_filter_excludes_virtual_locations(self):
+        """Test that domain filter does not include quants from virtual locations."""
+
+        virtual_location = self.env.ref("stock.stock_location_customers")
+        self.env["stock.quant"].create(
+            {
+                "product_id": self.product1.id,
+                "product_uom_id": self.product1.uom_id.id,
+                "location_id": virtual_location.id,
+                "quantity": 5.0,
+            }
+        )
+
+        inventory = self.inventory_model.create(
+            {
+                "name": "Domain inventory excluding virtual locations",
+                "product_selection": "domain",
+                "product_domain": [("id", "=", self.product1.id)],
+                "location_ids": self.env.ref("stock.stock_location_stock"),
+            }
+        )
+        inventory.action_state_to_in_progress()
+
+        self.assertEqual(len(inventory.stock_quant_ids), 1)
+        self.assertEqual(
+            inventory.stock_quant_ids.location_id,
+            self.env.ref("stock.stock_location_stock"),
+        )


### PR DESCRIPTION
## Problem

When using **Filtered Products** (domain) selection in Inventory Adjustment,
the results include quants from virtual locations (e.g. Customers, Inventory Adjustments),
which should not appear in a physical inventory count.

Fixes #2498

## Root Cause

`_get_quants()` was searching quants by `product_id` only, without filtering
by `location_id`, causing virtual location quants to be included.

## Solution

Added `location_id` filter to the quant search in `_get_quants()` when
`product_selection == "domain"`, consistent with how other selection
modes handle location filtering.

## Steps to Reproduce

1. Create an Inventory Adjustment
2. Set **Filtered Products** and define a domain (e.g. by category)
3. Click **Begin Adjustment**
4. ❌ Virtual location products appear in the results

## After Fix

- ✅ Only quants from the selected location are returned
- ✅ Virtual locations (Customers, Inventory Adjustments, etc.) are excluded
- ✅ Test added to cover this scenario