### PR TITLE
[18.0][FIX] stock_vertical_lift: Fix shuttle's inventory-mode filter

### DIFF
--- a/stock_vertical_lift/models/stock_quant.py
+++ b/stock_vertical_lift/models/stock_quant.py
@@ -8,6 +8,14 @@ class StockQuant(models.Model):
     _inherit = "stock.quant"
 
     vertical_lift_done = fields.Boolean()
+
+    def write(self, vals):
+        # A new inventory date invalidates vertical_lift_done,
+        # even if inventory_date=False
+        if "inventory_date" in vals and "vertical_lift_done" not in vals:
+            vals["vertical_lift_done"] = False
+        return super().write(vals)
+
     # Field used to sort lines by tray on the inventory scan screen, so entire
     # trays are processed one after the other
     vertical_lift_tray_id = fields.Many2one(

--- a/stock_vertical_lift/models/vertical_lift_operation_inventory.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_inventory.py
@@ -168,22 +168,22 @@ class VerticalLiftOperationInventory(models.Model):
             "domain": self._domain_stock_quant_to_do(),
         }
 
-    def _domain_stock_quant_to_do(self):
+    def _base_domain_stock_quant_to_do(self, location_ids):
+        # Mimic Odoo's `to_count` filter
         return [
-            ("location_id", "child_of", self.location_id.id),
-            ("inventory_quantity_set", "=", True),
+            ("location_id", "child_of", location_ids),
+            ("inventory_date", "<=", fields.Date.context_today(self)),
             ("vertical_lift_done", "=", False),
         ]
+
+    def _domain_stock_quant_to_do(self):
+        return self._base_domain_stock_quant_to_do(self.location_id.id)
 
     def _domain_inventory_lines_to_do_all(self):
         shuttle_locations = self.env["stock.location"].search(
             [("vertical_lift_kind", "=", "view")]
         )
-        return [
-            ("location_id", "child_of", shuttle_locations.ids),
-            ("inventory_quantity_set", "=", True),
-            ("vertical_lift_done", "=", False),
-        ]
+        return self._base_domain_stock_quant_to_do(shuttle_locations.ids)
 
     def reset_steps(self):
         self.clear_current_inventory_line()

--- a/stock_vertical_lift/tests/common.py
+++ b/stock_vertical_lift/tests/common.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
+from odoo import fields
+
 from odoo.addons.stock_location_tray.tests import common
 
 
@@ -130,9 +132,13 @@ class VerticalLiftCase(common.LocationTrayTypeCase):
 
     @classmethod
     def _create_stock_quants(cls, products):
-        """Create a stock.quant to adjust inventory.
+        """Create a stock.quant and schedule an inventory count for it.
 
         Products is a list of tuples (bin location, product).
+
+        The count is scheduled ("Request a Count" with "Leave Empty") without
+        setting the inventory quantity, so `inventory_quantity_set` stays False.
+        This is what puts the quant in the vertical lift inventory queue.
         """
         stock_quants = []
         for location, product in products:
@@ -143,7 +149,9 @@ class VerticalLiftCase(common.LocationTrayTypeCase):
                     "product_uom_id": product.uom_id.id,
                 }
             )
-            current_stock_quant.action_set_inventory_quantity()
+            current_stock_quant.with_context(inventory_mode=True).write(
+                {"inventory_date": fields.Date.context_today(current_stock_quant)}
+            )
             stock_quants.append(current_stock_quant)
         return stock_quants
 

--- a/stock_vertical_lift/tests/test_inventory.py
+++ b/stock_vertical_lift/tests/test_inventory.py
@@ -2,6 +2,7 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo import fields
 from odoo.tests import RecordCapturer
 from odoo.tools import mute_logger
 
@@ -46,6 +47,61 @@ class TestInventory(VerticalLiftCase):
         self.assertEqual(action["type"], "ir.actions.client")
         self.assertEqual(action["tag"], "vertical_lift_manual_barcode")
         self.assertEqual(action["name"], "Barcode")
+
+    @mute_logger(SHUTTLE_LOGGER)
+    def test_scheduled_count_without_value_is_queued(self):
+        # A count scheduled with "Leave Empty" has no inventory quantity set yet
+        # but must still show up in the queue (the bug this fixes).
+        stock_quant = self._create_stock_quants(
+            [(self.location_1a_x1y1, self.product_socks)]
+        )[0]
+        self.assertFalse(stock_quant.inventory_quantity_set)
+        operation = self._open_screen("inventory")
+        self.assertEqual(operation.number_of_ops, 1)
+        self.assertEqual(operation.quant_id, stock_quant)
+
+    @mute_logger(SHUTTLE_LOGGER)
+    def test_set_value_scheduled_later_is_not_queued(self):
+        # A count scheduled for a later date must NOT be queued yet, even when
+        # its value is already set: `inventory_quantity_set` is no longer a
+        # criteria, only the scheduled date is.
+        stock_quant = self.env["stock.quant"].create(
+            {
+                "product_id": self.product_socks.id,
+                "location_id": self.location_1a_x1y1.id,
+                "product_uom_id": self.product_socks.uom_id.id,
+            }
+        )
+        stock_quant.action_set_inventory_quantity()
+        tomorrow = fields.Date.add(fields.Date.context_today(stock_quant), days=1)
+        stock_quant.with_context(inventory_mode=True).write(
+            {"inventory_date": tomorrow}
+        )
+        self.assertTrue(stock_quant.inventory_quantity_set)
+        operation = self._open_screen("inventory")
+        self.assertEqual(operation.number_of_ops, 0)
+        self.assertFalse(operation.quant_id)
+
+    @mute_logger(SHUTTLE_LOGGER)
+    def test_reschedule_requeues_done_quant(self):
+        # Once counted on the shuttle a quant is flagged done; rescheduling a new
+        # count must clear that flag so it is queued again.
+        stock_quant = self._create_stock_quants(
+            [(self.location_1a_x1y1, self.product_socks)]
+        )[0]
+        self._update_qty_in_location(self.location_1a_x1y1, self.product_socks, 10)
+        operation = self._open_screen("inventory")
+        operation.quantity_input = 10.0
+        operation.button_save()
+        self.assertTrue(stock_quant.vertical_lift_done)
+
+        # schedule a new count
+        stock_quant.with_context(inventory_mode=True).write(
+            {"inventory_date": fields.Date.context_today(stock_quant)}
+        )
+        self.assertFalse(stock_quant.vertical_lift_done)
+        operation = self._open_screen("inventory")
+        self.assertEqual(operation.quant_id, stock_quant)
 
     @mute_logger(SHUTTLE_LOGGER)
     def test_inventory_count_ops(self):
@@ -116,7 +172,9 @@ class TestInventory(VerticalLiftCase):
             self.assertEqual(move.state, "done")
             self.assertEqual(move.quantity, 2.0)
         self.assertFalse(operation.quant_id)
-        self.assertTrue(quant.vertical_lift_done)
+        # applying the count reschedules the quant to a future date, which
+        # clears the done marker (new count campaign)
+        self.assertFalse(quant.vertical_lift_done)
         self.assertEqual(quant.quantity, 12.0)
         self.assertFalse(operation.quant_id)
 


### PR DESCRIPTION
# Context

The shuttle view was filtering based on `inventory_quantity_set`.
This field indicates that the value was **entered by the operator**, not that it has been applied.


# Fix 
Remove `inventory_quantity_set` from the filter and use the `inventory_date` instead,
like odoo's `to_count` filter.

Also fix the `vertical_lift_done` when `inventory_date` changes