### PR TITLE
[18.0][FIX] stock_lot_catalog: avoid duplicate field label on stock.lot

### DIFF
--- a/stock_lot_catalog/models/stock_lot.py
+++ b/stock_lot_catalog/models/stock_lot.py
@@ -10,7 +10,9 @@ class StockLot(models.Model):
     product_template_attribute_value_ids = fields.Many2many(
         related="product_id.product_template_attribute_value_ids"
     )
-    product_image_128 = fields.Image(related="product_id.image_128")
+    product_image_128 = fields.Image(
+        string="Product Image 128", related="product_id.image_128"
+    )
 
     def _get_lst_price(self):
         self.ensure_one()


### PR DESCRIPTION
When `stock_lot_catalog` is installed alongside modules that extend `stock.lot` with `image.mixin` (such as `stock_lot_multi_image` - https://github.com/OCA/stock-logistics-warehouse/pull/2272), Odoo logs a registry warning during module loading / test runs:

```text
WARNING odoo odoo.addons.base.models.ir_model: Two fields (product_image_128, image_128) of stock.lot() have the same label: Image 128. [Modules: stock_lot_catalog and base]
