### PR TITLE
[FIX] stock_vertical_lift: apply the count even when it matches

### DIFF
--- a/stock_vertical_lift/models/vertical_lift_operation_inventory.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_inventory.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-from odoo.tools import float_compare, float_is_zero
+from odoo.tools import float_is_zero
 
 # TODO handle autofocus + easy way to validate for the input field
 
@@ -237,16 +237,11 @@ class VerticalLiftOperationInventory(models.Model):
         quant = self.quant_id
         if quant and not quant.vertical_lift_done:
             quant.vertical_lift_done = True
-            if (
-                float_compare(
-                    self.quantity_input,
-                    quant.quantity,
-                    precision_rounding=quant.product_uom_id.rounding,
-                )
-                != 0
-            ):
-                quant.inventory_quantity = self.quantity_input
-                quant._apply_inventory()
+            # Apply even when the count matches the on-hand quantity: this is
+            # what reschedules `inventory_date` and leaves a trace in the
+            # inventory history, exactly like Odoo's own Physical Inventory.
+            quant.inventory_quantity = self.quantity_input
+            quant._apply_inventory()
             self.quantity_input = self.last_quantity_input = 0.0
         return True
 

--- a/stock_vertical_lift/tests/test_inventory.py
+++ b/stock_vertical_lift/tests/test_inventory.py
@@ -84,8 +84,8 @@ class TestInventory(VerticalLiftCase):
 
     @mute_logger(SHUTTLE_LOGGER)
     def test_reschedule_requeues_done_quant(self):
-        # Once counted on the shuttle a quant is flagged done; rescheduling a new
-        # count must clear that flag so it is queued again.
+        # Counting reschedules the quant to a later date, so it leaves the
+        # queue; scheduling a new count for today must put it back.
         stock_quant = self._create_stock_quants(
             [(self.location_1a_x1y1, self.product_socks)]
         )[0]
@@ -93,7 +93,7 @@ class TestInventory(VerticalLiftCase):
         operation = self._open_screen("inventory")
         operation.quantity_input = 10.0
         operation.button_save()
-        self.assertTrue(stock_quant.vertical_lift_done)
+        self.assertEqual(operation.number_of_ops, 0)
 
         # schedule a new count
         stock_quant.with_context(inventory_mode=True).write(
@@ -136,7 +136,7 @@ class TestInventory(VerticalLiftCase):
         # noop because we have no further lines
         self.assertEqual(operation.state, "noop")
         self.assertFalse(operation.quant_id)
-        self.assertTrue(stock_quant.vertical_lift_done)
+        self.assertEqual(operation.number_of_ops, 0)
         expected_result = {
             "effect": {
                 "fadeout": "slow",
@@ -146,6 +146,27 @@ class TestInventory(VerticalLiftCase):
             }
         }
         self.assertEqual(result, expected_result)
+
+    @mute_logger(SHUTTLE_LOGGER)
+    def test_identical_quantity_is_applied(self):
+        # Counting the same quantity as the on-hand one is still a count: it
+        # must reschedule `inventory_date` and leave a move in the history.
+        stock_quant = self._create_stock_quants(
+            [(self.location_1a_x1y1, self.product_socks)]
+        )[0]
+        self._update_qty_in_location(self.location_1a_x1y1, self.product_socks, 10)
+        today = fields.Date.context_today(stock_quant)
+        operation = self._open_screen("inventory")
+        operation.quantity_input = 10.0
+        with RecordCapturer(self.env["stock.move"], []) as capt:
+            operation.button_save()
+        move = capt.records
+        self.assertEqual(move.state, "done")
+        self.assertEqual(move.quantity, 0.0)
+        self.assertEqual(stock_quant.quantity, 10.0)
+        self.assertFalse(stock_quant.inventory_quantity_set)
+        self.assertGreater(stock_quant.inventory_date, today)
+        self.assertEqual(self.location_1a_x1y1.last_inventory_date, today)
 
     @mute_logger(SHUTTLE_LOGGER)
     def test_wrong_quantity(self):


### PR DESCRIPTION
The Kardex shuttle skipped _apply_inventory() when the counted quantity equalled the on-hand one
-> the scheduled date survived
-> the count left no trace

=> Always apply the result, like Odoo's Physical Inventory does.