### PR TITLE
[18.0][FIX] stock_move_packaging_qty: preserve done package count

### DIFF
--- a/stock_move_packaging_qty/models/stock_move.py
+++ b/stock_move_packaging_qty/models/stock_move.py
@@ -2,7 +2,7 @@
 # Copyright 2021 ForgeFlow, S.L.
 # Copyright 2024 Moduon Team S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
-from odoo import api, exceptions, fields, models
+from odoo import exceptions, fields, models
 
 
 class StockMove(models.Model):
@@ -10,9 +10,15 @@ class StockMove(models.Model):
 
     product_packaging_quantity = fields.Float(
         inverse="_inverse_product_packaging_quantity",
+        # Explicit dependencies may drift from core, but avoid storing the field or
+        # overriding writes while preserving manual package counts on quantity changes.
+        depends=(
+            "product_uom",
+            "product_packaging_id",
+            "move_line_ids.product_packaging_quantity",
+        ),
     )
 
-    @api.depends("product_packaging_id", "move_line_ids.product_packaging_quantity")
     def _compute_product_packaging_quantity(self):
         for move in self:
             if not move.product_packaging_id:

--- a/stock_move_packaging_qty/tests/test_stock_move_packaging_qty.py
+++ b/stock_move_packaging_qty/tests/test_stock_move_packaging_qty.py
@@ -77,8 +77,10 @@ class TestStockMovePackagingQty(TransactionCase):
         self.assertEqual(
             picking.move_ids_without_package.product_packaging_quantity, 0.2
         )
+        picking.picking_type_id.automatic_done_packaging_calculation = False
         # Allow to modify the packaging quantity
         picking.move_ids_without_package.write({"product_packaging_quantity": 1.0})
+        picking.move_ids_without_package.write({"quantity": 2.0})
         self.assertRecordValues(
             picking.move_ids_without_package,
             [
@@ -88,6 +90,7 @@ class TestStockMovePackagingQty(TransactionCase):
                     "product_packaging_qty": 0.2,
                     "product_packaging_quantity": 1.0,
                     "product_uom_qty": 1,
+                    "quantity": 2.0,
                 }
             ],
         )


### PR DESCRIPTION
Changing a move's done quantity recalculated manually entered package counts even when automatic packaging calculation was disabled on the operation type.

Explicit dependencies can drift if core adds new ones, but they avoid storing a derived field or overriding write paths with broader side effects.

https://www.loom.com/share/581dba9b05f540eabe890b8eb2a2d3a0

cc @moduon MT-15682

please review @EmilioPascual @fcvalgar 
