### PR TITLE
[FIX] stock_vertical_lift: propose the most urgent pick operation first

### DIFF
--- a/stock_vertical_lift/models/__init__.py
+++ b/stock_vertical_lift/models/__init__.py
@@ -8,4 +8,5 @@ from . import stock_move
 from . import stock_move_line
 from . import stock_quant
 from . import vertical_lift_command
+from . import res_company
 from . import res_config_settings

--- a/stock_vertical_lift/models/res_company.py
+++ b/stock_vertical_lift/models/res_company.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    vertical_lift_pick_by_priority = fields.Boolean(
+        string="Pick urgent transfers first",
+        default=True,
+        help="Propose the move lines of the most urgent transfers first, "
+        "using the transfer's priority and scheduled date.",
+    )
+    vertical_lift_pick_skipped_last = fields.Boolean(
+        string="Pick skipped lines last",
+        default=True,
+        help="Move lines skipped by the operator are proposed again only once "
+        "the other move lines have been processed.",
+    )

--- a/stock_vertical_lift/models/res_config_settings.py
+++ b/stock_vertical_lift/models/res_config_settings.py
@@ -10,3 +10,11 @@ class StockVerticalLiftSettings(models.TransientModel):
         string="Secret for Vertical Lift API",
         config_parameter="stock_vertical_lift.secret",
     )
+    vertical_lift_pick_by_priority = fields.Boolean(
+        related="company_id.vertical_lift_pick_by_priority",
+        readonly=False,
+    )
+    vertical_lift_pick_skipped_last = fields.Boolean(
+        related="company_id.vertical_lift_pick_skipped_last",
+        readonly=False,
+    )

--- a/stock_vertical_lift/models/vertical_lift_operation_pick.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_pick.py
@@ -118,12 +118,27 @@ class VerticalLiftOperationPick(models.Model):
         )
         return get_next(move_lines, self.current_move_line_id)
 
+    def _next_move_line_order_fields(self):
+        """Return the stock.move.line fields deciding which line comes next."""
+        self.ensure_one()
+        company = self.location_id.company_id or self.env.company
+        order_fields = []
+        if company.vertical_lift_pick_skipped_last:
+            # Must outrank urgency: an urgent line kept on top would be
+            # proposed again right away, so the operator could never skip it.
+            order_fields.append("vertical_lift_skipped")
+        if company.vertical_lift_pick_by_priority:
+            # "picking_id.priority" is not accepted.
+            # Luckily, a many2one delegates to the target model's _order
+            # (see BaseModel._order_field_to_sql)
+            # `picking_id` injects priority, then scheduled date.
+            order_fields.append("picking_id")
+        order_fields.append("id")
+        return order_fields
+
     def select_next_move_line(self):
         self.ensure_one()
-        next_move_line_order = "vertical_lift_skipped"
-        if self._order:
-            # If there already exists an order, keep it.
-            next_move_line_order += "," + self._order
+        next_move_line_order = ", ".join(self._next_move_line_order_fields())
         next_move_line = self._get_next_move_line(next_move_line_order)
         self.current_move_line_id = next_move_line
         if next_move_line:

--- a/stock_vertical_lift/tests/test_pick.py
+++ b/stock_vertical_lift/tests/test_pick.py
@@ -49,6 +49,50 @@ class TestPick(VerticalLiftCase):
         )
         self.assertEqual(operation.state, "scan_destination")
 
+    def _create_normal_and_urgent_pickings(self):
+        """Two ready transfers on the shuttle, the urgent one created last"""
+        self.picking_out.action_cancel()
+        product = self.env.ref("stock_vertical_lift.product_running_socks")
+        cell = self.env.ref(
+            "stock_vertical_lift.stock_location_vertical_lift_demo_tray_1a_x3y2"
+        )
+        self._update_quantity_in_cell(cell, product, 50)
+        normal = self._create_simple_picking_out(product, 1)
+        urgent = self._create_simple_picking_out(product, 1)
+        urgent.priority = "1"
+        pickings = normal | urgent
+        pickings.action_confirm()
+        pickings.action_assign()
+        return normal, urgent
+
+    @mute_logger(SHUTTLE_LOGGER)
+    def test_pick_select_next_move_line_urgent_first(self):
+        """An urgent picking is proposed before an older normal one"""
+        normal, urgent = self._create_normal_and_urgent_pickings()
+
+        operation = self._open_screen("pick")
+        self.assertEqual(operation.current_move_line_id.picking_id, urgent)
+
+    @mute_logger(SHUTTLE_LOGGER)
+    def test_pick_select_next_move_line_skipped_urgent_last(self):
+        """A skipped line waits for the others, even when it is the urgent one"""
+        normal, urgent = self._create_normal_and_urgent_pickings()
+        urgent.move_line_ids.vertical_lift_skipped = True
+
+        operation = self._open_screen("pick")
+        self.assertEqual(operation.current_move_line_id.picking_id, normal)
+        operation.select_next_move_line()
+        self.assertEqual(operation.current_move_line_id.picking_id, urgent)
+
+    @mute_logger(SHUTTLE_LOGGER)
+    def test_pick_select_next_move_line_priority_disabled(self):
+        """Without the priority setting, lines keep their creation order"""
+        normal, urgent = self._create_normal_and_urgent_pickings()
+        self.env.company.vertical_lift_pick_by_priority = False
+
+        operation = self._open_screen("pick")
+        self.assertEqual(operation.current_move_line_id.picking_id, normal)
+
     @mute_logger(SHUTTLE_LOGGER)
     def test_pick_select_next_move_line_was_skipped(self):
         """Previously skipped moves can be reprocessed"""

--- a/stock_vertical_lift/views/res_config_settings_views.xml
+++ b/stock_vertical_lift/views/res_config_settings_views.xml
@@ -14,6 +14,18 @@
                     >
                         <field name="vertical_lift_secret" />
                     </setting>
+                    <setting
+                        id="vertical_lift_pick_by_priority"
+                        title="Propose the move lines of the most urgent transfers first"
+                    >
+                        <field name="vertical_lift_pick_by_priority" />
+                    </setting>
+                    <setting
+                        id="vertical_lift_pick_skipped_last"
+                        title="Propose skipped move lines once the others are done"
+                    >
+                        <field name="vertical_lift_pick_skipped_last" />
+                    </setting>
                 </block>
             </block>
         </field>


### PR DESCRIPTION
`select_next_move_line` sorted `stock.move.line` records with the `_order` of `vertical.lift.operation.pick`.  
Sorting a model with another model's `_order` is a latent bug.

Order on `picking_id` instead, which sorts by the transfer's priority and scheduled date.
Skipped lines still come first, and both terms can be turned off per company.