### PR TITLE
[18.0][FIX] stock_vlm_mgmt: duplicate key conflicts when registering the widget.

### DIFF
--- a/stock_vlm_mgmt/static/src/js/location_tray_matrix/stock_location_tray.esm.js
+++ b/stock_vlm_mgmt/static/src/js/location_tray_matrix/stock_location_tray.esm.js
@@ -7,7 +7,7 @@ import {standardFieldProps} from "@web/views/fields/standard_field_props";
 import {useService} from "@web/core/utils/hooks";
 
 export class LocationTrayMatrixField extends Component {
-    static template = "stock_vlm_mgmt.location_tray_matrix";
+    static template = "stock_vlm_mgmt.stock_vlm_mgmt_location_tray_matrix";
     static props = {
         ...standardFieldProps,
         click_action: {
@@ -62,4 +62,6 @@ export const locationTrayMatrixField = {
     }),
 };
 
-registry.category("fields").add("location_tray_matrix", locationTrayMatrixField);
+registry
+    .category("fields")
+    .add("stock_vlm_mgmt_location_tray_matrix", locationTrayMatrixField);

--- a/stock_vlm_mgmt/static/src/js/location_tray_matrix/stock_location_tray.scss
+++ b/stock_vlm_mgmt/static/src/js/location_tray_matrix/stock_location_tray.scss
@@ -1,5 +1,5 @@
 // Widget in form view
-.o_field_location_tray_matrix {
+.o_field_stock_vlm_mgmt_location_tray_matrix {
     table {
         height: 200px;
         tr {
@@ -10,8 +10,8 @@
     }
 }
 // Widget in list view
-.o_location_tray_matrix_cell {
-    .o_field_location_tray_matrix {
+.o_stock_vlm_mgmt_location_tray_matrix_cell {
+    .o_field_stock_vlm_mgmt_location_tray_matrix {
         table {
             height: 70px;
             tr {

--- a/stock_vlm_mgmt/static/src/js/location_tray_matrix/stock_location_tray_views.xml
+++ b/stock_vlm_mgmt/static/src/js/location_tray_matrix/stock_location_tray_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <templates>
-    <t t-name="stock_vlm_mgmt.location_tray_matrix" owl="1">
+    <t t-name="stock_vlm_mgmt.stock_vlm_mgmt_location_tray_matrix" owl="1">
         <t
             t-set="cell_min_width"
             t-value="state.cells.length and (100 / state.cells[0].length) or 0"

--- a/stock_vlm_mgmt/views/stock_location_tray_type_views.xml
+++ b/stock_vlm_mgmt/views/stock_location_tray_type_views.xml
@@ -39,7 +39,7 @@
                     <group string="Layout" name="tray_layout">
                         <field
                             name="tray_matrix"
-                            widget="location_tray_matrix"
+                            widget="stock_vlm_mgmt_location_tray_matrix"
                             nolabel="1"
                         />
                     </group>

--- a/stock_vlm_mgmt/views/stock_location_vlm_tray_views.xml
+++ b/stock_vlm_mgmt/views/stock_location_vlm_tray_views.xml
@@ -32,7 +32,7 @@
                             <field
                                 name="tray_matrix"
                                 string="Tray layout"
-                                widget="location_tray_matrix"
+                                widget="stock_vlm_mgmt_location_tray_matrix"
                                 options="{'click_action': 'action_tray_content'}"
                                 nolabel="1"
                             />
@@ -49,7 +49,11 @@
                 <field name="name" />
                 <field name="location_id" />
                 <field name="tray_type_id" />
-                <field name="tray_matrix" widget="location_tray_matrix" nolabel="1" />
+                <field
+                    name="tray_matrix"
+                    widget="stock_vlm_mgmt_location_tray_matrix"
+                    nolabel="1"
+                />
                 <button
                     string="Call"
                     class="btn btn-secondary btn-lg"

--- a/stock_vlm_mgmt/views/stock_quant_vlm_views.xml
+++ b/stock_vlm_mgmt/views/stock_quant_vlm_views.xml
@@ -23,7 +23,7 @@
                         <group>
                             <field
                                 name="tray_matrix"
-                                widget="location_tray_matrix"
+                                widget="stock_vlm_mgmt_location_tray_matrix"
                                 options="{'live_cell_edit': True}"
                                 nolabel="1"
                             />

--- a/stock_vlm_mgmt/views/stock_vlm_task_views.xml
+++ b/stock_vlm_mgmt/views/stock_vlm_task_views.xml
@@ -37,7 +37,7 @@
                         <group>
                             <field
                                 name="tray_matrix"
-                                widget="location_tray_matrix"
+                                widget="stock_vlm_mgmt_location_tray_matrix"
                                 options="{'live_cell_edit': True}"
                                 nolabel="1"
                             />

--- a/stock_vlm_mgmt/wizards/stock_vlm_task_action_views.xml
+++ b/stock_vlm_mgmt/wizards/stock_vlm_task_action_views.xml
@@ -63,7 +63,7 @@
                         <group name="position" col="1">
                             <field
                                 name="tray_matrix"
-                                widget="location_tray_matrix"
+                                widget="stock_vlm_mgmt_location_tray_matrix"
                                 options="{'live_cell_edit': True}"
                                 nolabel="1"
                                 readonly="state == 'done'"


### PR DESCRIPTION
@Tecnativa TT57303
@christian-ramos-tecnativa @pedrobaeza

The widget registration key has been updated, as it was conflicting with the widget created by `stock_location_tray`. I checked and confirmed that `stock_location_tray` has existed since older versions, so I believe we should use a different key to register the widget in this addon.

This issue was already mentioned in the migration PR #2474 