### PR TITLE
[19.0][FIX] stock_picking_type_user_restriction: imply base.group_user

### DIFF
--- a/stock_picking_type_user_restriction/README.rst
+++ b/stock_picking_type_user_restriction/README.rst
@@ -74,6 +74,7 @@ Contributors
 - Lorenzo Battistini (https://takobi.online)
 - Daniel Domínguez - https://xtendoo.es <dani.xtendoo@gmail.com>
 - Denis Roussel <denis.roussel@acsone.eu>
+- Alan Ramos <alan.ramos@jarsa.com>
 
 Maintainers
 -----------

--- a/stock_picking_type_user_restriction/__manifest__.py
+++ b/stock_picking_type_user_restriction/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock picking type - Restrict users",
     "summary": "Restrict some users to see and use only certain picking types",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Warehouse",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "author": "Xtendoo, TAKOBI, Odoo Community Association (OCA)",

--- a/stock_picking_type_user_restriction/readme/CONTRIBUTORS.md
+++ b/stock_picking_type_user_restriction/readme/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 - Lorenzo Battistini (<https://takobi.online>)
 - Daniel Domínguez - <https://xtendoo.es> \<dani.xtendoo@gmail.com\>
 - Denis Roussel \<denis.roussel@acsone.eu\>
+- Alan Ramos \<alan.ramos@jarsa.com\>

--- a/stock_picking_type_user_restriction/security/stock_security.xml
+++ b/stock_picking_type_user_restriction/security/stock_security.xml
@@ -3,6 +3,7 @@
     <record id="group_assigned_picking_types_user" model="res.groups">
         <field name="name">User: Assigned Operation Types Only</field>
         <field name="privilege_id" ref="stock.res_groups_privilege_inventory" />
+        <field name="implied_ids" eval="[Command.link(ref('base.group_user'))]" />
         <field
             name="comment"
         >The user will have access to his assigned operation types.</field>

--- a/stock_picking_type_user_restriction/static/description/index.html
+++ b/stock_picking_type_user_restriction/static/description/index.html
@@ -420,6 +420,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Lorenzo Battistini (<a class="reference external" href="https://takobi.online">https://takobi.online</a>)</li>
 <li>Daniel Domínguez - <a class="reference external" href="https://xtendoo.es">https://xtendoo.es</a> &lt;<a class="reference external" href="mailto:dani.xtendoo&#64;gmail.com">dani.xtendoo&#64;gmail.com</a>&gt;</li>
 <li>Denis Roussel &lt;<a class="reference external" href="mailto:denis.roussel&#64;acsone.eu">denis.roussel&#64;acsone.eu</a>&gt;</li>
+<li>Alan Ramos &lt;<a class="reference external" href="mailto:alan.ramos&#64;jarsa.com">alan.ramos&#64;jarsa.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_picking_type_user_restriction/tests/test_picking_type_user_restriction.py
+++ b/stock_picking_type_user_restriction/tests/test_picking_type_user_restriction.py
@@ -77,3 +77,13 @@ class TestUserRestriction(TransactionCase):
             self.stock_user_assigned_type.id
         ).search([("name", "=", "Delivery Orders")])
         self.assertFalse(self.picking_type_out in pick_types)
+
+    def test_assigned_user_is_internal_and_sees_inventory_menu(self):
+        # The group must imply base.group_user, otherwise a user having only
+        # this group is a portal-like user (share=True) that cannot read
+        # ir.ui.menu and never sees the Inventory app
+        user = self.stock_user_assigned_type
+        self.assertFalse(user.share)
+        self.assertTrue(user.has_group("base.group_user"))
+        menu_ids = self.env["ir.ui.menu"].with_user(user)._visible_menu_ids()
+        self.assertIn(self.env.ref("stock.menu_stock_root").id, menu_ids)


### PR DESCRIPTION
A user having **only** the `User: Assigned Operation Types Only` group is not an internal user (`share=True`): the group does not imply `base.group_user`, unlike `stock.group_stock_user`. Such a user cannot read `ir.ui.menu` at all, so the Inventory app never shows up even though `stock.menu_stock_root` is granted to the group.

This PR makes the group imply `base.group_user` and adds a test checking that a user with only this group is internal and sees the Inventory root menu.

Found on a 19.0 production database where users get this group through `base_user_role` roles without any other group.

Assisted-by: Claude Fable 5.1